### PR TITLE
docs(workflow): shorten branch naming

### DIFF
--- a/docs/parallel-agent-workflow.md
+++ b/docs/parallel-agent-workflow.md
@@ -78,23 +78,35 @@ Use one branch per issue.
 Format:
 
 ```bash
-feature/<issue-number>-<lane>-<slug>
-fix/<issue-number>-<lane>-<slug>
-docs/<issue-number>-<lane>-<slug>
+feature/<issue-number>-<slug>
+fix/<issue-number>-<slug>
+docs/<issue-number>-<slug>
 ```
 
 Examples:
 
 ```bash
-feature/123-backend-e3-implementar-alta-de-vehicle
-feature/124-frontend-e2-redesign-redisenar-onboarding-transporter
-fix/125-frontend-e2-redesign-corregir-estado-de-carga
+feature/123-e3-schema
+feature/124-e2-onboarding
+fix/125-onboarding-loading-state
 ```
+
+The lane does not live in the branch name. The lane is identified by:
+
+- the `lane` field on the issue
+- the `Lane:` field in the PR body
+- the work order defined by the user
 
 Helper command:
 
 ```bash
-pnpm agent:branch --lane backend-e3 --issue-number 123 --issue-title "Implementar alta de vehicle"
+pnpm agent:branch --issue-number 123 --issue-title "Extender schema base E3"
+```
+
+Optional short slug:
+
+```bash
+pnpm agent:branch --issue-number 123 --slug e3-schema
 ```
 
 ## Pull request standard
@@ -134,7 +146,7 @@ Optional repeated flags:
 3. Implement only the assigned issue scope.
 4. Run the relevant tests and checks.
 5. Push the branch.
-6. Open the PR with the standard template.
+6. Codex opens the PR automatically with the standard template after the push.
 7. Wait for human review and merge.
 8. After the user confirms merge, return to `develop`, pull the latest changes, create the next branch, and start the next ready issue in the same lane.
 
@@ -165,6 +177,7 @@ Before starting an issue, the agent should verify:
 - the issue does not require a blocked backend contract
 - the issue does not modify a protected zone without approval
 - the issue stays small enough for a focused PR
+- the short branch slug is clear enough to recognize the issue quickly
 
 ## Suggested operating rhythm
 

--- a/scripts/agent-workflow.mjs
+++ b/scripts/agent-workflow.mjs
@@ -54,7 +54,7 @@ function slugify(value) {
 
 function printUsage() {
   console.log(`Usage:
-  pnpm agent:branch --lane backend-e3 --issue-number 123 --issue-title "Implementar alta de vehicle" [--type feature]
+  pnpm agent:branch --issue-number 123 --issue-title "Implementar alta de vehicle" [--slug e3-schema] [--type feature]
   pnpm agent:pr --lane frontend-e2-redesign --issue-number 456 --issue-title "Redisenar onboarding" [--acceptance "..."] [--test "..."] [--risk "..."] [--notes "..."]`);
 }
 
@@ -79,12 +79,13 @@ function getLaneLabel(lane) {
 }
 
 function buildBranchName(args) {
-  const lane = requireArg(args, "lane");
   const issueNumber = requireArg(args, "issue-number");
-  const issueTitle = requireArg(args, "issue-title");
+  const branchSlug = args.slug
+    ? slugify(args.slug)
+    : slugify(requireArg(args, "issue-title"));
   const branchType = args.type ?? "feature";
 
-  return `${branchType}/${issueNumber}-${slugify(lane)}-${slugify(issueTitle)}`;
+  return `${branchType}/${issueNumber}-${branchSlug}`;
 }
 
 function buildChecklist(items, fallback) {


### PR DESCRIPTION
## Summary

- No linked issue: ajuste del workflow de ramas cortas
- Lane: `shared-support`
- Scope: acorta el formato de ramas a `tipo/numero-slug` y mantiene el carril solo en la issue y en la PR

## Why

El flujo nuevo necesitaba nombres de rama mas cortos y faciles de leer, sin perder trazabilidad con la issue ni el lane real de trabajo.

## Acceptance Criteria

- [x] `pnpm agent:branch` genera ramas cortas sin `lane`
- [x] `pnpm agent:branch` acepta `--slug` explicito
- [x] `pnpm agent:pr` sigue incluyendo `Lane:` en el body de la PR
- [x] La documentacion del workflow coincide con el nuevo formato

## Validation

- [x] `node scripts/agent-workflow.mjs branch --issue-number 123 --issue-title "Extender schema base E3"`
- [x] `node scripts/agent-workflow.mjs branch --issue-number 123 --slug e3-schema`
- [x] `node scripts/agent-workflow.mjs pr --lane frontend-e2-redesign --issue-number 124 --issue-title "Redisenar onboarding transporter" --slug e2-onboarding --acceptance "La UI usa el backend existente" --test "pnpm --filter @logistica/web test" --risk "Pendiente validar copy final" --notes "No cambia contrato backend"`
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`

## Risks

- No hay riesgo funcional de producto; el cambio afecta solo el tooling y la guia operativa
- Queda pendiente validar el flujo completo con la primera issue real creada bajo este formato

## Screenshots / Evidence

- No aplica

## Handoff Notes

- Next ready issue: crear las primeras issues reales de `backend-e3` y `frontend-e2-redesign` usando ramas cortas
- Contract changes: ninguno
- Protected zones touched: ninguna

## Checklist

- [x] Un solo proposito claro
- [x] No toca zonas protegidas sin aprobacion explicita
- [x] Incluye manejo razonable de errores si aplica
- [x] `.env.example` actualizado si se agregaron variables
- [x] Documentacion actualizada si cambia comportamiento importante
- [x] PR chico y revisable