### PR TITLE
feat(trailer): add authenticated trailer creation

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { AdminModule } from './admin/admin.module';
 import { AccountsModule } from './identity/accounts/accounts.module';
 import { AuthenticationModule } from './identity/authentication/authentication.module';
 import { TransporterProfileModule } from './identity/transporter-profile/transporter-profile.module';
+import { TrailerModule } from './trailer/trailer.module';
 import { VehicleModule } from './vehicle/vehicle.module';
 
 @Module({
@@ -36,6 +37,7 @@ import { VehicleModule } from './vehicle/vehicle.module';
     AccountsModule,
     AuthenticationModule,
     TransporterProfileModule,
+    TrailerModule,
     VehicleModule,
   ],
   controllers: [],

--- a/apps/api/src/trailer/application/trailer.service.spec.ts
+++ b/apps/api/src/trailer/application/trailer.service.spec.ts
@@ -1,0 +1,85 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { TrailerService } from './trailer.service';
+
+describe('TrailerService', () => {
+  const trailerRepository = {
+    findTransporterProfileByAccountId: jest.fn(),
+    create: jest.fn(),
+  };
+
+  let trailerService: TrailerService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    trailerService = new TrailerService(trailerRepository as never);
+  });
+
+  it('creates a trailer for the authenticated transporter', async () => {
+    trailerRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+    trailerRepository.create.mockResolvedValue({
+      id: 'trailer-id',
+      totalCapacity: 12,
+      cargoType: 'EQUINE',
+      capacityUnit: 'SLOT',
+      isActive: true,
+    });
+
+    await expect(
+      trailerService.createOwnTrailer('account-id', {
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      }),
+    ).resolves.toEqual({
+      id: 'trailer-id',
+      totalCapacity: 12,
+      cargoType: 'EQUINE',
+      capacityUnit: 'SLOT',
+      isActive: true,
+    });
+
+    expect(
+      trailerRepository.findTransporterProfileByAccountId,
+    ).toHaveBeenCalledWith('account-id');
+    expect(trailerRepository.create).toHaveBeenCalledWith(
+      'transporter-profile-id',
+      {
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      },
+    );
+  });
+
+  it('throws when the authenticated account has no transporter profile', async () => {
+    trailerRepository.findTransporterProfileByAccountId.mockResolvedValue(null);
+
+    await expect(
+      trailerService.createOwnTrailer('missing-account', {
+        totalCapacity: 10,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      }),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(trailerRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when the provided capacity is not operationally valid', async () => {
+    trailerRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+
+    await expect(
+      trailerService.createOwnTrailer('account-id', {
+        totalCapacity: 0,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(trailerRepository.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/trailer/application/trailer.service.ts
+++ b/apps/api/src/trailer/application/trailer.service.ts
@@ -1,0 +1,54 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import type { TrailerResponseDto } from '../dto/trailer.response.dto';
+import { TrailerRepository } from '../repositories/trailer.repository';
+import type { CreateTrailerInput, TrailerRecord } from '../types/trailer.types';
+
+@Injectable()
+export class TrailerService {
+  constructor(private readonly trailerRepository: TrailerRepository) {}
+
+  async createOwnTrailer(
+    accountId: string,
+    input: CreateTrailerInput,
+  ): Promise<TrailerResponseDto> {
+    const transporterProfile =
+      await this.trailerRepository.findTransporterProfileByAccountId(accountId);
+
+    if (!transporterProfile) {
+      throw new NotFoundException(
+        'Transporter profile not found for the authenticated account.',
+      );
+    }
+
+    this.validateOperationalCapacity(input);
+
+    const createdTrailer = await this.trailerRepository.create(
+      transporterProfile.id,
+      input,
+    );
+
+    return this.toTrailerResponse(createdTrailer);
+  }
+
+  private validateOperationalCapacity(input: CreateTrailerInput): void {
+    if (!Number.isInteger(input.totalCapacity) || input.totalCapacity <= 0) {
+      throw new BadRequestException(
+        'Trailer total capacity must be a positive integer.',
+      );
+    }
+  }
+
+  private toTrailerResponse(trailer: TrailerRecord): TrailerResponseDto {
+    return {
+      id: trailer.id,
+      totalCapacity: trailer.totalCapacity,
+      cargoType: trailer.cargoType,
+      capacityUnit: trailer.capacityUnit,
+      isActive: trailer.isActive,
+    };
+  }
+}

--- a/apps/api/src/trailer/dto/create-trailer.dto.ts
+++ b/apps/api/src/trailer/dto/create-trailer.dto.ts
@@ -1,0 +1,3 @@
+import type { ICreateTrailerDto } from '@logistica/shared';
+
+export type CreateTrailerDto = ICreateTrailerDto;

--- a/apps/api/src/trailer/dto/trailer.response.dto.ts
+++ b/apps/api/src/trailer/dto/trailer.response.dto.ts
@@ -1,0 +1,3 @@
+import type { ITrailerView } from '@logistica/shared';
+
+export type TrailerResponseDto = ITrailerView;

--- a/apps/api/src/trailer/repositories/trailer.repository.ts
+++ b/apps/api/src/trailer/repositories/trailer.repository.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '@logistica/database';
+import type {
+  CreateTrailerInput,
+  TrailerRecord,
+  TransporterProfileOwnerRecord,
+} from '../types/trailer.types';
+import {
+  trailerSelect,
+  transporterProfileOwnerSelect,
+} from '../types/trailer.types';
+
+@Injectable()
+export class TrailerRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findTransporterProfileByAccountId(
+    accountId: string,
+  ): Promise<TransporterProfileOwnerRecord | null> {
+    return this.prisma.transporterProfile.findUnique({
+      where: { accountId },
+      select: transporterProfileOwnerSelect,
+    });
+  }
+
+  async create(
+    transporterProfileId: string,
+    input: CreateTrailerInput,
+  ): Promise<TrailerRecord> {
+    return this.prisma.trailer.create({
+      data: {
+        transporterProfile: {
+          connect: {
+            id: transporterProfileId,
+          },
+        },
+        totalCapacity: input.totalCapacity,
+        cargoType: input.cargoType,
+        capacityUnit: input.capacityUnit,
+      },
+      select: trailerSelect,
+    });
+  }
+}

--- a/apps/api/src/trailer/trailer.controller.spec.ts
+++ b/apps/api/src/trailer/trailer.controller.spec.ts
@@ -1,0 +1,167 @@
+import {
+  Injectable,
+  type ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
+import { RolesGuard } from '../identity/authentication/guards/roles.guard';
+import { TrailerService } from './application/trailer.service';
+import { TrailerController } from './trailer.controller';
+
+@Injectable()
+class TestJwtAuthGuard {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{
+      headers: Record<string, string | string[] | undefined>;
+      user?: { accountId: string; role: 'CLIENT' | 'TRANSPORTER' | 'ADMIN' };
+    }>();
+    const authorizationHeader = request.headers.authorization;
+
+    if (typeof authorizationHeader !== 'string') {
+      throw new UnauthorizedException();
+    }
+
+    const [, role] = authorizationHeader.split(' ');
+
+    if (role !== 'CLIENT' && role !== 'TRANSPORTER' && role !== 'ADMIN') {
+      throw new UnauthorizedException();
+    }
+
+    request.user = {
+      accountId: 'transporter-account-id',
+      role,
+    };
+
+    return true;
+  }
+}
+
+describe('TrailerController', () => {
+  const trailerService = {
+    createOwnTrailer: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  async function createApp() {
+    const moduleBuilder = Test.createTestingModule({
+      controllers: [TrailerController],
+      providers: [
+        RolesGuard,
+        {
+          provide: TrailerService,
+          useValue: trailerService,
+        },
+      ],
+    });
+
+    moduleBuilder.overrideGuard(JwtAuthGuard).useClass(TestJwtAuthGuard);
+
+    const moduleRef = await moduleBuilder.compile();
+    const app = moduleRef.createNestApplication();
+    await app.init();
+
+    return app;
+  }
+
+  it('creates a trailer for a transporter token', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    trailerService.createOwnTrailer.mockResolvedValue({
+      id: 'trailer-id',
+      totalCapacity: 12,
+      cargoType: 'EQUINE',
+      capacityUnit: 'SLOT',
+      isActive: true,
+    });
+
+    await request(server)
+      .post('/trailers')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      })
+      .expect(201)
+      .expect({
+        id: 'trailer-id',
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+        isActive: true,
+      });
+
+    expect(trailerService.createOwnTrailer).toHaveBeenCalledWith(
+      'transporter-account-id',
+      {
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      },
+    );
+
+    await app.close();
+  });
+
+  it('returns 400 when the payload is invalid', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trailers')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        totalCapacity: 0,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      })
+      .expect(400);
+
+    expect(trailerService.createOwnTrailer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 401 when the access token is missing', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trailers')
+      .send({
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      })
+      .expect(401);
+
+    expect(trailerService.createOwnTrailer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 403 when the authenticated role is not TRANSPORTER', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trailers')
+      .set('Authorization', 'Bearer CLIENT')
+      .send({
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      })
+      .expect(403);
+
+    expect(trailerService.createOwnTrailer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+});

--- a/apps/api/src/trailer/trailer.controller.ts
+++ b/apps/api/src/trailer/trailer.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { CreateTrailerSchema } from '@logistica/shared';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { Roles } from '../identity/authentication/decorators/roles.decorator';
+import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
+import { RolesGuard } from '../identity/authentication/guards/roles.guard';
+import type { AuthenticatedAccount } from '../identity/authentication/types/authentication.types';
+import { TrailerService } from './application/trailer.service';
+import type { CreateTrailerDto } from './dto/create-trailer.dto';
+import type { TrailerResponseDto } from './dto/trailer.response.dto';
+
+interface AuthenticatedHttpRequest {
+  user: AuthenticatedAccount;
+}
+
+@Controller('trailers')
+export class TrailerController {
+  constructor(private readonly trailerService: TrailerService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async createOwnTrailer(
+    @Req() request: AuthenticatedHttpRequest,
+    @Body(new ZodValidationPipe(CreateTrailerSchema))
+    createTrailerDto: CreateTrailerDto,
+  ): Promise<TrailerResponseDto> {
+    return this.trailerService.createOwnTrailer(
+      request.user.accountId,
+      createTrailerDto,
+    );
+  }
+}

--- a/apps/api/src/trailer/trailer.module.ts
+++ b/apps/api/src/trailer/trailer.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '@logistica/database';
+import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
+import { RolesGuard } from '../identity/authentication/guards/roles.guard';
+import { TrailerService } from './application/trailer.service';
+import { TrailerController } from './trailer.controller';
+import { TrailerRepository } from './repositories/trailer.repository';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [TrailerController],
+  providers: [TrailerService, TrailerRepository, JwtAuthGuard, RolesGuard],
+  exports: [TrailerService],
+})
+export class TrailerModule {}

--- a/apps/api/src/trailer/types/trailer.types.ts
+++ b/apps/api/src/trailer/types/trailer.types.ts
@@ -1,0 +1,23 @@
+import type { Prisma } from '@logistica/database';
+import type { ICreateTrailerDto } from '@logistica/shared';
+
+export const trailerSelect = {
+  id: true,
+  totalCapacity: true,
+  cargoType: true,
+  capacityUnit: true,
+  isActive: true,
+} satisfies Prisma.TrailerSelect;
+
+export const transporterProfileOwnerSelect = {
+  id: true,
+} satisfies Prisma.TransporterProfileSelect;
+
+export type CreateTrailerInput = ICreateTrailerDto;
+export type TrailerRecord = Prisma.TrailerGetPayload<{
+  select: typeof trailerSelect;
+}>;
+export type TransporterProfileOwnerRecord =
+  Prisma.TransporterProfileGetPayload<{
+    select: typeof transporterProfileOwnerSelect;
+  }>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './schemas/auth.schema';
+export * from './schemas/trailer.schema';
 export * from './schemas/transporter-profile.schema';
 export * from './schemas/vehicle.schema';
 export * from './interfaces/interfaces';

--- a/packages/shared/src/interfaces/interfaces.ts
+++ b/packages/shared/src/interfaces/interfaces.ts
@@ -1,19 +1,24 @@
-import { z } from "zod";
+import { z } from 'zod';
 import {
   LoginSchema,
   RegisterSchema,
   RegisterClientSchema,
   RegisterTransporterSchema,
-} from "../schemas/auth.schema";
+} from '../schemas/auth.schema';
 import {
   CreateVehicleSchema,
   UpdateVehicleSchema,
-} from "../schemas/vehicle.schema";
+} from '../schemas/vehicle.schema';
+import {
+  CapacityUnitSchema,
+  CargoTypeSchema,
+  CreateTrailerSchema,
+} from '../schemas/trailer.schema';
 
 const emailSchema = z.string().trim().email().max(320);
 const cuidSchema = z.string().cuid();
 
-export const AccountRoleSchema = z.enum(["CLIENT", "TRANSPORTER", "ADMIN"]);
+export const AccountRoleSchema = z.enum(['CLIENT', 'TRANSPORTER', 'ADMIN']);
 export type AccountRole = z.infer<typeof AccountRoleSchema>;
 
 export const RegisterClientDtoSchema = RegisterClientSchema;
@@ -47,10 +52,10 @@ export const UserProfileViewSchema = z.object({
 export type IUserProfileView = z.infer<typeof UserProfileViewSchema>;
 
 export const TransporterVerificationStatusSchema = z.enum([
-  "INCOMPLETE",
-  "PENDING",
-  "VERIFIED",
-  "REJECTED",
+  'INCOMPLETE',
+  'PENDING',
+  'VERIFIED',
+  'REJECTED',
 ]);
 export type ITransporterVerificationStatus = z.infer<
   typeof TransporterVerificationStatusSchema
@@ -77,6 +82,15 @@ export const VehicleViewSchema = z.object({
 });
 export type IVehicleView = z.infer<typeof VehicleViewSchema>;
 
+export const TrailerViewSchema = z.object({
+  id: cuidSchema,
+  totalCapacity: z.number().int().positive(),
+  cargoType: CargoTypeSchema,
+  capacityUnit: CapacityUnitSchema,
+  isActive: z.boolean(),
+});
+export type ITrailerView = z.infer<typeof TrailerViewSchema>;
+
 export type IUpdateTransporterProfileDto = {
   displayName?: string;
   businessName?: string | null;
@@ -90,6 +104,9 @@ export type ICreateVehicleDto = z.infer<typeof CreateVehicleDtoSchema>;
 
 export const UpdateVehicleDtoSchema = UpdateVehicleSchema;
 export type IUpdateVehicleDto = z.infer<typeof UpdateVehicleDtoSchema>;
+
+export const CreateTrailerDtoSchema = CreateTrailerSchema;
+export type ICreateTrailerDto = z.infer<typeof CreateTrailerDtoSchema>;
 
 export const AuthProfileViewSchema = z
   .union([UserProfileViewSchema, TransporterProfileViewSchema])

--- a/packages/shared/src/schemas/trailer.schema.ts
+++ b/packages/shared/src/schemas/trailer.schema.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const CargoTypeSchema = z.enum([
+  'EQUINE',
+  'GENERAL_CARGO',
+  'FOOD',
+  'PEOPLE',
+]);
+
+export const CapacityUnitSchema = z.enum(['SLOT', 'KG', 'M3', 'SEAT']);
+
+export const CreateTrailerSchema = z
+  .object({
+    totalCapacity: z
+      .number()
+      .int('La capacidad total debe ser un numero entero.')
+      .positive('La capacidad total debe ser mayor a cero.'),
+    cargoType: CargoTypeSchema,
+    capacityUnit: CapacityUnitSchema,
+  })
+  .strict();
+
+export type CreateTrailerDto = z.infer<typeof CreateTrailerSchema>;


### PR DESCRIPTION
## Summary

Closes #105
Lane: Backend E3
Branch: eature/105-e3-trailer-create
Issue: Implementar alta de trailer con capacidad operativa

## What Changed

- Added a new authenticated Trailer backend module with controller, service, repository, DTOs and typed Prisma selects.
- Persisted 	otalCapacity, cargoType and capacityUnit for the authenticated transporter's trailer creation flow.
- Added shared trailer schemas/types plus service and controller tests for happy path, auth/role checks and invalid capacity handling.

## Acceptance Criteria

- [x] Transportista puede crear un trailer
- [x] El trailer guarda totalCapacity, cargoType y capacityUnit
- [x] No se aceptan capacidades invalidas

## Validation

- pnpm --filter @logistica/shared build
- pnpm --filter @logistica/api exec eslint src/trailer src/app.module.ts
- pnpm --filter @logistica/api exec jest --config jest.config.cjs --runInBand src/trailer
- pnpm --filter @logistica/api exec tsc --noEmit -p tsconfig.json

## Risks

- Capacity consistency is currently enforced as a positive integer plus valid enum values; trailer-to-vehicle association rules remain for later issues.

## UI Evidence

- N/A (backend-only change)

## Notes For Review

- No auth, payments, roles, webhooks or anti-overbooking logic was changed.