### PR TITLE
feat(web): redesign transporter dashboard

### DIFF
--- a/apps/web/features/dashboard/components/dashboard-navigation.test.tsx
+++ b/apps/web/features/dashboard/components/dashboard-navigation.test.tsx
@@ -23,7 +23,9 @@ describe("DashboardNavigation", () => {
 
     const user = userEvent.setup();
 
-    await user.click(screen.getByRole("button", { name: /Ir al dashboard/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Ver panel del transportista/i }),
+    );
 
     expect(push).toHaveBeenCalledWith("/dashboard");
   });
@@ -33,7 +35,7 @@ describe("DashboardNavigation", () => {
 
     const user = userEvent.setup();
 
-    await user.click(screen.getByRole("button", { name: /Completar onboarding/i }));
+    await user.click(screen.getByRole("button", { name: /Abrir onboarding/i }));
 
     expect(push).toHaveBeenCalledWith("/onboarding/transporter");
   });

--- a/apps/web/features/dashboard/components/dashboard-navigation.tsx
+++ b/apps/web/features/dashboard/components/dashboard-navigation.tsx
@@ -5,22 +5,30 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 
 type DashboardDestination = {
+  eyebrow: string;
   description: string;
   href: string;
+  meta: string;
   title: string;
   variant?: "ghost" | "primary";
 };
 
 const DASHBOARD_DESTINATIONS: DashboardDestination[] = [
   {
-    description: "Volver a la vista principal del area privada.",
+    description:
+      "Consulta el resumen del estado actual, la hoja de ruta del area privada y los accesos mas usados.",
+    eyebrow: "Panel actual",
     href: "/dashboard",
-    title: "Ir al dashboard",
+    meta: "Ruta principal protegida",
+    title: "Ver panel del transportista",
   },
   {
-    description: "Continuar con la carga y revision del perfil transportista.",
+    description:
+      "Segui con la carga y revision del perfil transportista sin salir del flujo protegido actual.",
+    eyebrow: "Siguiente paso",
     href: "/onboarding/transporter",
-    title: "Completar onboarding",
+    meta: "Continua donde lo dejaste",
+    title: "Abrir onboarding",
     variant: "ghost",
   },
 ];
@@ -41,29 +49,40 @@ export function DashboardNavigation() {
           className="text-lg font-semibold text-foreground"
           id="dashboard-navigation-title"
         >
-          Accesos rapidos
+          Accesos prioritarios
         </h2>
         <p className="text-sm leading-6 text-muted">
-          Usa estos accesos para moverte entre las rutas privadas disponibles
-          despues de iniciar sesion.
+          Usa estos accesos para moverte entre las rutas protegidas mas
+          importantes sin perder el contexto de tu sesion.
         </p>
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2">
-        {DASHBOARD_DESTINATIONS.map(({ description, href, title, variant }) => (
+        {DASHBOARD_DESTINATIONS.map(
+          ({ description, eyebrow, href, meta, title, variant }) => (
           <Button
-            className="h-auto min-h-14 flex-col items-start px-5 py-4 text-left"
+            className="h-auto min-h-[11rem] flex-col items-start justify-between rounded-[1.8rem] px-5 py-5 text-left"
             key={href}
             onClick={() => handleNavigation(href)}
             type="button"
             variant={variant}
           >
-            <span>{title}</span>
-            <span className="text-sm font-normal leading-6 text-current/80">
-              {description}
+            <div className="space-y-3">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-current/70">
+                {eyebrow}
+              </span>
+              <span className="block text-lg font-semibold leading-7">{title}</span>
+              <span className="block text-sm font-normal leading-6 text-current/80">
+                {description}
+              </span>
+            </div>
+
+            <span className="inline-flex rounded-full border border-current/15 bg-black/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-current/80">
+              {meta}
             </span>
           </Button>
-        ))}
+          ),
+        )}
       </div>
     </section>
   );

--- a/apps/web/features/dashboard/pages/dashboard-page.test.tsx
+++ b/apps/web/features/dashboard/pages/dashboard-page.test.tsx
@@ -1,0 +1,27 @@
+/** @jest-environment jsdom */
+
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import DashboardPageView from "./dashboard-page";
+
+jest.mock("../components/dashboard-navigation", () => ({
+  DashboardNavigation: () => <div>Mock dashboard navigation</div>,
+}));
+
+jest.mock("@/features/auth/components/feedback/logout-button", () => ({
+  LogoutButton: () => <button type="button">Mock logout</button>,
+}));
+
+describe("DashboardPageView", () => {
+  it("renders the redesigned transporter dashboard summary", () => {
+    render(<DashboardPageView />);
+
+    expect(
+      screen.getByRole("heading", { name: /Panel operativo del transportista/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Contrato E2/i)).toBeInTheDocument();
+    expect(screen.getByText(/Mock dashboard navigation/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Mock logout/i })).toBeInTheDocument();
+    expect(screen.queryByText(/Placeholder de dashboard/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/features/dashboard/pages/dashboard-page.tsx
+++ b/apps/web/features/dashboard/pages/dashboard-page.tsx
@@ -1,22 +1,186 @@
 import { DashboardNavigation } from "../components/dashboard-navigation";
 import { LogoutButton } from "@/features/auth/components/feedback/logout-button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const dashboardSignals = [
+  {
+    label: "Sesion protegida",
+    value: "Bootstrap restaurado",
+  },
+  {
+    label: "Contrato activo",
+    value: "API E2 intacta",
+  },
+  {
+    label: "Proximo foco",
+    value: "Perfil y operacion",
+  },
+];
+
+const dashboardHighlights = [
+  {
+    description:
+      "Tu acceso privado ya esta funcionando y el flujo del onboarding sigue siendo la pieza central para dejar el perfil listo.",
+    title: "Base operativa estable",
+  },
+  {
+    description:
+      "La nueva navegacion prioriza contexto, siguiente accion y lectura rapida sin tocar contratos backend.",
+    title: "Navegacion mas clara",
+  },
+  {
+    description:
+      "El panel resume donde estas parado y te deja a un click de las rutas protegidas mas importantes.",
+    title: "Entrada mas util",
+  },
+];
 
 export default function DashboardPageView() {
   return (
-    <main className="flex min-h-screen items-center justify-center px-6 py-16">
-      <div className="w-full max-w-2xl rounded-3xl border border-border bg-panel p-10 shadow-soft">
-        <span className="text-sm font-semibold uppercase tracking-[0.28em] text-muted">
-          Dashboard
-        </span>
-        <h1 className="mt-4 font-heading text-4xl font-semibold text-foreground">
-          Placeholder de dashboard
-        </h1>
-        <p className="mt-4 text-base leading-7 text-muted">
-          El flujo base ya restaura la sesion con bootstrap global. La proteccion
-          de rutas privadas y guest-only ahora se resuelve desde layouts del App Router.
-        </p>
-        <DashboardNavigation />
-        <LogoutButton />
+    <main className="relative min-h-screen overflow-hidden bg-[linear-gradient(180deg,#f5eee4_0%,#ebdfcd_52%,#e2d2ba_100%)] px-6 py-10">
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+        <div className="absolute left-[-5rem] top-[-4rem] size-[18rem] rounded-full bg-[#dbe9d6]/55 blur-3xl" />
+        <div className="absolute right-[-4rem] top-[8rem] size-[15rem] rounded-full bg-[#f0d3ad]/55 blur-3xl" />
+        <div className="absolute bottom-[-7rem] left-[28%] size-[16rem] rounded-full bg-[#c7ddd6]/40 blur-3xl" />
+      </div>
+
+      <div className="relative mx-auto w-full max-w-6xl space-y-6">
+        <section className="grid gap-6 lg:grid-cols-[1.15fr_0.85fr]">
+          <Card className="overflow-hidden border-white/35 bg-[linear-gradient(160deg,#1a4d3b_0%,#12312a_48%,#0d1d19_100%)] p-8 text-primary-foreground shadow-[0_30px_60px_rgba(16,39,33,0.18)]">
+            <CardHeader className="space-y-5">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-foreground/88">
+                  E2 redesign
+                </span>
+                <span className="rounded-full border border-white/10 bg-[rgba(255,255,255,0.08)] px-4 py-2 text-sm font-semibold text-primary-foreground/88">
+                  Dashboard protegido
+                </span>
+              </div>
+
+              <div className="space-y-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-primary-foreground/62">
+                  Area privada del transportista
+                </p>
+                <h1 className="max-w-3xl font-heading text-4xl font-semibold leading-tight text-primary-foreground sm:text-[2.9rem]">
+                  Panel operativo del transportista
+                </h1>
+                <CardDescription className="max-w-2xl text-base leading-7 text-primary-foreground/76">
+                  La sesion ya se restauro correctamente. Este panel pone en primer
+                  plano el contexto, la proxima accion y los accesos protegidos
+                  mas importantes sin cambiar la API actual.
+                </CardDescription>
+              </div>
+            </CardHeader>
+
+            <CardContent className="mt-8 grid gap-3 sm:grid-cols-3">
+              {dashboardSignals.map((signal) => (
+                <article
+                  className="rounded-[1.6rem] border border-white/10 bg-[rgba(10,26,22,0.52)] px-4 py-4"
+                  key={signal.label}
+                >
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-primary-foreground/58">
+                    {signal.label}
+                  </p>
+                  <p className="mt-2 text-sm font-semibold leading-6 text-primary-foreground">
+                    {signal.value}
+                  </p>
+                </article>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card className="border-white/70 bg-white/84 p-7 shadow-[0_18px_40px_rgba(21,40,33,0.08)] backdrop-blur">
+            <CardHeader className="space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                Lo que ya esta resuelto
+              </p>
+              <CardTitle className="text-[2rem]">Resumen rapido del flujo</CardTitle>
+              <CardDescription className="text-base leading-7">
+                El area protegida ya cuenta con bootstrap de sesion, guards y
+                onboarding conectado. Este dashboard mejora lectura y orientacion.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent className="space-y-4">
+              {dashboardHighlights.map((highlight) => (
+                <article
+                  className="rounded-[1.5rem] border border-border/70 bg-panel/70 px-5 py-4"
+                  key={highlight.title}
+                >
+                  <h2 className="text-base font-semibold text-foreground">
+                    {highlight.title}
+                  </h2>
+                  <p className="mt-2 text-sm leading-6 text-muted">
+                    {highlight.description}
+                  </p>
+                </article>
+              ))}
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[1.05fr_0.95fr]">
+          <Card className="border-white/75 bg-white/86 p-7 shadow-[0_18px_40px_rgba(21,40,33,0.08)] backdrop-blur">
+            <CardHeader className="space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                Navegacion prioritaria
+              </p>
+              <CardTitle className="text-[2rem]">Segui el recorrido protegido</CardTitle>
+              <CardDescription className="text-base leading-7">
+                Usa el panel como base y el onboarding como proxima accion natural
+                para dejar tu operacion lista.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent>
+              <DashboardNavigation />
+            </CardContent>
+          </Card>
+
+          <Card className="border-white/75 bg-[linear-gradient(180deg,rgba(255,255,255,0.86),rgba(247,242,233,0.92))] p-7 shadow-[0_18px_40px_rgba(21,40,33,0.08)] backdrop-blur">
+            <CardHeader className="space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                Control de sesion
+              </p>
+              <CardTitle className="text-[2rem]">Sesion activa y contexto visible</CardTitle>
+              <CardDescription className="text-base leading-7">
+                La proteccion de rutas sigue igual. Este bloque solo hace mas
+                evidente donde estas, que se conserva y como salir si hace falta.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent className="space-y-5">
+              <div className="rounded-[1.5rem] border border-primary/12 bg-primary/5 px-5 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-primary/70">
+                  Contrato E2
+                </p>
+                <p className="mt-2 text-sm leading-6 text-foreground/78">
+                  No se modifico el backend ni el shape de los datos. El cambio es
+                  visual, estructural y de experiencia dentro del area protegida.
+                </p>
+              </div>
+
+              <div className="rounded-[1.5rem] border border-border/70 bg-panel/70 px-5 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                  Siguiente accion recomendada
+                </p>
+                <p className="mt-2 text-sm leading-6 text-foreground/78">
+                  Si tu perfil todavia no esta completo, entra al onboarding y
+                  continua desde ahi. Si ya esta resuelto, usa este panel como
+                  punto de partida del area privada.
+                </p>
+              </div>
+
+              <LogoutButton />
+            </CardContent>
+          </Card>
+        </section>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary

Closes #121
Lane: Frontend E2 Redesign
Scope: reemplaza el dashboard placeholder y mejora la navegacion protegida del transportista sin cambiar contratos backend

## Why

Despues del redise?o del onboarding E2, el siguiente punto visible del transportista seguia siendo un dashboard muy basico. Esta rama mejora ese punto de entrada sin depender de E3 ni cambiar la API actual.

## Acceptance Criteria

- [x] El dashboard ya no se ve como placeholder
- [x] La navegacion protegida del transportista es mas clara y util
- [x] No cambian contratos API ni payloads backend
- [x] La experiencia funciona bien en desktop y mobile

## Validation

- [x] `cmd /c pnpm --filter @logistica/web test -- dashboard`
- [x] `cmd /c pnpm --filter @logistica/web typecheck`
- [ ] Screenshots adjuntas

## Risks

- No se pudieron adjuntar screenshots desde este flujo automatizado
- El cambio es visual y de navegacion; conviene revisar la PR con vista de UI en GitHub/local

## Screenshots / Evidence

- No disponibles desde este flujo; ver visualmente en la rama publicada

## Handoff Notes

- Next ready issue: continuar frontend E2 con el siguiente slice visual o esperar definicion de nuevo objetivo
- Contract changes: ninguno
- Protected zones touched: ninguna

## Checklist

- [x] Un solo proposito claro
- [x] No toca zonas protegidas sin aprobacion explicita
- [x] Incluye manejo razonable de errores si aplica
- [x] `.env.example` actualizado si se agregaron variables
- [x] Documentacion actualizada si cambia comportamiento importante
- [x] PR chico y revisable