### PR TITLE
feat(web): implement vehicle creation form

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { AdminModule } from './admin/admin.module';
 import { AccountsModule } from './identity/accounts/accounts.module';
 import { AuthenticationModule } from './identity/authentication/authentication.module';
 import { TransporterProfileModule } from './identity/transporter-profile/transporter-profile.module';
+import { TrailerModule } from './trailer/trailer.module';
 import { VehicleModule } from './vehicle/vehicle.module';
 
 @Module({
@@ -36,6 +37,7 @@ import { VehicleModule } from './vehicle/vehicle.module';
     AccountsModule,
     AuthenticationModule,
     TransporterProfileModule,
+    TrailerModule,
     VehicleModule,
   ],
   controllers: [],

--- a/apps/api/src/trailer/application/trailer.service.spec.ts
+++ b/apps/api/src/trailer/application/trailer.service.spec.ts
@@ -1,0 +1,85 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { TrailerService } from './trailer.service';
+
+describe('TrailerService', () => {
+  const trailerRepository = {
+    findTransporterProfileByAccountId: jest.fn(),
+    create: jest.fn(),
+  };
+
+  let trailerService: TrailerService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    trailerService = new TrailerService(trailerRepository as never);
+  });
+
+  it('creates a trailer for the authenticated transporter', async () => {
+    trailerRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+    trailerRepository.create.mockResolvedValue({
+      id: 'trailer-id',
+      totalCapacity: 12,
+      cargoType: 'EQUINE',
+      capacityUnit: 'SLOT',
+      isActive: true,
+    });
+
+    await expect(
+      trailerService.createOwnTrailer('account-id', {
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      }),
+    ).resolves.toEqual({
+      id: 'trailer-id',
+      totalCapacity: 12,
+      cargoType: 'EQUINE',
+      capacityUnit: 'SLOT',
+      isActive: true,
+    });
+
+    expect(
+      trailerRepository.findTransporterProfileByAccountId,
+    ).toHaveBeenCalledWith('account-id');
+    expect(trailerRepository.create).toHaveBeenCalledWith(
+      'transporter-profile-id',
+      {
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      },
+    );
+  });
+
+  it('throws when the authenticated account has no transporter profile', async () => {
+    trailerRepository.findTransporterProfileByAccountId.mockResolvedValue(null);
+
+    await expect(
+      trailerService.createOwnTrailer('missing-account', {
+        totalCapacity: 10,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      }),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(trailerRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when the provided capacity is not operationally valid', async () => {
+    trailerRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+
+    await expect(
+      trailerService.createOwnTrailer('account-id', {
+        totalCapacity: 0,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(trailerRepository.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/trailer/application/trailer.service.ts
+++ b/apps/api/src/trailer/application/trailer.service.ts
@@ -1,0 +1,54 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import type { TrailerResponseDto } from '../dto/trailer.response.dto';
+import { TrailerRepository } from '../repositories/trailer.repository';
+import type { CreateTrailerInput, TrailerRecord } from '../types/trailer.types';
+
+@Injectable()
+export class TrailerService {
+  constructor(private readonly trailerRepository: TrailerRepository) {}
+
+  async createOwnTrailer(
+    accountId: string,
+    input: CreateTrailerInput,
+  ): Promise<TrailerResponseDto> {
+    const transporterProfile =
+      await this.trailerRepository.findTransporterProfileByAccountId(accountId);
+
+    if (!transporterProfile) {
+      throw new NotFoundException(
+        'Transporter profile not found for the authenticated account.',
+      );
+    }
+
+    this.validateOperationalCapacity(input);
+
+    const createdTrailer = await this.trailerRepository.create(
+      transporterProfile.id,
+      input,
+    );
+
+    return this.toTrailerResponse(createdTrailer);
+  }
+
+  private validateOperationalCapacity(input: CreateTrailerInput): void {
+    if (!Number.isInteger(input.totalCapacity) || input.totalCapacity <= 0) {
+      throw new BadRequestException(
+        'Trailer total capacity must be a positive integer.',
+      );
+    }
+  }
+
+  private toTrailerResponse(trailer: TrailerRecord): TrailerResponseDto {
+    return {
+      id: trailer.id,
+      totalCapacity: trailer.totalCapacity,
+      cargoType: trailer.cargoType,
+      capacityUnit: trailer.capacityUnit,
+      isActive: trailer.isActive,
+    };
+  }
+}

--- a/apps/api/src/trailer/dto/create-trailer.dto.ts
+++ b/apps/api/src/trailer/dto/create-trailer.dto.ts
@@ -1,0 +1,3 @@
+import type { ICreateTrailerDto } from '@logistica/shared';
+
+export type CreateTrailerDto = ICreateTrailerDto;

--- a/apps/api/src/trailer/dto/trailer.response.dto.ts
+++ b/apps/api/src/trailer/dto/trailer.response.dto.ts
@@ -1,0 +1,3 @@
+import type { ITrailerView } from '@logistica/shared';
+
+export type TrailerResponseDto = ITrailerView;

--- a/apps/api/src/trailer/repositories/trailer.repository.ts
+++ b/apps/api/src/trailer/repositories/trailer.repository.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '@logistica/database';
+import type {
+  CreateTrailerInput,
+  TrailerRecord,
+  TransporterProfileOwnerRecord,
+} from '../types/trailer.types';
+import {
+  trailerSelect,
+  transporterProfileOwnerSelect,
+} from '../types/trailer.types';
+
+@Injectable()
+export class TrailerRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findTransporterProfileByAccountId(
+    accountId: string,
+  ): Promise<TransporterProfileOwnerRecord | null> {
+    return this.prisma.transporterProfile.findUnique({
+      where: { accountId },
+      select: transporterProfileOwnerSelect,
+    });
+  }
+
+  async create(
+    transporterProfileId: string,
+    input: CreateTrailerInput,
+  ): Promise<TrailerRecord> {
+    return this.prisma.trailer.create({
+      data: {
+        transporterProfile: {
+          connect: {
+            id: transporterProfileId,
+          },
+        },
+        totalCapacity: input.totalCapacity,
+        cargoType: input.cargoType,
+        capacityUnit: input.capacityUnit,
+      },
+      select: trailerSelect,
+    });
+  }
+}

--- a/apps/api/src/trailer/trailer.controller.spec.ts
+++ b/apps/api/src/trailer/trailer.controller.spec.ts
@@ -1,0 +1,167 @@
+import {
+  Injectable,
+  type ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
+import { RolesGuard } from '../identity/authentication/guards/roles.guard';
+import { TrailerService } from './application/trailer.service';
+import { TrailerController } from './trailer.controller';
+
+@Injectable()
+class TestJwtAuthGuard {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{
+      headers: Record<string, string | string[] | undefined>;
+      user?: { accountId: string; role: 'CLIENT' | 'TRANSPORTER' | 'ADMIN' };
+    }>();
+    const authorizationHeader = request.headers.authorization;
+
+    if (typeof authorizationHeader !== 'string') {
+      throw new UnauthorizedException();
+    }
+
+    const [, role] = authorizationHeader.split(' ');
+
+    if (role !== 'CLIENT' && role !== 'TRANSPORTER' && role !== 'ADMIN') {
+      throw new UnauthorizedException();
+    }
+
+    request.user = {
+      accountId: 'transporter-account-id',
+      role,
+    };
+
+    return true;
+  }
+}
+
+describe('TrailerController', () => {
+  const trailerService = {
+    createOwnTrailer: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  async function createApp() {
+    const moduleBuilder = Test.createTestingModule({
+      controllers: [TrailerController],
+      providers: [
+        RolesGuard,
+        {
+          provide: TrailerService,
+          useValue: trailerService,
+        },
+      ],
+    });
+
+    moduleBuilder.overrideGuard(JwtAuthGuard).useClass(TestJwtAuthGuard);
+
+    const moduleRef = await moduleBuilder.compile();
+    const app = moduleRef.createNestApplication();
+    await app.init();
+
+    return app;
+  }
+
+  it('creates a trailer for a transporter token', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    trailerService.createOwnTrailer.mockResolvedValue({
+      id: 'trailer-id',
+      totalCapacity: 12,
+      cargoType: 'EQUINE',
+      capacityUnit: 'SLOT',
+      isActive: true,
+    });
+
+    await request(server)
+      .post('/trailers')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      })
+      .expect(201)
+      .expect({
+        id: 'trailer-id',
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+        isActive: true,
+      });
+
+    expect(trailerService.createOwnTrailer).toHaveBeenCalledWith(
+      'transporter-account-id',
+      {
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      },
+    );
+
+    await app.close();
+  });
+
+  it('returns 400 when the payload is invalid', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trailers')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        totalCapacity: 0,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      })
+      .expect(400);
+
+    expect(trailerService.createOwnTrailer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 401 when the access token is missing', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trailers')
+      .send({
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      })
+      .expect(401);
+
+    expect(trailerService.createOwnTrailer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 403 when the authenticated role is not TRANSPORTER', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trailers')
+      .set('Authorization', 'Bearer CLIENT')
+      .send({
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+      })
+      .expect(403);
+
+    expect(trailerService.createOwnTrailer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+});

--- a/apps/api/src/trailer/trailer.controller.ts
+++ b/apps/api/src/trailer/trailer.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { CreateTrailerSchema } from '@logistica/shared';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { Roles } from '../identity/authentication/decorators/roles.decorator';
+import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
+import { RolesGuard } from '../identity/authentication/guards/roles.guard';
+import type { AuthenticatedAccount } from '../identity/authentication/types/authentication.types';
+import { TrailerService } from './application/trailer.service';
+import type { CreateTrailerDto } from './dto/create-trailer.dto';
+import type { TrailerResponseDto } from './dto/trailer.response.dto';
+
+interface AuthenticatedHttpRequest {
+  user: AuthenticatedAccount;
+}
+
+@Controller('trailers')
+export class TrailerController {
+  constructor(private readonly trailerService: TrailerService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async createOwnTrailer(
+    @Req() request: AuthenticatedHttpRequest,
+    @Body(new ZodValidationPipe(CreateTrailerSchema))
+    createTrailerDto: CreateTrailerDto,
+  ): Promise<TrailerResponseDto> {
+    return this.trailerService.createOwnTrailer(
+      request.user.accountId,
+      createTrailerDto,
+    );
+  }
+}

--- a/apps/api/src/trailer/trailer.module.ts
+++ b/apps/api/src/trailer/trailer.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '@logistica/database';
+import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
+import { RolesGuard } from '../identity/authentication/guards/roles.guard';
+import { TrailerService } from './application/trailer.service';
+import { TrailerController } from './trailer.controller';
+import { TrailerRepository } from './repositories/trailer.repository';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [TrailerController],
+  providers: [TrailerService, TrailerRepository, JwtAuthGuard, RolesGuard],
+  exports: [TrailerService],
+})
+export class TrailerModule {}

--- a/apps/api/src/trailer/types/trailer.types.ts
+++ b/apps/api/src/trailer/types/trailer.types.ts
@@ -1,0 +1,23 @@
+import type { Prisma } from '@logistica/database';
+import type { ICreateTrailerDto } from '@logistica/shared';
+
+export const trailerSelect = {
+  id: true,
+  totalCapacity: true,
+  cargoType: true,
+  capacityUnit: true,
+  isActive: true,
+} satisfies Prisma.TrailerSelect;
+
+export const transporterProfileOwnerSelect = {
+  id: true,
+} satisfies Prisma.TransporterProfileSelect;
+
+export type CreateTrailerInput = ICreateTrailerDto;
+export type TrailerRecord = Prisma.TrailerGetPayload<{
+  select: typeof trailerSelect;
+}>;
+export type TransporterProfileOwnerRecord =
+  Prisma.TransporterProfileGetPayload<{
+    select: typeof transporterProfileOwnerSelect;
+  }>;

--- a/apps/web/app/(protected)/vehicles/layout.tsx
+++ b/apps/web/app/(protected)/vehicles/layout.tsx
@@ -1,0 +1,15 @@
+import { AuthRouteGuard } from "@/features/auth/components/guards/auth-route-guard";
+
+type VehiclesLayoutProps = {
+  children: React.ReactNode;
+};
+
+const ALLOWED_TRANSPORTER_ROLES = ["TRANSPORTER"] as const;
+
+export default function VehiclesLayout({ children }: VehiclesLayoutProps) {
+  return (
+    <AuthRouteGuard allowedRoles={ALLOWED_TRANSPORTER_ROLES} mode="protected">
+      {children}
+    </AuthRouteGuard>
+  );
+}

--- a/apps/web/app/(protected)/vehicles/new/page.tsx
+++ b/apps/web/app/(protected)/vehicles/new/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/features/vehicle/pages/vehicle-create-page";

--- a/apps/web/features/dashboard/components/dashboard-navigation.test.tsx
+++ b/apps/web/features/dashboard/components/dashboard-navigation.test.tsx
@@ -39,4 +39,14 @@ describe("DashboardNavigation", () => {
 
     expect(push).toHaveBeenCalledWith("/onboarding/transporter");
   });
+
+  it("navigates to the vehicle creation route", async () => {
+    render(<DashboardNavigation />);
+
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /Registrar vehicle/i }));
+
+    expect(push).toHaveBeenCalledWith("/vehicles/new");
+  });
 });

--- a/apps/web/features/dashboard/components/dashboard-navigation.tsx
+++ b/apps/web/features/dashboard/components/dashboard-navigation.tsx
@@ -31,6 +31,15 @@ const DASHBOARD_DESTINATIONS: DashboardDestination[] = [
     title: "Abrir onboarding",
     variant: "ghost",
   },
+  {
+    description:
+      "Carga el vehicle inicial del transportista con feedback de validacion y respuesta real del backend E3.",
+    eyebrow: "Nuevo flujo E3",
+    href: "/vehicles/new",
+    meta: "Alta minima usable",
+    title: "Registrar vehicle",
+    variant: "ghost",
+  },
 ];
 
 export function DashboardNavigation() {
@@ -57,7 +66,7 @@ export function DashboardNavigation() {
         </p>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
         {DASHBOARD_DESTINATIONS.map(
           ({ description, eyebrow, href, meta, title, variant }) => (
           <Button

--- a/apps/web/features/vehicle/components/vehicle-form.test.tsx
+++ b/apps/web/features/vehicle/components/vehicle-form.test.tsx
@@ -1,0 +1,110 @@
+/** @jest-environment jsdom */
+
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useCreateVehicle } from "../hooks/use-create-vehicle";
+import type { Vehicle, VehicleFormValues } from "../types/vehicle.types";
+import { VehicleForm } from "./vehicle-form";
+
+jest.mock("../hooks/use-create-vehicle", () => ({
+  useCreateVehicle: jest.fn(),
+}));
+
+const mockedUseCreateVehicle = jest.mocked(useCreateVehicle);
+type CreateVehicleMock = (values: VehicleFormValues) => Promise<Vehicle | null>;
+
+describe("VehicleForm", () => {
+  beforeEach(() => {
+    mockedUseCreateVehicle.mockReset();
+  });
+
+  it("shows client validation feedback and keeps submit disabled for invalid values", async () => {
+    const createVehicle: jest.MockedFunction<CreateVehicleMock> = jest.fn(
+      async (_values: VehicleFormValues) => null,
+    );
+
+    mockedUseCreateVehicle.mockReturnValue({
+      createVehicle,
+      isSubmitting: false,
+      resetSubmitError: jest.fn(),
+      submitError: null,
+    });
+
+    render(<VehicleForm />);
+
+    const user = userEvent.setup();
+    const submitButton = screen.getByRole("button", { name: /Registrar vehicle/i });
+
+    expect(submitButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText("Patente"), "123");
+    await user.type(screen.getByLabelText("Marca"), "Scania");
+    await user.type(screen.getByLabelText("Modelo"), "R450");
+
+    await waitFor(() => {
+      expect(screen.getByText("Ingresa una patente valida.")).toBeInTheDocument();
+    });
+
+    expect(submitButton).toBeDisabled();
+    expect(createVehicle).not.toHaveBeenCalled();
+  });
+
+  it("submits valid values and shows the created vehicle feedback", async () => {
+    const createVehicle: jest.MockedFunction<CreateVehicleMock> = jest.fn(
+      async (_values: VehicleFormValues) => ({
+        brand: "Scania",
+        id: "cmavhcl110000wqz5oy7k8v01",
+        isActive: true,
+        licensePlate: "AA123BB",
+        model: "R450",
+      }),
+    );
+
+    mockedUseCreateVehicle.mockReturnValue({
+      createVehicle,
+      isSubmitting: false,
+      resetSubmitError: jest.fn(),
+      submitError: null,
+    });
+
+    render(<VehicleForm />);
+
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText("Patente"), "aa123bb");
+    await user.type(screen.getByLabelText("Marca"), "Scania");
+    await user.type(screen.getByLabelText("Modelo"), "R450");
+
+    await user.click(screen.getByRole("button", { name: /Registrar vehicle/i }));
+
+    await waitFor(() => {
+      expect(createVehicle).toHaveBeenCalledWith({
+        brand: "Scania",
+        licensePlate: "AA123BB",
+        model: "R450",
+      });
+    });
+
+    expect(
+      await screen.findByText(/Vehicle registrado correctamente: AA123BB - Scania R450./i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows loading feedback while the request is in flight", async () => {
+    const createVehicle: jest.MockedFunction<CreateVehicleMock> = jest.fn(
+      async (_values: VehicleFormValues) => null,
+    );
+
+    mockedUseCreateVehicle.mockReturnValue({
+      createVehicle,
+      isSubmitting: true,
+      resetSubmitError: jest.fn(),
+      submitError: null,
+    });
+
+    render(<VehicleForm />);
+
+    expect(screen.getByRole("button", { name: /Registrando/i })).toBeDisabled();
+  });
+});

--- a/apps/web/features/vehicle/components/vehicle-form.tsx
+++ b/apps/web/features/vehicle/components/vehicle-form.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CreateVehicleSchema } from "@logistica/shared";
+import { useForm } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useCreateVehicle } from "../hooks/use-create-vehicle";
+import type { Vehicle, VehicleFormValues } from "../types/vehicle.types";
+
+const DEFAULT_VALUES: VehicleFormValues = {
+  brand: "",
+  licensePlate: "",
+  model: "",
+};
+
+export function VehicleForm() {
+  const [createdVehicle, setCreatedVehicle] = useState<Vehicle | null>(null);
+  const {
+    formState: { errors, isDirty, isSubmitted, isValid },
+    handleSubmit,
+    register,
+    reset,
+  } = useForm<VehicleFormValues>({
+    defaultValues: DEFAULT_VALUES,
+    mode: "onChange",
+    resolver: zodResolver(CreateVehicleSchema),
+  });
+  const { createVehicle, isSubmitting, resetSubmitError, submitError } =
+    useCreateVehicle();
+
+  async function onSubmit(values: VehicleFormValues): Promise<void> {
+    setCreatedVehicle(null);
+    resetSubmitError();
+    const vehicle = await createVehicle(values);
+
+    if (!vehicle) {
+      return;
+    }
+
+    setCreatedVehicle(vehicle);
+    reset(DEFAULT_VALUES);
+  }
+
+  const licensePlateError =
+    isSubmitted || errors.licensePlate
+      ? errors.licensePlate?.message
+      : undefined;
+  const brandError =
+    isSubmitted || errors.brand ? errors.brand?.message : undefined;
+  const modelError =
+    isSubmitted || errors.model ? errors.model?.message : undefined;
+
+  return (
+    <Card className="border-white/75 bg-white/88 p-6 shadow-[0_18px_40px_rgba(21,40,33,0.08)] sm:p-8">
+      <CardHeader className="space-y-3">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.26em] text-muted">
+          Issue #110
+        </p>
+        <CardTitle>Registrar un vehicle operativo</CardTitle>
+        <CardDescription className="max-w-2xl text-base leading-7">
+          Esta alta minima te deja cargar un vehicle real contra el backend E3
+          ya disponible. La gestion completa de flota queda para la issue #109.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="mt-2">
+        <form className="space-y-6" noValidate onSubmit={handleSubmit(onSubmit)}>
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="space-y-2">
+              <label
+                className="text-[13px] font-semibold text-foreground/92"
+                htmlFor="licensePlate"
+              >
+                Patente
+              </label>
+              <Input
+                autoCapitalize="characters"
+                autoCorrect="off"
+                disabled={isSubmitting}
+                error={licensePlateError}
+                id="licensePlate"
+                maxLength={8}
+                placeholder="Ej: AA123BB"
+                {...register("licensePlate")}
+              />
+              <p className="text-sm leading-6 text-muted">
+                Se admiten entre 6 y 8 caracteres alfanumericos.
+              </p>
+              {licensePlateError ? (
+                <p className="text-sm text-destructive/90">{licensePlateError}</p>
+              ) : null}
+            </div>
+
+            <div className="space-y-2">
+              <label
+                className="text-[13px] font-semibold text-foreground/92"
+                htmlFor="brand"
+              >
+                Marca
+              </label>
+              <Input
+                autoComplete="organization"
+                disabled={isSubmitting}
+                error={brandError}
+                id="brand"
+                maxLength={80}
+                placeholder="Ej: Scania"
+                {...register("brand")}
+              />
+              {brandError ? (
+                <p className="text-sm text-destructive/90">{brandError}</p>
+              ) : null}
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <label
+                className="text-[13px] font-semibold text-foreground/92"
+                htmlFor="model"
+              >
+                Modelo
+              </label>
+              <Input
+                disabled={isSubmitting}
+                error={modelError}
+                id="model"
+                maxLength={80}
+                placeholder="Ej: R450"
+                {...register("model")}
+              />
+              {modelError ? (
+                <p className="text-sm text-destructive/90">{modelError}</p>
+              ) : null}
+            </div>
+          </div>
+
+          {submitError ? (
+            <div
+              aria-live="polite"
+              className="rounded-[1.4rem] border border-destructive/18 bg-[rgba(177,88,63,0.08)] px-4 py-3.5 text-sm leading-6 text-destructive"
+            >
+              {submitError}
+            </div>
+          ) : null}
+
+          {createdVehicle ? (
+            <div
+              aria-live="polite"
+              className="rounded-[1.4rem] border border-primary/20 bg-primary/5 px-4 py-3.5 text-sm leading-6 text-primary"
+            >
+              Vehicle registrado correctamente: {createdVehicle.licensePlate} -{" "}
+              {createdVehicle.brand} {createdVehicle.model}.
+            </div>
+          ) : null}
+
+          <Button
+            disabled={!isDirty || !isValid || isSubmitting}
+            isLoading={isSubmitting}
+            loadingText="Registrando"
+            type="submit"
+          >
+            Registrar vehicle
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/features/vehicle/hooks/use-create-vehicle.ts
+++ b/apps/web/features/vehicle/hooks/use-create-vehicle.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { ApiError, BadRequestError, ConflictError } from "@/src/lib/api";
+import { useFormSubmit } from "@/src/lib/forms/hooks/useFormSubmit";
+import { createVehicle } from "../services/create-vehicle-api";
+import type { Vehicle, VehicleFormValues } from "../types/vehicle.types";
+
+function getCreateVehicleErrorMessage(error: unknown): string {
+  if (error instanceof ConflictError) {
+    return "Ya existe un vehicle con esa patente. Revisa el dato e intenta de nuevo.";
+  }
+
+  if (error instanceof BadRequestError) {
+    return "Los datos del vehicle no son validos. Revisa los campos e intenta otra vez.";
+  }
+
+  if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+    return "Tu sesion no tiene acceso para registrar vehicles. Vuelve a ingresar e intenta otra vez.";
+  }
+
+  if (error instanceof ApiError && error.status >= 500) {
+    return "No pudimos registrar el vehicle por un problema del servidor. Intenta nuevamente en unos segundos.";
+  }
+
+  return "No pudimos registrar el vehicle. Vuelve a intentarlo.";
+}
+
+type UseCreateVehicleOptions = {
+  onSuccess?: (vehicle: Vehicle) => void;
+};
+
+export function useCreateVehicle({
+  onSuccess,
+}: UseCreateVehicleOptions = {}) {
+  const { isSubmitting, resetSubmitError, submit, submitError } = useFormSubmit(
+    async (values: VehicleFormValues) => {
+      const vehicle = await createVehicle(values);
+
+      onSuccess?.(vehicle);
+
+      return vehicle;
+    },
+    {
+      getErrorMessage: getCreateVehicleErrorMessage,
+    },
+  );
+
+  return {
+    createVehicle: submit,
+    isSubmitting,
+    resetSubmitError,
+    submitError,
+  };
+}

--- a/apps/web/features/vehicle/pages/vehicle-create-page.tsx
+++ b/apps/web/features/vehicle/pages/vehicle-create-page.tsx
@@ -1,0 +1,128 @@
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { VehicleForm } from "../components/vehicle-form";
+
+const setupHighlights = [
+  {
+    description:
+      "El contrato backend ya esta listo para crear un vehicle propio del transportista autenticado.",
+    title: "Integracion real con E3",
+  },
+  {
+    description:
+      "La vista resuelve solo el alta inicial. La seccion completa de flota queda para la issue #109.",
+    title: "Alcance acotado y usable",
+  },
+];
+
+export default function VehicleCreatePage() {
+  return (
+    <main className="relative min-h-screen overflow-hidden bg-[linear-gradient(180deg,#eef4ef_0%,#e7efe7_46%,#d9e4da_100%)] px-6 py-10">
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+        <div className="absolute left-[-4rem] top-[-5rem] size-[18rem] rounded-full bg-[#c7ddd6]/50 blur-3xl" />
+        <div className="absolute right-[-5rem] top-[7rem] size-[15rem] rounded-full bg-[#f0d3ad]/42 blur-3xl" />
+        <div className="absolute bottom-[-8rem] left-[22%] size-[16rem] rounded-full bg-[#dbe9d6]/55 blur-3xl" />
+      </div>
+
+      <div className="relative mx-auto w-full max-w-6xl space-y-6">
+        <section className="grid gap-6 xl:grid-cols-[1.08fr_0.92fr]">
+          <Card className="overflow-hidden border-white/35 bg-[linear-gradient(160deg,#153f31_0%,#102d24_46%,#0b1b16_100%)] p-8 text-primary-foreground shadow-[0_28px_60px_rgba(16,39,33,0.18)]">
+            <CardHeader className="space-y-5">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-foreground/88">
+                  Frontend E3
+                </span>
+                <span className="rounded-full border border-white/10 bg-[rgba(255,255,255,0.08)] px-4 py-2 text-sm font-semibold text-primary-foreground/88">
+                  Alta inicial de vehicle
+                </span>
+              </div>
+
+              <div className="space-y-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-primary-foreground/62">
+                  Area protegida del transportista
+                </p>
+                <h1 className="max-w-3xl font-heading text-4xl font-semibold leading-tight text-primary-foreground sm:text-[2.9rem]">
+                  Carga tu primer vehicle operativo
+                </h1>
+                <CardDescription className="max-w-2xl text-base leading-7 text-primary-foreground/76">
+                  Esta vista deja lista la alta del vehicle con feedback claro,
+                  validaciones coherentes con backend y una entrada simple desde
+                  el dashboard, sin meterse todavia en la gestion completa de
+                  flota.
+                </CardDescription>
+              </div>
+            </CardHeader>
+
+            <CardContent className="mt-8 grid gap-3 sm:grid-cols-2">
+              {setupHighlights.map((highlight) => (
+                <article
+                  className="rounded-[1.6rem] border border-white/10 bg-[rgba(10,26,22,0.52)] px-4 py-4"
+                  key={highlight.title}
+                >
+                  <h2 className="text-sm font-semibold text-primary-foreground">
+                    {highlight.title}
+                  </h2>
+                  <p className="mt-2 text-sm leading-6 text-primary-foreground/76">
+                    {highlight.description}
+                  </p>
+                </article>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card className="border-white/70 bg-white/84 p-7 shadow-[0_18px_40px_rgba(21,40,33,0.08)] backdrop-blur">
+            <CardHeader className="space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                Antes de guardar
+              </p>
+              <CardTitle className="text-[2rem]">
+                Verifica los datos minimos
+              </CardTitle>
+              <CardDescription className="text-base leading-7">
+                La patente debe ser unica y la marca/modelo se validan con el
+                mismo contrato compartido que usa el backend.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent className="space-y-4">
+              <div className="rounded-[1.5rem] border border-border/70 bg-panel/70 px-5 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                  Flujo incluido
+                </p>
+                <p className="mt-2 text-sm leading-6 text-foreground/78">
+                  Formulario, validaciones, loading, error, exito e integracion
+                  real con el endpoint protegido de vehicles.
+                </p>
+              </div>
+
+              <div className="rounded-[1.5rem] border border-primary/12 bg-primary/5 px-5 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-primary/70">
+                  Siguiente capa
+                </p>
+                <p className="mt-2 text-sm leading-6 text-foreground/78">
+                  Cuando la flota se expanda, la issue #109 sumara listados,
+                  acciones y contexto operativo alrededor de este primer alta.
+                </p>
+              </div>
+
+              <Link
+                className="inline-flex min-h-14 items-center justify-center rounded-[1.4rem] bg-primary/5 px-5 py-3 text-[15px] font-semibold text-foreground transition hover:bg-primary/8"
+                href="/dashboard"
+              >
+                Volver al dashboard
+              </Link>
+            </CardContent>
+          </Card>
+        </section>
+
+        <VehicleForm />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/features/vehicle/services/create-vehicle-api.test.ts
+++ b/apps/web/features/vehicle/services/create-vehicle-api.test.ts
@@ -1,0 +1,103 @@
+import { createVehicle } from "./create-vehicle-api";
+
+jest.mock("@/features/auth/services/session/access-token-store", () => ({
+  getAccessToken: jest.fn(),
+}));
+
+const { getAccessToken } = jest.requireMock(
+  "@/features/auth/services/session/access-token-store",
+) as {
+  getAccessToken: jest.Mock;
+};
+
+describe("createVehicle", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = "http://localhost:3001";
+    getAccessToken.mockReturnValue("access-token-value");
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+    delete process.env.NEXT_PUBLIC_API_URL;
+  });
+
+  it("posts the vehicle payload and returns the parsed response", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          brand: "Scania",
+          id: "cmavhcl110000wqz5oy7k8v01",
+          isActive: true,
+          licensePlate: "AA123BB",
+          model: "R450",
+        }),
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 201,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      createVehicle({
+        brand: "Scania",
+        licensePlate: "AA123BB",
+        model: "R450",
+      }),
+    ).resolves.toMatchObject({
+      id: "cmavhcl110000wqz5oy7k8v01",
+      licensePlate: "AA123BB",
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://localhost:3001/vehicles",
+      expect.objectContaining({
+        body: JSON.stringify({
+          brand: "Scania",
+          licensePlate: "AA123BB",
+          model: "R450",
+        }),
+        credentials: "include",
+        headers: expect.any(Headers),
+        method: "POST",
+      }),
+    );
+
+    const [, requestInit] = (global.fetch as jest.Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const headers = requestInit.headers as Headers;
+
+    expect(headers.get("Authorization")).toBe("Bearer access-token-value");
+  });
+
+  it("throws when the backend responds with an invalid vehicle payload", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          created: true,
+        }),
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 201,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      createVehicle({
+        brand: "Scania",
+        licensePlate: "AA123BB",
+        model: "R450",
+      }),
+    ).rejects.toThrow("payload invalido");
+  });
+});

--- a/apps/web/features/vehicle/services/create-vehicle-api.ts
+++ b/apps/web/features/vehicle/services/create-vehicle-api.ts
@@ -1,0 +1,35 @@
+import { type CreateVehicleDto } from "@logistica/shared";
+import { apiClient } from "@/src/lib/api";
+import { getAccessToken } from "@/features/auth/services/session/access-token-store";
+import { VehicleViewSchema, type Vehicle } from "../types/vehicle.types";
+
+const INVALID_CREATE_VEHICLE_RESPONSE_MESSAGE =
+  "La API respondio con un payload invalido para POST /vehicles.";
+
+function buildAuthorizationHeaders(
+  accessToken: string | null,
+): HeadersInit | undefined {
+  if (!accessToken) {
+    return undefined;
+  }
+
+  return {
+    Authorization: `Bearer ${accessToken}`,
+  };
+}
+
+export async function createVehicle(
+  dto: CreateVehicleDto,
+): Promise<Vehicle> {
+  const response = await apiClient.post<unknown>("/vehicles", {
+    body: dto,
+    headers: buildAuthorizationHeaders(getAccessToken()),
+  });
+  const parsed = VehicleViewSchema.safeParse(response.data);
+
+  if (!parsed.success) {
+    throw new Error(INVALID_CREATE_VEHICLE_RESPONSE_MESSAGE);
+  }
+
+  return parsed.data;
+}

--- a/apps/web/features/vehicle/types/vehicle.types.ts
+++ b/apps/web/features/vehicle/types/vehicle.types.ts
@@ -1,0 +1,10 @@
+import {
+  type CreateVehicleDto,
+  type IVehicleView,
+  VehicleViewSchema,
+} from "@logistica/shared";
+
+export type Vehicle = IVehicleView;
+export type VehicleFormValues = CreateVehicleDto;
+
+export { VehicleViewSchema };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './schemas/auth.schema';
+export * from './schemas/trailer.schema';
 export * from './schemas/transporter-profile.schema';
 export * from './schemas/vehicle.schema';
 export * from './interfaces/interfaces';

--- a/packages/shared/src/interfaces/interfaces.ts
+++ b/packages/shared/src/interfaces/interfaces.ts
@@ -1,19 +1,24 @@
-import { z } from "zod";
+import { z } from 'zod';
 import {
   LoginSchema,
   RegisterSchema,
   RegisterClientSchema,
   RegisterTransporterSchema,
-} from "../schemas/auth.schema";
+} from '../schemas/auth.schema';
 import {
   CreateVehicleSchema,
   UpdateVehicleSchema,
-} from "../schemas/vehicle.schema";
+} from '../schemas/vehicle.schema';
+import {
+  CapacityUnitSchema,
+  CargoTypeSchema,
+  CreateTrailerSchema,
+} from '../schemas/trailer.schema';
 
 const emailSchema = z.string().trim().email().max(320);
 const cuidSchema = z.string().cuid();
 
-export const AccountRoleSchema = z.enum(["CLIENT", "TRANSPORTER", "ADMIN"]);
+export const AccountRoleSchema = z.enum(['CLIENT', 'TRANSPORTER', 'ADMIN']);
 export type AccountRole = z.infer<typeof AccountRoleSchema>;
 
 export const RegisterClientDtoSchema = RegisterClientSchema;
@@ -47,10 +52,10 @@ export const UserProfileViewSchema = z.object({
 export type IUserProfileView = z.infer<typeof UserProfileViewSchema>;
 
 export const TransporterVerificationStatusSchema = z.enum([
-  "INCOMPLETE",
-  "PENDING",
-  "VERIFIED",
-  "REJECTED",
+  'INCOMPLETE',
+  'PENDING',
+  'VERIFIED',
+  'REJECTED',
 ]);
 export type ITransporterVerificationStatus = z.infer<
   typeof TransporterVerificationStatusSchema
@@ -77,6 +82,15 @@ export const VehicleViewSchema = z.object({
 });
 export type IVehicleView = z.infer<typeof VehicleViewSchema>;
 
+export const TrailerViewSchema = z.object({
+  id: cuidSchema,
+  totalCapacity: z.number().int().positive(),
+  cargoType: CargoTypeSchema,
+  capacityUnit: CapacityUnitSchema,
+  isActive: z.boolean(),
+});
+export type ITrailerView = z.infer<typeof TrailerViewSchema>;
+
 export type IUpdateTransporterProfileDto = {
   displayName?: string;
   businessName?: string | null;
@@ -90,6 +104,9 @@ export type ICreateVehicleDto = z.infer<typeof CreateVehicleDtoSchema>;
 
 export const UpdateVehicleDtoSchema = UpdateVehicleSchema;
 export type IUpdateVehicleDto = z.infer<typeof UpdateVehicleDtoSchema>;
+
+export const CreateTrailerDtoSchema = CreateTrailerSchema;
+export type ICreateTrailerDto = z.infer<typeof CreateTrailerDtoSchema>;
 
 export const AuthProfileViewSchema = z
   .union([UserProfileViewSchema, TransporterProfileViewSchema])

--- a/packages/shared/src/schemas/trailer.schema.ts
+++ b/packages/shared/src/schemas/trailer.schema.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const CargoTypeSchema = z.enum([
+  'EQUINE',
+  'GENERAL_CARGO',
+  'FOOD',
+  'PEOPLE',
+]);
+
+export const CapacityUnitSchema = z.enum(['SLOT', 'KG', 'M3', 'SEAT']);
+
+export const CreateTrailerSchema = z
+  .object({
+    totalCapacity: z
+      .number()
+      .int('La capacidad total debe ser un numero entero.')
+      .positive('La capacidad total debe ser mayor a cero.'),
+    cargoType: CargoTypeSchema,
+    capacityUnit: CapacityUnitSchema,
+  })
+  .strict();
+
+export type CreateTrailerDto = z.infer<typeof CreateTrailerSchema>;


### PR DESCRIPTION
## Summary

Closes #110
Lane: Frontend E3
Branch: `feature/110-e3-vehicle-form`
Issue: Implementar formulario de alta de vehicle

## What Changed

- Added a new protected transporter route at `/vehicles/new` with a dedicated E3 vehicle creation page.
- Implemented the vehicle form, creation service and submit hook using the shared schema and the real `POST /vehicles` contract.
- Exposed the entry point from the protected dashboard and added focused frontend tests for the new flow.

## Acceptance Criteria

- [x] Existe una ruta protegida minima para registrar un vehicle
- [x] El formulario usa validaciones coherentes con el backend actual
- [x] El usuario ve estados de loading, error y exito al crear el vehicle
- [x] La integracion se conecta al endpoint real POST /vehicles sin cambiar contratos

## Validation

- `cmd /c pnpm --filter @logistica/web test -- vehicle dashboard-navigation`
- `cmd /c pnpm --filter @logistica/web build`
- `cmd /c pnpm --filter @logistica/web typecheck` bloqueado por un error preexistente en `apps/web/tailwind.config.ts`: Cannot find module 'tailwindcss'

## Risks

- La gestion completa de flota sigue pendiente en la issue #109; esta vista solo cubre el alta inicial.
- No pude adjuntar screenshots desde este flujo automatizado.

## UI Evidence

- No pude adjuntar screenshots desde este flujo automatizado.

## Notes For Review

- La ruta nueva queda protegida para `TRANSPORTER` en `/vehicles/new`.
- El dashboard ahora expone una entrada minima hacia el formulario.