### PR TITLE
feat(database): add fleet schema entities

### DIFF
--- a/packages/database/prisma/migrations/20260406154425_add_fleet_entities/migration.sql
+++ b/packages/database/prisma/migrations/20260406154425_add_fleet_entities/migration.sql
@@ -1,0 +1,64 @@
+-- CreateEnum
+CREATE TYPE "CargoType" AS ENUM ('EQUINE', 'GENERAL_CARGO', 'FOOD', 'PEOPLE');
+
+-- CreateEnum
+CREATE TYPE "CapacityUnit" AS ENUM ('SLOT', 'KG', 'M3', 'SEAT');
+
+-- CreateTable
+CREATE TABLE "vehicles" (
+    "id" TEXT NOT NULL,
+    "transporterProfileId" TEXT NOT NULL,
+    "licensePlate" TEXT NOT NULL,
+    "brand" TEXT NOT NULL,
+    "model" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "vehicles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "trailers" (
+    "id" TEXT NOT NULL,
+    "transporterProfileId" TEXT NOT NULL,
+    "vehicleId" TEXT,
+    "totalCapacity" INTEGER NOT NULL,
+    "cargoType" "CargoType" NOT NULL DEFAULT 'EQUINE',
+    "capacityUnit" "CapacityUnit" NOT NULL DEFAULT 'SLOT',
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "trailers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "vehicles_licensePlate_key" ON "vehicles"("licensePlate");
+
+-- CreateIndex
+CREATE INDEX "vehicles_transporterProfileId_idx" ON "vehicles"("transporterProfileId");
+
+-- CreateIndex
+CREATE INDEX "vehicles_transporterProfileId_isActive_idx" ON "vehicles"("transporterProfileId", "isActive");
+
+-- CreateIndex
+CREATE INDEX "vehicles_isActive_idx" ON "vehicles"("isActive");
+
+-- CreateIndex
+CREATE INDEX "trailers_transporterProfileId_idx" ON "trailers"("transporterProfileId");
+
+-- CreateIndex
+CREATE INDEX "trailers_transporterProfileId_isActive_idx" ON "trailers"("transporterProfileId", "isActive");
+
+-- CreateIndex
+CREATE INDEX "trailers_vehicleId_idx" ON "trailers"("vehicleId");
+
+-- AddForeignKey
+ALTER TABLE "vehicles" ADD CONSTRAINT "vehicles_transporterProfileId_fkey" FOREIGN KEY ("transporterProfileId") REFERENCES "transporter_profiles"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "trailers" ADD CONSTRAINT "trailers_transporterProfileId_fkey" FOREIGN KEY ("transporterProfileId") REFERENCES "transporter_profiles"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "trailers" ADD CONSTRAINT "trailers_vehicleId_fkey" FOREIGN KEY ("vehicleId") REFERENCES "vehicles"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -27,6 +27,20 @@ enum TransporterVerificationStatus {
   REJECTED
 }
 
+enum CargoType {
+  EQUINE
+  GENERAL_CARGO
+  FOOD
+  PEOPLE
+}
+
+enum CapacityUnit {
+  SLOT
+  KG
+  M3
+  SEAT
+}
+
 model Account {
   id                 String              @id @default(cuid())
   email              String              @unique
@@ -76,8 +90,49 @@ model TransporterProfile {
   updatedAt          DateTime  @updatedAt
 
   account            Account   @relation(fields: [accountId], references: [id], onDelete: Cascade)
+  vehicles           Vehicle[]
+  trailers           Trailer[]
 
   @@map("transporter_profiles")
+}
+
+model Vehicle {
+  id                    String    @id @default(cuid())
+  transporterProfileId   String
+  licensePlate           String    @unique
+  brand                  String
+  model                  String
+  isActive               Boolean   @default(true)
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
+
+  transporterProfile     TransporterProfile @relation(fields: [transporterProfileId], references: [id], onDelete: Cascade)
+  trailers               Trailer[]
+
+  @@index([transporterProfileId])
+  @@index([transporterProfileId, isActive])
+  @@index([isActive])
+  @@map("vehicles")
+}
+
+model Trailer {
+  id                    String    @id @default(cuid())
+  transporterProfileId   String
+  vehicleId              String?
+  totalCapacity          Int
+  cargoType              CargoType @default(EQUINE)
+  capacityUnit           CapacityUnit @default(SLOT)
+  isActive               Boolean   @default(true)
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
+
+  transporterProfile     TransporterProfile @relation(fields: [transporterProfileId], references: [id], onDelete: Cascade)
+  vehicle                Vehicle?  @relation(fields: [vehicleId], references: [id], onDelete: SetNull)
+
+  @@index([transporterProfileId])
+  @@index([transporterProfileId, isActive])
+  @@index([vehicleId])
+  @@map("trailers")
 }
 
 model Session {


### PR DESCRIPTION
## Summary

Closes #102
Lane: Backend E3
Branch: `feature/102-e3-schema`
Issue: Extender schema con Vehicle, Trailer, CargoType y CapacityUnit

## What Changed

- Added Prisma enums `CargoType` and `CapacityUnit`
- Added Prisma models `Vehicle` and `Trailer` with relations to `TransporterProfile`
- Added a non-destructive migration that creates the new enums, tables, indexes and foreign keys

## Acceptance Criteria

- [x] Existe el modelo Vehicle
- [x] Existe el modelo Trailer
- [x] Existen CargoType y CapacityUnit
- [x] La migracion corre sin errores

## Validation

- `pnpm --filter @logistica/database typecheck`
- `pnpm --filter @logistica/database build`

## Risks

- El cambio toca schema y migracion, por lo que las siguientes issues E3 deben partir de esta rama ya mergeada o de `develop` actualizado luego del merge
- No agrega todavia endpoints ni validaciones HTTP; solo deja la base de datos lista para las siguientes issues del carril

## UI Evidence

- No aplica

## Notes For Review

- Cambio limitado a Prisma schema + migracion no destructiva
- No toca auth, pagos, roles, webhooks ni anti-overbooking
- Deja preparada la base para alta/edicion/listado de vehicles y trailers