### PR TITLE
feat: implementar actualizacion y desactivacion de vehicle

### DIFF
--- a/apps/api/src/vehicle/application/vehicle.service.spec.ts
+++ b/apps/api/src/vehicle/application/vehicle.service.spec.ts
@@ -6,7 +6,9 @@ describe('VehicleService', () => {
   const vehicleRepository = {
     findTransporterProfileByAccountId: jest.fn(),
     findByLicensePlate: jest.fn(),
+    findOwnedById: jest.fn(),
     create: jest.fn(),
+    updateById: jest.fn(),
   };
 
   let vehicleService: VehicleService;
@@ -116,5 +118,113 @@ describe('VehicleService', () => {
         model: 'R450',
       }),
     ).rejects.toThrow(ConflictException);
+  });
+
+  it('updates an owned vehicle', async () => {
+    vehicleRepository.findOwnedById.mockResolvedValue({
+      id: 'vehicle-id',
+      licensePlate: 'AB123CD',
+      brand: 'Scania',
+      model: 'R450',
+      isActive: true,
+    });
+    vehicleRepository.updateById.mockResolvedValue({
+      id: 'vehicle-id',
+      licensePlate: 'AB123CD',
+      brand: 'Mercedes',
+      model: 'Actros',
+      isActive: true,
+    });
+
+    await expect(
+      vehicleService.updateOwnVehicle('account-id', 'vehicle-id', {
+        brand: ' Mercedes ',
+        model: ' Actros ',
+      }),
+    ).resolves.toEqual({
+      id: 'vehicle-id',
+      licensePlate: 'AB123CD',
+      brand: 'Mercedes',
+      model: 'Actros',
+      isActive: true,
+    });
+
+    expect(vehicleRepository.findOwnedById).toHaveBeenCalledWith(
+      'account-id',
+      'vehicle-id',
+    );
+    expect(vehicleRepository.findByLicensePlate).not.toHaveBeenCalled();
+    expect(vehicleRepository.updateById).toHaveBeenCalledWith('vehicle-id', {
+      brand: 'Mercedes',
+      model: 'Actros',
+    });
+  });
+
+  it('throws when updating a vehicle that is not owned by the account', async () => {
+    vehicleRepository.findOwnedById.mockResolvedValue(null);
+
+    await expect(
+      vehicleService.updateOwnVehicle('account-id', 'vehicle-id', {
+        brand: 'Mercedes',
+      }),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(vehicleRepository.updateById).not.toHaveBeenCalled();
+  });
+
+  it('throws conflict when updating to a duplicated license plate', async () => {
+    vehicleRepository.findOwnedById.mockResolvedValue({
+      id: 'vehicle-id',
+      licensePlate: 'AB123CD',
+      brand: 'Scania',
+      model: 'R450',
+      isActive: true,
+    });
+    vehicleRepository.findByLicensePlate.mockResolvedValue({
+      id: 'other-vehicle-id',
+      licensePlate: 'CD456EF',
+      brand: 'Volvo',
+      model: 'FH',
+      isActive: true,
+    });
+
+    await expect(
+      vehicleService.updateOwnVehicle('account-id', 'vehicle-id', {
+        licensePlate: 'cd456ef',
+      }),
+    ).rejects.toThrow(ConflictException);
+
+    expect(vehicleRepository.updateById).not.toHaveBeenCalled();
+  });
+
+  it('deactivates an owned vehicle without hard deleting it', async () => {
+    vehicleRepository.findOwnedById.mockResolvedValue({
+      id: 'vehicle-id',
+      licensePlate: 'AB123CD',
+      brand: 'Scania',
+      model: 'R450',
+      isActive: true,
+    });
+    vehicleRepository.updateById.mockResolvedValue({
+      id: 'vehicle-id',
+      licensePlate: 'AB123CD',
+      brand: 'Scania',
+      model: 'R450',
+      isActive: false,
+    });
+
+    await expect(
+      vehicleService.deactivateOwnVehicle('account-id', 'vehicle-id'),
+    ).resolves.toEqual({
+      id: 'vehicle-id',
+      licensePlate: 'AB123CD',
+      brand: 'Scania',
+      model: 'R450',
+      isActive: false,
+    });
+
+    expect(vehicleRepository.updateById).toHaveBeenCalledWith('vehicle-id', {
+      isActive: false,
+    });
   });
 });

--- a/apps/api/src/vehicle/application/vehicle.service.ts
+++ b/apps/api/src/vehicle/application/vehicle.service.ts
@@ -6,7 +6,12 @@ import {
 import { Prisma } from '@logistica/database';
 import type { VehicleResponseDto } from '../dto/vehicle.response.dto';
 import { VehicleRepository } from '../repositories/vehicle.repository';
-import type { CreateVehicleInput, VehicleRecord } from '../types/vehicle.types';
+import type {
+  CreateVehicleInput,
+  NormalizedVehicleUpdateInput,
+  UpdateVehicleInput,
+  VehicleRecord,
+} from '../types/vehicle.types';
 
 @Injectable()
 export class VehicleService {
@@ -54,11 +59,103 @@ export class VehicleService {
     }
   }
 
+  async updateOwnVehicle(
+    accountId: string,
+    vehicleId: string,
+    input: UpdateVehicleInput,
+  ): Promise<VehicleResponseDto> {
+    const existingVehicle = await this.vehicleRepository.findOwnedById(
+      accountId,
+      vehicleId,
+    );
+
+    if (!existingVehicle) {
+      throw new NotFoundException(
+        'Vehicle not found for the authenticated account.',
+      );
+    }
+
+    const normalizedInput = this.normalizeUpdateInput(input);
+
+    if (
+      normalizedInput.licensePlate &&
+      normalizedInput.licensePlate !== existingVehicle.licensePlate
+    ) {
+      const duplicatedVehicle = await this.vehicleRepository.findByLicensePlate(
+        normalizedInput.licensePlate,
+      );
+
+      if (duplicatedVehicle && duplicatedVehicle.id !== existingVehicle.id) {
+        throw new ConflictException(
+          'A vehicle with this license plate already exists.',
+        );
+      }
+    }
+
+    try {
+      const updatedVehicle = await this.vehicleRepository.updateById(
+        vehicleId,
+        normalizedInput,
+      );
+
+      return this.toVehicleResponse(updatedVehicle);
+    } catch (error) {
+      if (this.isUniqueConstraintViolation(error)) {
+        throw new ConflictException(
+          'A vehicle with this license plate already exists.',
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  async deactivateOwnVehicle(
+    accountId: string,
+    vehicleId: string,
+  ): Promise<VehicleResponseDto> {
+    const existingVehicle = await this.vehicleRepository.findOwnedById(
+      accountId,
+      vehicleId,
+    );
+
+    if (!existingVehicle) {
+      throw new NotFoundException(
+        'Vehicle not found for the authenticated account.',
+      );
+    }
+
+    if (!existingVehicle.isActive) {
+      return this.toVehicleResponse(existingVehicle);
+    }
+
+    const deactivatedVehicle = await this.vehicleRepository.updateById(
+      vehicleId,
+      {
+        isActive: false,
+      },
+    );
+
+    return this.toVehicleResponse(deactivatedVehicle);
+  }
+
   private normalizeInput(input: CreateVehicleInput): CreateVehicleInput {
     return {
       licensePlate: input.licensePlate.trim().toUpperCase(),
       brand: input.brand.trim(),
       model: input.model.trim(),
+    };
+  }
+
+  private normalizeUpdateInput(
+    input: UpdateVehicleInput,
+  ): NormalizedVehicleUpdateInput {
+    return {
+      ...(input.licensePlate !== undefined
+        ? { licensePlate: input.licensePlate.trim().toUpperCase() }
+        : {}),
+      ...(input.brand !== undefined ? { brand: input.brand.trim() } : {}),
+      ...(input.model !== undefined ? { model: input.model.trim() } : {}),
     };
   }
 

--- a/apps/api/src/vehicle/dto/update-vehicle.dto.ts
+++ b/apps/api/src/vehicle/dto/update-vehicle.dto.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import type { IUpdateVehicleDto } from '@logistica/shared';
+
+export const VehicleParamsSchema = z.object({
+  id: z.string().cuid(),
+});
+
+export type VehicleParamsDto = z.infer<typeof VehicleParamsSchema>;
+export type UpdateVehicleDto = IUpdateVehicleDto;

--- a/apps/api/src/vehicle/repositories/vehicle.repository.ts
+++ b/apps/api/src/vehicle/repositories/vehicle.repository.ts
@@ -4,6 +4,7 @@ import type {
   CreateVehicleInput,
   TransporterProfileOwnerRecord,
   VehicleRecord,
+  VehicleUpdateData,
 } from '../types/vehicle.types';
 import {
   transporterProfileOwnerSelect,
@@ -32,6 +33,21 @@ export class VehicleRepository {
     });
   }
 
+  async findOwnedById(
+    accountId: string,
+    vehicleId: string,
+  ): Promise<VehicleRecord | null> {
+    return this.prisma.vehicle.findFirst({
+      where: {
+        id: vehicleId,
+        transporterProfile: {
+          accountId,
+        },
+      },
+      select: vehicleSelect,
+    });
+  }
+
   async create(
     transporterProfileId: string,
     input: CreateVehicleInput,
@@ -47,6 +63,17 @@ export class VehicleRepository {
         brand: input.brand,
         model: input.model,
       },
+      select: vehicleSelect,
+    });
+  }
+
+  async updateById(
+    vehicleId: string,
+    data: VehicleUpdateData,
+  ): Promise<VehicleRecord> {
+    return this.prisma.vehicle.update({
+      where: { id: vehicleId },
+      data,
       select: vehicleSelect,
     });
   }

--- a/apps/api/src/vehicle/types/vehicle.types.ts
+++ b/apps/api/src/vehicle/types/vehicle.types.ts
@@ -14,6 +14,12 @@ export const transporterProfileOwnerSelect = {
 } satisfies Prisma.TransporterProfileSelect;
 
 export type CreateVehicleInput = ICreateVehicleDto;
+export type NormalizedVehicleUpdateInput = {
+  licensePlate?: string;
+  brand?: string;
+  model?: string;
+};
+export type UpdateVehicleInput = NormalizedVehicleUpdateInput;
 export type VehicleRecord = Prisma.VehicleGetPayload<{
   select: typeof vehicleSelect;
 }>;
@@ -21,3 +27,4 @@ export type TransporterProfileOwnerRecord =
   Prisma.TransporterProfileGetPayload<{
     select: typeof transporterProfileOwnerSelect;
   }>;
+export type VehicleUpdateData = Prisma.VehicleUpdateInput;

--- a/apps/api/src/vehicle/vehicle.controller.spec.ts
+++ b/apps/api/src/vehicle/vehicle.controller.spec.ts
@@ -1,6 +1,8 @@
 import {
+  ConflictException,
   Injectable,
   type ExecutionContext,
+  NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
@@ -41,6 +43,8 @@ class TestJwtAuthGuard {
 describe('VehicleController', () => {
   const vehicleService = {
     createOwnVehicle: jest.fn(),
+    updateOwnVehicle: jest.fn(),
+    deactivateOwnVehicle: jest.fn(),
   };
 
   beforeEach(() => {
@@ -161,6 +165,145 @@ describe('VehicleController', () => {
       .expect(403);
 
     expect(vehicleService.createOwnVehicle).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('updates an owned vehicle for a transporter token', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    vehicleService.updateOwnVehicle.mockResolvedValue({
+      id: 'vehicle-id',
+      licensePlate: 'AB123CD',
+      brand: 'Mercedes',
+      model: 'Actros',
+      isActive: true,
+    });
+
+    await request(server)
+      .patch('/vehicles/vehicle-id')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        brand: 'Mercedes',
+        model: 'Actros',
+      })
+      .expect(400);
+
+    expect(vehicleService.updateOwnVehicle).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('updates an owned vehicle when the id is valid', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const vehicleId = 'cm9vehicle0000wqz5oy7k8ph1';
+
+    vehicleService.updateOwnVehicle.mockResolvedValue({
+      id: vehicleId,
+      licensePlate: 'AB123CD',
+      brand: 'Mercedes',
+      model: 'Actros',
+      isActive: true,
+    });
+
+    await request(server)
+      .patch(`/vehicles/${vehicleId}`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        brand: 'Mercedes',
+        model: 'Actros',
+      })
+      .expect(200)
+      .expect({
+        id: vehicleId,
+        licensePlate: 'AB123CD',
+        brand: 'Mercedes',
+        model: 'Actros',
+        isActive: true,
+      });
+
+    expect(vehicleService.updateOwnVehicle).toHaveBeenCalledWith(
+      'transporter-account-id',
+      vehicleId,
+      {
+        brand: 'Mercedes',
+        model: 'Actros',
+      },
+    );
+
+    await app.close();
+  });
+
+  it('returns 409 when updating a vehicle collides with an existing license plate', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const vehicleId = 'cm9vehicle0000wqz5oy7k8ph1';
+
+    vehicleService.updateOwnVehicle.mockRejectedValue(
+      new ConflictException(
+        'A vehicle with this license plate already exists.',
+      ),
+    );
+
+    await request(server)
+      .patch(`/vehicles/${vehicleId}`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        licensePlate: 'CD456EF',
+      })
+      .expect(409);
+
+    await app.close();
+  });
+
+  it('deactivates an owned vehicle for a transporter token', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const vehicleId = 'cm9vehicle0000wqz5oy7k8ph1';
+
+    vehicleService.deactivateOwnVehicle.mockResolvedValue({
+      id: vehicleId,
+      licensePlate: 'AB123CD',
+      brand: 'Scania',
+      model: 'R450',
+      isActive: false,
+    });
+
+    await request(server)
+      .patch(`/vehicles/${vehicleId}/deactivate`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .expect(200)
+      .expect({
+        id: vehicleId,
+        licensePlate: 'AB123CD',
+        brand: 'Scania',
+        model: 'R450',
+        isActive: false,
+      });
+
+    expect(vehicleService.deactivateOwnVehicle).toHaveBeenCalledWith(
+      'transporter-account-id',
+      vehicleId,
+    );
+
+    await app.close();
+  });
+
+  it('returns 404 when deactivating a vehicle that is not owned by the account', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const vehicleId = 'cm9vehicle0000wqz5oy7k8ph1';
+
+    vehicleService.deactivateOwnVehicle.mockRejectedValue(
+      new NotFoundException('Vehicle not found for the authenticated account.'),
+    );
+
+    await request(server)
+      .patch(`/vehicles/${vehicleId}/deactivate`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .expect(404);
 
     await app.close();
   });

--- a/apps/api/src/vehicle/vehicle.controller.ts
+++ b/apps/api/src/vehicle/vehicle.controller.ts
@@ -1,5 +1,13 @@
-import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
-import { CreateVehicleSchema } from '@logistica/shared';
+import {
+  Body,
+  Controller,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { CreateVehicleSchema, UpdateVehicleSchema } from '@logistica/shared';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { Roles } from '../identity/authentication/decorators/roles.decorator';
 import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
@@ -7,6 +15,11 @@ import { RolesGuard } from '../identity/authentication/guards/roles.guard';
 import type { AuthenticatedAccount } from '../identity/authentication/types/authentication.types';
 import { VehicleService } from './application/vehicle.service';
 import type { CreateVehicleDto } from './dto/create-vehicle.dto';
+import type {
+  UpdateVehicleDto,
+  VehicleParamsDto,
+} from './dto/update-vehicle.dto';
+import { VehicleParamsSchema } from './dto/update-vehicle.dto';
 import type { VehicleResponseDto } from './dto/vehicle.response.dto';
 
 interface AuthenticatedHttpRequest {
@@ -28,6 +41,37 @@ export class VehicleController {
     return this.vehicleService.createOwnVehicle(
       request.user.accountId,
       createVehicleDto,
+    );
+  }
+
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async updateOwnVehicle(
+    @Req() request: AuthenticatedHttpRequest,
+    @Param(new ZodValidationPipe(VehicleParamsSchema))
+    params: VehicleParamsDto,
+    @Body(new ZodValidationPipe(UpdateVehicleSchema))
+    updateVehicleDto: UpdateVehicleDto,
+  ): Promise<VehicleResponseDto> {
+    return this.vehicleService.updateOwnVehicle(
+      request.user.accountId,
+      params.id,
+      updateVehicleDto,
+    );
+  }
+
+  @Patch(':id/deactivate')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async deactivateOwnVehicle(
+    @Req() request: AuthenticatedHttpRequest,
+    @Param(new ZodValidationPipe(VehicleParamsSchema))
+    params: VehicleParamsDto,
+  ): Promise<VehicleResponseDto> {
+    return this.vehicleService.deactivateOwnVehicle(
+      request.user.accountId,
+      params.id,
     );
   }
 }

--- a/packages/shared/src/interfaces/interfaces.ts
+++ b/packages/shared/src/interfaces/interfaces.ts
@@ -5,7 +5,10 @@ import {
   RegisterClientSchema,
   RegisterTransporterSchema,
 } from "../schemas/auth.schema";
-import { CreateVehicleSchema } from "../schemas/vehicle.schema";
+import {
+  CreateVehicleSchema,
+  UpdateVehicleSchema,
+} from "../schemas/vehicle.schema";
 
 const emailSchema = z.string().trim().email().max(320);
 const cuidSchema = z.string().cuid();
@@ -84,6 +87,9 @@ export type IUpdateTransporterProfileDto = {
 
 export const CreateVehicleDtoSchema = CreateVehicleSchema;
 export type ICreateVehicleDto = z.infer<typeof CreateVehicleDtoSchema>;
+
+export const UpdateVehicleDtoSchema = UpdateVehicleSchema;
+export type IUpdateVehicleDto = z.infer<typeof UpdateVehicleDtoSchema>;
 
 export const AuthProfileViewSchema = z
   .union([UserProfileViewSchema, TransporterProfileViewSchema])

--- a/packages/shared/src/schemas/vehicle.schema.ts
+++ b/packages/shared/src/schemas/vehicle.schema.ts
@@ -25,4 +25,25 @@ export const CreateVehicleSchema = z
   })
   .strict();
 
+export const UpdateVehicleSchema = z
+  .object({
+    licensePlate: z
+      .string()
+      .trim()
+      .transform((value) => value.toUpperCase())
+      .pipe(
+        z
+          .string()
+          .regex(LICENSE_PLATE_REGEX, 'Ingresa una patente valida.'),
+      )
+      .optional(),
+    brand: requiredTrimmedTextSchema(80, 'Ingresa la marca del vehicle.').optional(),
+    model: requiredTrimmedTextSchema(80, 'Ingresa el modelo del vehicle.').optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'Debes enviar al menos un campo para actualizar el vehicle.',
+  });
+
 export type CreateVehicleDto = z.infer<typeof CreateVehicleSchema>;
+export type UpdateVehicleDto = z.infer<typeof UpdateVehicleSchema>;


### PR DESCRIPTION
## Summary
- add PATCH endpoints for transporters to update their own vehicles and deactivate them without hard delete
- validate vehicle ownership and duplicate plate conflicts in the service and repository flow
- cover update and deactivate paths with unit and HTTP tests

## Issue
Closes #104

## Lane
Lane: Backend E3

## Acceptance Criteria
- authenticated transporters can update their own vehicle brand, model, and license plate
- authenticated transporters can deactivate their own vehicle without deleting the record
- non-owners receive not found responses and duplicate license plates return conflict responses
- update and deactivate flows are covered by tests

## Validation
- pnpm --filter @logistica/shared build
- pnpm --filter @logistica/api exec eslint src/vehicle src/app.module.ts
- pnpm --filter @logistica/api exec jest --config jest.config.cjs --runInBand src/vehicle
- pnpm --filter @logistica/api exec tsc --noEmit -p tsconfig.json

## Risks
- deactivation is soft-only for now; any future list endpoints must keep honoring isActive filters where appropriate

## Handoff Notes
- next backend slice can build on this ownership-checked base for fleet listing or trailer management without touching auth or payments