### PR TITLE
feat(vehicle): add authenticated vehicle creation

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { AdminModule } from './admin/admin.module';
 import { AccountsModule } from './identity/accounts/accounts.module';
 import { AuthenticationModule } from './identity/authentication/authentication.module';
 import { TransporterProfileModule } from './identity/transporter-profile/transporter-profile.module';
+import { VehicleModule } from './vehicle/vehicle.module';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { TransporterProfileModule } from './identity/transporter-profile/transpo
     AccountsModule,
     AuthenticationModule,
     TransporterProfileModule,
+    VehicleModule,
   ],
   controllers: [],
   providers: [],

--- a/apps/api/src/vehicle/application/vehicle.service.spec.ts
+++ b/apps/api/src/vehicle/application/vehicle.service.spec.ts
@@ -1,4 +1,5 @@
 import { ConflictException, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@logistica/database';
 import { VehicleService } from './vehicle.service';
 
 describe('VehicleService', () => {
@@ -42,15 +43,20 @@ describe('VehicleService', () => {
       isActive: true,
     });
 
-    expect(vehicleRepository.findTransporterProfileByAccountId).toHaveBeenCalledWith(
-      'account-id',
+    expect(
+      vehicleRepository.findTransporterProfileByAccountId,
+    ).toHaveBeenCalledWith('account-id');
+    expect(vehicleRepository.findByLicensePlate).toHaveBeenCalledWith(
+      'AB123CD',
     );
-    expect(vehicleRepository.findByLicensePlate).toHaveBeenCalledWith('AB123CD');
-    expect(vehicleRepository.create).toHaveBeenCalledWith('transporter-profile-id', {
-      licensePlate: 'AB123CD',
-      brand: 'Scania',
-      model: 'R450',
-    });
+    expect(vehicleRepository.create).toHaveBeenCalledWith(
+      'transporter-profile-id',
+      {
+        licensePlate: 'AB123CD',
+        brand: 'Scania',
+        model: 'R450',
+      },
+    );
   });
 
   it('throws when the authenticated account has no transporter profile', async () => {
@@ -89,5 +95,26 @@ describe('VehicleService', () => {
     ).rejects.toThrow(ConflictException);
 
     expect(vehicleRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('throws conflict when create fails with a unique constraint race', async () => {
+    vehicleRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+    vehicleRepository.findByLicensePlate.mockResolvedValue(null);
+    vehicleRepository.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('Unique constraint failed.', {
+        code: 'P2002',
+        clientVersion: 'test',
+      }),
+    );
+
+    await expect(
+      vehicleService.createOwnVehicle('account-id', {
+        licensePlate: 'ab123cd',
+        brand: 'Scania',
+        model: 'R450',
+      }),
+    ).rejects.toThrow(ConflictException);
   });
 });

--- a/apps/api/src/vehicle/application/vehicle.service.spec.ts
+++ b/apps/api/src/vehicle/application/vehicle.service.spec.ts
@@ -1,0 +1,93 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { VehicleService } from './vehicle.service';
+
+describe('VehicleService', () => {
+  const vehicleRepository = {
+    findTransporterProfileByAccountId: jest.fn(),
+    findByLicensePlate: jest.fn(),
+    create: jest.fn(),
+  };
+
+  let vehicleService: VehicleService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    vehicleService = new VehicleService(vehicleRepository as never);
+  });
+
+  it('creates a vehicle for the authenticated transporter', async () => {
+    vehicleRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+    vehicleRepository.findByLicensePlate.mockResolvedValue(null);
+    vehicleRepository.create.mockResolvedValue({
+      id: 'vehicle-id',
+      licensePlate: 'AB123CD',
+      brand: 'Scania',
+      model: 'R450',
+      isActive: true,
+    });
+
+    await expect(
+      vehicleService.createOwnVehicle('account-id', {
+        licensePlate: 'ab123cd',
+        brand: '  Scania  ',
+        model: '  R450 ',
+      }),
+    ).resolves.toEqual({
+      id: 'vehicle-id',
+      licensePlate: 'AB123CD',
+      brand: 'Scania',
+      model: 'R450',
+      isActive: true,
+    });
+
+    expect(vehicleRepository.findTransporterProfileByAccountId).toHaveBeenCalledWith(
+      'account-id',
+    );
+    expect(vehicleRepository.findByLicensePlate).toHaveBeenCalledWith('AB123CD');
+    expect(vehicleRepository.create).toHaveBeenCalledWith('transporter-profile-id', {
+      licensePlate: 'AB123CD',
+      brand: 'Scania',
+      model: 'R450',
+    });
+  });
+
+  it('throws when the authenticated account has no transporter profile', async () => {
+    vehicleRepository.findTransporterProfileByAccountId.mockResolvedValue(null);
+
+    await expect(
+      vehicleService.createOwnVehicle('missing-account', {
+        licensePlate: 'AB123CD',
+        brand: 'Scania',
+        model: 'R450',
+      }),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(vehicleRepository.findByLicensePlate).not.toHaveBeenCalled();
+    expect(vehicleRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when the license plate already exists', async () => {
+    vehicleRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+    vehicleRepository.findByLicensePlate.mockResolvedValue({
+      id: 'existing-vehicle-id',
+      licensePlate: 'AB123CD',
+      brand: 'Volvo',
+      model: 'FH',
+      isActive: true,
+    });
+
+    await expect(
+      vehicleService.createOwnVehicle('account-id', {
+        licensePlate: 'ab123cd',
+        brand: 'Scania',
+        model: 'R450',
+      }),
+    ).rejects.toThrow(ConflictException);
+
+    expect(vehicleRepository.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/vehicle/application/vehicle.service.ts
+++ b/apps/api/src/vehicle/application/vehicle.service.ts
@@ -1,4 +1,9 @@
-import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@logistica/database';
 import type { VehicleResponseDto } from '../dto/vehicle.response.dto';
 import { VehicleRepository } from '../repositories/vehicle.repository';
 import type { CreateVehicleInput, VehicleRecord } from '../types/vehicle.types';
@@ -26,15 +31,27 @@ export class VehicleService {
     );
 
     if (existingVehicle) {
-      throw new ConflictException('A vehicle with this license plate already exists.');
+      throw new ConflictException(
+        'A vehicle with this license plate already exists.',
+      );
     }
 
-    const createdVehicle = await this.vehicleRepository.create(
-      transporterProfile.id,
-      normalizedInput,
-    );
+    try {
+      const createdVehicle = await this.vehicleRepository.create(
+        transporterProfile.id,
+        normalizedInput,
+      );
 
-    return this.toVehicleResponse(createdVehicle);
+      return this.toVehicleResponse(createdVehicle);
+    } catch (error) {
+      if (this.isUniqueConstraintViolation(error)) {
+        throw new ConflictException(
+          'A vehicle with this license plate already exists.',
+        );
+      }
+
+      throw error;
+    }
   }
 
   private normalizeInput(input: CreateVehicleInput): CreateVehicleInput {
@@ -53,5 +70,12 @@ export class VehicleService {
       model: vehicle.model,
       isActive: vehicle.isActive,
     };
+  }
+
+  private isUniqueConstraintViolation(error: unknown): boolean {
+    return (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    );
   }
 }

--- a/apps/api/src/vehicle/application/vehicle.service.ts
+++ b/apps/api/src/vehicle/application/vehicle.service.ts
@@ -1,0 +1,57 @@
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import type { VehicleResponseDto } from '../dto/vehicle.response.dto';
+import { VehicleRepository } from '../repositories/vehicle.repository';
+import type { CreateVehicleInput, VehicleRecord } from '../types/vehicle.types';
+
+@Injectable()
+export class VehicleService {
+  constructor(private readonly vehicleRepository: VehicleRepository) {}
+
+  async createOwnVehicle(
+    accountId: string,
+    input: CreateVehicleInput,
+  ): Promise<VehicleResponseDto> {
+    const transporterProfile =
+      await this.vehicleRepository.findTransporterProfileByAccountId(accountId);
+
+    if (!transporterProfile) {
+      throw new NotFoundException(
+        'Transporter profile not found for the authenticated account.',
+      );
+    }
+
+    const normalizedInput = this.normalizeInput(input);
+    const existingVehicle = await this.vehicleRepository.findByLicensePlate(
+      normalizedInput.licensePlate,
+    );
+
+    if (existingVehicle) {
+      throw new ConflictException('A vehicle with this license plate already exists.');
+    }
+
+    const createdVehicle = await this.vehicleRepository.create(
+      transporterProfile.id,
+      normalizedInput,
+    );
+
+    return this.toVehicleResponse(createdVehicle);
+  }
+
+  private normalizeInput(input: CreateVehicleInput): CreateVehicleInput {
+    return {
+      licensePlate: input.licensePlate.trim().toUpperCase(),
+      brand: input.brand.trim(),
+      model: input.model.trim(),
+    };
+  }
+
+  private toVehicleResponse(vehicle: VehicleRecord): VehicleResponseDto {
+    return {
+      id: vehicle.id,
+      licensePlate: vehicle.licensePlate,
+      brand: vehicle.brand,
+      model: vehicle.model,
+      isActive: vehicle.isActive,
+    };
+  }
+}

--- a/apps/api/src/vehicle/dto/create-vehicle.dto.ts
+++ b/apps/api/src/vehicle/dto/create-vehicle.dto.ts
@@ -1,0 +1,3 @@
+import type { ICreateVehicleDto } from '@logistica/shared';
+
+export type CreateVehicleDto = ICreateVehicleDto;

--- a/apps/api/src/vehicle/dto/vehicle.response.dto.ts
+++ b/apps/api/src/vehicle/dto/vehicle.response.dto.ts
@@ -1,0 +1,3 @@
+import type { IVehicleView } from '@logistica/shared';
+
+export type VehicleResponseDto = IVehicleView;

--- a/apps/api/src/vehicle/repositories/vehicle.repository.ts
+++ b/apps/api/src/vehicle/repositories/vehicle.repository.ts
@@ -5,7 +5,10 @@ import type {
   TransporterProfileOwnerRecord,
   VehicleRecord,
 } from '../types/vehicle.types';
-import { transporterProfileOwnerSelect, vehicleSelect } from '../types/vehicle.types';
+import {
+  transporterProfileOwnerSelect,
+  vehicleSelect,
+} from '../types/vehicle.types';
 
 @Injectable()
 export class VehicleRepository {
@@ -20,7 +23,9 @@ export class VehicleRepository {
     });
   }
 
-  async findByLicensePlate(licensePlate: string): Promise<VehicleRecord | null> {
+  async findByLicensePlate(
+    licensePlate: string,
+  ): Promise<VehicleRecord | null> {
     return this.prisma.vehicle.findUnique({
       where: { licensePlate },
       select: vehicleSelect,

--- a/apps/api/src/vehicle/repositories/vehicle.repository.ts
+++ b/apps/api/src/vehicle/repositories/vehicle.repository.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '@logistica/database';
+import type {
+  CreateVehicleInput,
+  TransporterProfileOwnerRecord,
+  VehicleRecord,
+} from '../types/vehicle.types';
+import { transporterProfileOwnerSelect, vehicleSelect } from '../types/vehicle.types';
+
+@Injectable()
+export class VehicleRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findTransporterProfileByAccountId(
+    accountId: string,
+  ): Promise<TransporterProfileOwnerRecord | null> {
+    return this.prisma.transporterProfile.findUnique({
+      where: { accountId },
+      select: transporterProfileOwnerSelect,
+    });
+  }
+
+  async findByLicensePlate(licensePlate: string): Promise<VehicleRecord | null> {
+    return this.prisma.vehicle.findUnique({
+      where: { licensePlate },
+      select: vehicleSelect,
+    });
+  }
+
+  async create(
+    transporterProfileId: string,
+    input: CreateVehicleInput,
+  ): Promise<VehicleRecord> {
+    return this.prisma.vehicle.create({
+      data: {
+        transporterProfile: {
+          connect: {
+            id: transporterProfileId,
+          },
+        },
+        licensePlate: input.licensePlate,
+        brand: input.brand,
+        model: input.model,
+      },
+      select: vehicleSelect,
+    });
+  }
+}

--- a/apps/api/src/vehicle/types/vehicle.types.ts
+++ b/apps/api/src/vehicle/types/vehicle.types.ts
@@ -17,6 +17,7 @@ export type CreateVehicleInput = ICreateVehicleDto;
 export type VehicleRecord = Prisma.VehicleGetPayload<{
   select: typeof vehicleSelect;
 }>;
-export type TransporterProfileOwnerRecord = Prisma.TransporterProfileGetPayload<{
-  select: typeof transporterProfileOwnerSelect;
-}>;
+export type TransporterProfileOwnerRecord =
+  Prisma.TransporterProfileGetPayload<{
+    select: typeof transporterProfileOwnerSelect;
+  }>;

--- a/apps/api/src/vehicle/types/vehicle.types.ts
+++ b/apps/api/src/vehicle/types/vehicle.types.ts
@@ -1,0 +1,22 @@
+import type { Prisma } from '@logistica/database';
+import type { ICreateVehicleDto } from '@logistica/shared';
+
+export const vehicleSelect = {
+  id: true,
+  licensePlate: true,
+  brand: true,
+  model: true,
+  isActive: true,
+} satisfies Prisma.VehicleSelect;
+
+export const transporterProfileOwnerSelect = {
+  id: true,
+} satisfies Prisma.TransporterProfileSelect;
+
+export type CreateVehicleInput = ICreateVehicleDto;
+export type VehicleRecord = Prisma.VehicleGetPayload<{
+  select: typeof vehicleSelect;
+}>;
+export type TransporterProfileOwnerRecord = Prisma.TransporterProfileGetPayload<{
+  select: typeof transporterProfileOwnerSelect;
+}>;

--- a/apps/api/src/vehicle/vehicle.controller.spec.ts
+++ b/apps/api/src/vehicle/vehicle.controller.spec.ts
@@ -1,0 +1,167 @@
+import {
+  Injectable,
+  type ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
+import { RolesGuard } from '../identity/authentication/guards/roles.guard';
+import { VehicleService } from './application/vehicle.service';
+import { VehicleController } from './vehicle.controller';
+
+@Injectable()
+class TestJwtAuthGuard {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{
+      headers: Record<string, string | string[] | undefined>;
+      user?: { accountId: string; role: 'CLIENT' | 'TRANSPORTER' | 'ADMIN' };
+    }>();
+    const authorizationHeader = request.headers.authorization;
+
+    if (typeof authorizationHeader !== 'string') {
+      throw new UnauthorizedException();
+    }
+
+    const [, role] = authorizationHeader.split(' ');
+
+    if (role !== 'CLIENT' && role !== 'TRANSPORTER' && role !== 'ADMIN') {
+      throw new UnauthorizedException();
+    }
+
+    request.user = {
+      accountId: 'transporter-account-id',
+      role,
+    };
+
+    return true;
+  }
+}
+
+describe('VehicleController', () => {
+  const vehicleService = {
+    createOwnVehicle: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  async function createApp() {
+    const moduleBuilder = Test.createTestingModule({
+      controllers: [VehicleController],
+      providers: [
+        RolesGuard,
+        {
+          provide: VehicleService,
+          useValue: vehicleService,
+        },
+      ],
+    });
+
+    moduleBuilder.overrideGuard(JwtAuthGuard).useClass(TestJwtAuthGuard);
+
+    const moduleRef = await moduleBuilder.compile();
+    const app = moduleRef.createNestApplication();
+    await app.init();
+
+    return app;
+  }
+
+  it('creates a vehicle for a transporter token', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    vehicleService.createOwnVehicle.mockResolvedValue({
+      id: 'vehicle-id',
+      licensePlate: 'AB123CD',
+      brand: 'Scania',
+      model: 'R450',
+      isActive: true,
+    });
+
+    await request(server)
+      .post('/vehicles')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        licensePlate: 'ab123cd',
+        brand: 'Scania',
+        model: 'R450',
+      })
+      .expect(201)
+      .expect({
+        id: 'vehicle-id',
+        licensePlate: 'AB123CD',
+        brand: 'Scania',
+        model: 'R450',
+        isActive: true,
+      });
+
+    expect(vehicleService.createOwnVehicle).toHaveBeenCalledWith(
+      'transporter-account-id',
+      {
+        licensePlate: 'AB123CD',
+        brand: 'Scania',
+        model: 'R450',
+      },
+    );
+
+    await app.close();
+  });
+
+  it('returns 400 when the payload is invalid', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/vehicles')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        licensePlate: '12',
+        brand: '',
+        model: 'R450',
+      })
+      .expect(400);
+
+    expect(vehicleService.createOwnVehicle).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 401 when the access token is missing', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/vehicles')
+      .send({
+        licensePlate: 'AB123CD',
+        brand: 'Scania',
+        model: 'R450',
+      })
+      .expect(401);
+
+    expect(vehicleService.createOwnVehicle).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 403 when the authenticated role is not TRANSPORTER', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/vehicles')
+      .set('Authorization', 'Bearer CLIENT')
+      .send({
+        licensePlate: 'AB123CD',
+        brand: 'Scania',
+        model: 'R450',
+      })
+      .expect(403);
+
+    expect(vehicleService.createOwnVehicle).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+});

--- a/apps/api/src/vehicle/vehicle.controller.ts
+++ b/apps/api/src/vehicle/vehicle.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { CreateVehicleSchema } from '@logistica/shared';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { Roles } from '../identity/authentication/decorators/roles.decorator';
+import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
+import { RolesGuard } from '../identity/authentication/guards/roles.guard';
+import type { AuthenticatedAccount } from '../identity/authentication/types/authentication.types';
+import { VehicleService } from './application/vehicle.service';
+import type { CreateVehicleDto } from './dto/create-vehicle.dto';
+import type { VehicleResponseDto } from './dto/vehicle.response.dto';
+
+interface AuthenticatedHttpRequest {
+  user: AuthenticatedAccount;
+}
+
+@Controller('vehicles')
+export class VehicleController {
+  constructor(private readonly vehicleService: VehicleService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async createOwnVehicle(
+    @Req() request: AuthenticatedHttpRequest,
+    @Body(new ZodValidationPipe(CreateVehicleSchema))
+    createVehicleDto: CreateVehicleDto,
+  ): Promise<VehicleResponseDto> {
+    return this.vehicleService.createOwnVehicle(
+      request.user.accountId,
+      createVehicleDto,
+    );
+  }
+}

--- a/apps/api/src/vehicle/vehicle.module.ts
+++ b/apps/api/src/vehicle/vehicle.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '@logistica/database';
+import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
+import { RolesGuard } from '../identity/authentication/guards/roles.guard';
+import { VehicleService } from './application/vehicle.service';
+import { VehicleController } from './vehicle.controller';
+import { VehicleRepository } from './repositories/vehicle.repository';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [VehicleController],
+  providers: [VehicleService, VehicleRepository, JwtAuthGuard, RolesGuard],
+  exports: [VehicleService],
+})
+export class VehicleModule {}

--- a/apps/web/features/dashboard/components/dashboard-navigation.test.tsx
+++ b/apps/web/features/dashboard/components/dashboard-navigation.test.tsx
@@ -23,7 +23,9 @@ describe("DashboardNavigation", () => {
 
     const user = userEvent.setup();
 
-    await user.click(screen.getByRole("button", { name: /Ir al dashboard/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Ver panel del transportista/i }),
+    );
 
     expect(push).toHaveBeenCalledWith("/dashboard");
   });
@@ -33,7 +35,7 @@ describe("DashboardNavigation", () => {
 
     const user = userEvent.setup();
 
-    await user.click(screen.getByRole("button", { name: /Completar onboarding/i }));
+    await user.click(screen.getByRole("button", { name: /Abrir onboarding/i }));
 
     expect(push).toHaveBeenCalledWith("/onboarding/transporter");
   });

--- a/apps/web/features/dashboard/components/dashboard-navigation.tsx
+++ b/apps/web/features/dashboard/components/dashboard-navigation.tsx
@@ -5,22 +5,30 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 
 type DashboardDestination = {
+  eyebrow: string;
   description: string;
   href: string;
+  meta: string;
   title: string;
   variant?: "ghost" | "primary";
 };
 
 const DASHBOARD_DESTINATIONS: DashboardDestination[] = [
   {
-    description: "Volver a la vista principal del area privada.",
+    description:
+      "Consulta el resumen del estado actual, la hoja de ruta del area privada y los accesos mas usados.",
+    eyebrow: "Panel actual",
     href: "/dashboard",
-    title: "Ir al dashboard",
+    meta: "Ruta principal protegida",
+    title: "Ver panel del transportista",
   },
   {
-    description: "Continuar con la carga y revision del perfil transportista.",
+    description:
+      "Segui con la carga y revision del perfil transportista sin salir del flujo protegido actual.",
+    eyebrow: "Siguiente paso",
     href: "/onboarding/transporter",
-    title: "Completar onboarding",
+    meta: "Continua donde lo dejaste",
+    title: "Abrir onboarding",
     variant: "ghost",
   },
 ];
@@ -41,29 +49,40 @@ export function DashboardNavigation() {
           className="text-lg font-semibold text-foreground"
           id="dashboard-navigation-title"
         >
-          Accesos rapidos
+          Accesos prioritarios
         </h2>
         <p className="text-sm leading-6 text-muted">
-          Usa estos accesos para moverte entre las rutas privadas disponibles
-          despues de iniciar sesion.
+          Usa estos accesos para moverte entre las rutas protegidas mas
+          importantes sin perder el contexto de tu sesion.
         </p>
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2">
-        {DASHBOARD_DESTINATIONS.map(({ description, href, title, variant }) => (
+        {DASHBOARD_DESTINATIONS.map(
+          ({ description, eyebrow, href, meta, title, variant }) => (
           <Button
-            className="h-auto min-h-14 flex-col items-start px-5 py-4 text-left"
+            className="h-auto min-h-[11rem] flex-col items-start justify-between rounded-[1.8rem] px-5 py-5 text-left"
             key={href}
             onClick={() => handleNavigation(href)}
             type="button"
             variant={variant}
           >
-            <span>{title}</span>
-            <span className="text-sm font-normal leading-6 text-current/80">
-              {description}
+            <div className="space-y-3">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-current/70">
+                {eyebrow}
+              </span>
+              <span className="block text-lg font-semibold leading-7">{title}</span>
+              <span className="block text-sm font-normal leading-6 text-current/80">
+                {description}
+              </span>
+            </div>
+
+            <span className="inline-flex rounded-full border border-current/15 bg-black/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-current/80">
+              {meta}
             </span>
           </Button>
-        ))}
+          ),
+        )}
       </div>
     </section>
   );

--- a/apps/web/features/dashboard/pages/dashboard-page.test.tsx
+++ b/apps/web/features/dashboard/pages/dashboard-page.test.tsx
@@ -1,0 +1,27 @@
+/** @jest-environment jsdom */
+
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import DashboardPageView from "./dashboard-page";
+
+jest.mock("../components/dashboard-navigation", () => ({
+  DashboardNavigation: () => <div>Mock dashboard navigation</div>,
+}));
+
+jest.mock("@/features/auth/components/feedback/logout-button", () => ({
+  LogoutButton: () => <button type="button">Mock logout</button>,
+}));
+
+describe("DashboardPageView", () => {
+  it("renders the redesigned transporter dashboard summary", () => {
+    render(<DashboardPageView />);
+
+    expect(
+      screen.getByRole("heading", { name: /Panel operativo del transportista/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Contrato E2/i)).toBeInTheDocument();
+    expect(screen.getByText(/Mock dashboard navigation/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Mock logout/i })).toBeInTheDocument();
+    expect(screen.queryByText(/Placeholder de dashboard/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/features/dashboard/pages/dashboard-page.tsx
+++ b/apps/web/features/dashboard/pages/dashboard-page.tsx
@@ -1,22 +1,186 @@
 import { DashboardNavigation } from "../components/dashboard-navigation";
 import { LogoutButton } from "@/features/auth/components/feedback/logout-button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const dashboardSignals = [
+  {
+    label: "Sesion protegida",
+    value: "Bootstrap restaurado",
+  },
+  {
+    label: "Contrato activo",
+    value: "API E2 intacta",
+  },
+  {
+    label: "Proximo foco",
+    value: "Perfil y operacion",
+  },
+];
+
+const dashboardHighlights = [
+  {
+    description:
+      "Tu acceso privado ya esta funcionando y el flujo del onboarding sigue siendo la pieza central para dejar el perfil listo.",
+    title: "Base operativa estable",
+  },
+  {
+    description:
+      "La nueva navegacion prioriza contexto, siguiente accion y lectura rapida sin tocar contratos backend.",
+    title: "Navegacion mas clara",
+  },
+  {
+    description:
+      "El panel resume donde estas parado y te deja a un click de las rutas protegidas mas importantes.",
+    title: "Entrada mas util",
+  },
+];
 
 export default function DashboardPageView() {
   return (
-    <main className="flex min-h-screen items-center justify-center px-6 py-16">
-      <div className="w-full max-w-2xl rounded-3xl border border-border bg-panel p-10 shadow-soft">
-        <span className="text-sm font-semibold uppercase tracking-[0.28em] text-muted">
-          Dashboard
-        </span>
-        <h1 className="mt-4 font-heading text-4xl font-semibold text-foreground">
-          Placeholder de dashboard
-        </h1>
-        <p className="mt-4 text-base leading-7 text-muted">
-          El flujo base ya restaura la sesion con bootstrap global. La proteccion
-          de rutas privadas y guest-only ahora se resuelve desde layouts del App Router.
-        </p>
-        <DashboardNavigation />
-        <LogoutButton />
+    <main className="relative min-h-screen overflow-hidden bg-[linear-gradient(180deg,#f5eee4_0%,#ebdfcd_52%,#e2d2ba_100%)] px-6 py-10">
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+        <div className="absolute left-[-5rem] top-[-4rem] size-[18rem] rounded-full bg-[#dbe9d6]/55 blur-3xl" />
+        <div className="absolute right-[-4rem] top-[8rem] size-[15rem] rounded-full bg-[#f0d3ad]/55 blur-3xl" />
+        <div className="absolute bottom-[-7rem] left-[28%] size-[16rem] rounded-full bg-[#c7ddd6]/40 blur-3xl" />
+      </div>
+
+      <div className="relative mx-auto w-full max-w-6xl space-y-6">
+        <section className="grid gap-6 lg:grid-cols-[1.15fr_0.85fr]">
+          <Card className="overflow-hidden border-white/35 bg-[linear-gradient(160deg,#1a4d3b_0%,#12312a_48%,#0d1d19_100%)] p-8 text-primary-foreground shadow-[0_30px_60px_rgba(16,39,33,0.18)]">
+            <CardHeader className="space-y-5">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-foreground/88">
+                  E2 redesign
+                </span>
+                <span className="rounded-full border border-white/10 bg-[rgba(255,255,255,0.08)] px-4 py-2 text-sm font-semibold text-primary-foreground/88">
+                  Dashboard protegido
+                </span>
+              </div>
+
+              <div className="space-y-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-primary-foreground/62">
+                  Area privada del transportista
+                </p>
+                <h1 className="max-w-3xl font-heading text-4xl font-semibold leading-tight text-primary-foreground sm:text-[2.9rem]">
+                  Panel operativo del transportista
+                </h1>
+                <CardDescription className="max-w-2xl text-base leading-7 text-primary-foreground/76">
+                  La sesion ya se restauro correctamente. Este panel pone en primer
+                  plano el contexto, la proxima accion y los accesos protegidos
+                  mas importantes sin cambiar la API actual.
+                </CardDescription>
+              </div>
+            </CardHeader>
+
+            <CardContent className="mt-8 grid gap-3 sm:grid-cols-3">
+              {dashboardSignals.map((signal) => (
+                <article
+                  className="rounded-[1.6rem] border border-white/10 bg-[rgba(10,26,22,0.52)] px-4 py-4"
+                  key={signal.label}
+                >
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-primary-foreground/58">
+                    {signal.label}
+                  </p>
+                  <p className="mt-2 text-sm font-semibold leading-6 text-primary-foreground">
+                    {signal.value}
+                  </p>
+                </article>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card className="border-white/70 bg-white/84 p-7 shadow-[0_18px_40px_rgba(21,40,33,0.08)] backdrop-blur">
+            <CardHeader className="space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                Lo que ya esta resuelto
+              </p>
+              <CardTitle className="text-[2rem]">Resumen rapido del flujo</CardTitle>
+              <CardDescription className="text-base leading-7">
+                El area protegida ya cuenta con bootstrap de sesion, guards y
+                onboarding conectado. Este dashboard mejora lectura y orientacion.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent className="space-y-4">
+              {dashboardHighlights.map((highlight) => (
+                <article
+                  className="rounded-[1.5rem] border border-border/70 bg-panel/70 px-5 py-4"
+                  key={highlight.title}
+                >
+                  <h2 className="text-base font-semibold text-foreground">
+                    {highlight.title}
+                  </h2>
+                  <p className="mt-2 text-sm leading-6 text-muted">
+                    {highlight.description}
+                  </p>
+                </article>
+              ))}
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[1.05fr_0.95fr]">
+          <Card className="border-white/75 bg-white/86 p-7 shadow-[0_18px_40px_rgba(21,40,33,0.08)] backdrop-blur">
+            <CardHeader className="space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                Navegacion prioritaria
+              </p>
+              <CardTitle className="text-[2rem]">Segui el recorrido protegido</CardTitle>
+              <CardDescription className="text-base leading-7">
+                Usa el panel como base y el onboarding como proxima accion natural
+                para dejar tu operacion lista.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent>
+              <DashboardNavigation />
+            </CardContent>
+          </Card>
+
+          <Card className="border-white/75 bg-[linear-gradient(180deg,rgba(255,255,255,0.86),rgba(247,242,233,0.92))] p-7 shadow-[0_18px_40px_rgba(21,40,33,0.08)] backdrop-blur">
+            <CardHeader className="space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                Control de sesion
+              </p>
+              <CardTitle className="text-[2rem]">Sesion activa y contexto visible</CardTitle>
+              <CardDescription className="text-base leading-7">
+                La proteccion de rutas sigue igual. Este bloque solo hace mas
+                evidente donde estas, que se conserva y como salir si hace falta.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent className="space-y-5">
+              <div className="rounded-[1.5rem] border border-primary/12 bg-primary/5 px-5 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-primary/70">
+                  Contrato E2
+                </p>
+                <p className="mt-2 text-sm leading-6 text-foreground/78">
+                  No se modifico el backend ni el shape de los datos. El cambio es
+                  visual, estructural y de experiencia dentro del area protegida.
+                </p>
+              </div>
+
+              <div className="rounded-[1.5rem] border border-border/70 bg-panel/70 px-5 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                  Siguiente accion recomendada
+                </p>
+                <p className="mt-2 text-sm leading-6 text-foreground/78">
+                  Si tu perfil todavia no esta completo, entra al onboarding y
+                  continua desde ahi. Si ya esta resuelto, usa este panel como
+                  punto de partida del area privada.
+                </p>
+              </div>
+
+              <LogoutButton />
+            </CardContent>
+          </Card>
+        </section>
       </div>
     </main>
   );

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from './schemas/auth.schema';
 export * from './schemas/transporter-profile.schema';
+export * from './schemas/vehicle.schema';
 export * from './interfaces/interfaces';

--- a/packages/shared/src/interfaces/interfaces.ts
+++ b/packages/shared/src/interfaces/interfaces.ts
@@ -5,6 +5,7 @@ import {
   RegisterClientSchema,
   RegisterTransporterSchema,
 } from "../schemas/auth.schema";
+import { CreateVehicleSchema } from "../schemas/vehicle.schema";
 
 const emailSchema = z.string().trim().email().max(320);
 const cuidSchema = z.string().cuid();
@@ -64,6 +65,15 @@ export type ITransporterProfileView = z.infer<
   typeof TransporterProfileViewSchema
 >;
 
+export const VehicleViewSchema = z.object({
+  id: cuidSchema,
+  licensePlate: z.string().trim().min(1).max(8),
+  brand: z.string().trim().min(1).max(80),
+  model: z.string().trim().min(1).max(80),
+  isActive: z.boolean(),
+});
+export type IVehicleView = z.infer<typeof VehicleViewSchema>;
+
 export type IUpdateTransporterProfileDto = {
   displayName?: string;
   businessName?: string | null;
@@ -71,6 +81,9 @@ export type IUpdateTransporterProfileDto = {
   bio?: string | null;
   maxDetourKmDefault?: number | null;
 };
+
+export const CreateVehicleDtoSchema = CreateVehicleSchema;
+export type ICreateVehicleDto = z.infer<typeof CreateVehicleDtoSchema>;
 
 export const AuthProfileViewSchema = z
   .union([UserProfileViewSchema, TransporterProfileViewSchema])

--- a/packages/shared/src/schemas/vehicle.schema.ts
+++ b/packages/shared/src/schemas/vehicle.schema.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+const LICENSE_PLATE_REGEX = /^[A-Z0-9]{6,8}$/;
+
+const requiredTrimmedTextSchema = (maxLength: number, requiredMessage: string) =>
+  z
+    .string()
+    .trim()
+    .min(1, requiredMessage)
+    .max(maxLength, `El valor no puede superar los ${maxLength} caracteres.`);
+
+export const CreateVehicleSchema = z
+  .object({
+    licensePlate: z
+      .string()
+      .trim()
+      .transform((value) => value.toUpperCase())
+      .pipe(
+        z
+          .string()
+          .regex(LICENSE_PLATE_REGEX, "Ingresa una patente valida."),
+      ),
+    brand: requiredTrimmedTextSchema(80, "Ingresa la marca del vehicle."),
+    model: requiredTrimmedTextSchema(80, "Ingresa el modelo del vehicle."),
+  })
+  .strict();
+
+export type CreateVehicleDto = z.infer<typeof CreateVehicleSchema>;


### PR DESCRIPTION
## Summary

Closes #103
Lane: Backend E3
Branch: `feature/103-e3-vehicle-create`
Issue: Implementar alta de vehicle para el transportista autenticado

## What Changed

- Added a dedicated `vehicle` backend module with controller, service, repository and typed DTOs.
- Implemented authenticated vehicle creation for transporters using the new E3 schema entities.
- Added shared validation/schema support for vehicle creation and API response typing.

## Acceptance Criteria

- [x] Transportista puede crear un vehicle
- [x] La patente, marca y modelo quedan persistidos
- [x] Otro usuario no puede crear vehicles en nombre ajeno

## Validation

- cmd /c pnpm --filter @logistica/shared build
- cmd /c pnpm --filter @logistica/shared typecheck
- cmd /c pnpm --filter @logistica/api exec tsc --noEmit -p tsconfig.json
- cmd /c pnpm --filter @logistica/api exec jest --config jest.config.cjs --runInBand src/vehicle

## Risks

- Los scripts habituales de `@logistica/api` que pasan por `prisma generate` siguen fallando en este entorno por binarios/locks de Prisma, por eso la validacion se hizo con `tsc` y `jest` directos sobre el modulo.
- La unicidad de patente se valida primero por consulta y ademas queda respaldada por la restriccion unica en base de datos.

## UI Evidence

- No aplica

## Notes For Review

- Se agrego el modulo `vehicle` sin tocar auth, pagos, roles, webhooks ni anti-overbooking.
- El endpoint expuesto es `POST /vehicles` para el transportista autenticado.
- Queda listo el terreno para las siguientes issues de update/deactivate/listados de fleet.