### PR TITLE
feat(trailer): support own trailer updates

### DIFF
--- a/apps/api/src/trailer/application/trailer.service.spec.ts
+++ b/apps/api/src/trailer/application/trailer.service.spec.ts
@@ -4,7 +4,9 @@ import { TrailerService } from './trailer.service';
 describe('TrailerService', () => {
   const trailerRepository = {
     findTransporterProfileByAccountId: jest.fn(),
+    findOwnedById: jest.fn(),
     create: jest.fn(),
+    updateById: jest.fn(),
   };
 
   let trailerService: TrailerService;
@@ -81,5 +83,107 @@ describe('TrailerService', () => {
     ).rejects.toThrow(BadRequestException);
 
     expect(trailerRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('updates an owned trailer', async () => {
+    trailerRepository.findOwnedById.mockResolvedValue({
+      id: 'trailer-id',
+      totalCapacity: 12,
+      cargoType: 'EQUINE',
+      capacityUnit: 'SLOT',
+      isActive: true,
+    });
+    trailerRepository.updateById.mockResolvedValue({
+      id: 'trailer-id',
+      totalCapacity: 16,
+      cargoType: 'GENERAL_CARGO',
+      capacityUnit: 'KG',
+      isActive: true,
+    });
+
+    await expect(
+      trailerService.updateOwnTrailer('account-id', 'trailer-id', {
+        totalCapacity: 16,
+        cargoType: 'GENERAL_CARGO',
+        capacityUnit: 'KG',
+      }),
+    ).resolves.toEqual({
+      id: 'trailer-id',
+      totalCapacity: 16,
+      cargoType: 'GENERAL_CARGO',
+      capacityUnit: 'KG',
+      isActive: true,
+    });
+
+    expect(trailerRepository.findOwnedById).toHaveBeenCalledWith(
+      'account-id',
+      'trailer-id',
+    );
+    expect(trailerRepository.updateById).toHaveBeenCalledWith('trailer-id', {
+      totalCapacity: 16,
+      cargoType: 'GENERAL_CARGO',
+      capacityUnit: 'KG',
+    });
+  });
+
+  it('throws when updating a trailer that is not owned by the account', async () => {
+    trailerRepository.findOwnedById.mockResolvedValue(null);
+
+    await expect(
+      trailerService.updateOwnTrailer('account-id', 'trailer-id', {
+        totalCapacity: 14,
+      }),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(trailerRepository.updateById).not.toHaveBeenCalled();
+  });
+
+  it('throws when updating a trailer with an invalid capacity', async () => {
+    trailerRepository.findOwnedById.mockResolvedValue({
+      id: 'trailer-id',
+      totalCapacity: 12,
+      cargoType: 'EQUINE',
+      capacityUnit: 'SLOT',
+      isActive: true,
+    });
+
+    await expect(
+      trailerService.updateOwnTrailer('account-id', 'trailer-id', {
+        totalCapacity: 0,
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(trailerRepository.updateById).not.toHaveBeenCalled();
+  });
+
+  it('deactivates an owned trailer without hard deleting it', async () => {
+    trailerRepository.findOwnedById.mockResolvedValue({
+      id: 'trailer-id',
+      totalCapacity: 12,
+      cargoType: 'EQUINE',
+      capacityUnit: 'SLOT',
+      isActive: true,
+    });
+    trailerRepository.updateById.mockResolvedValue({
+      id: 'trailer-id',
+      totalCapacity: 12,
+      cargoType: 'EQUINE',
+      capacityUnit: 'SLOT',
+      isActive: false,
+    });
+
+    await expect(
+      trailerService.deactivateOwnTrailer('account-id', 'trailer-id'),
+    ).resolves.toEqual({
+      id: 'trailer-id',
+      totalCapacity: 12,
+      cargoType: 'EQUINE',
+      capacityUnit: 'SLOT',
+      isActive: false,
+    });
+
+    expect(trailerRepository.updateById).toHaveBeenCalledWith('trailer-id', {
+      isActive: false,
+    });
   });
 });

--- a/apps/api/src/trailer/application/trailer.service.ts
+++ b/apps/api/src/trailer/application/trailer.service.ts
@@ -5,7 +5,11 @@ import {
 } from '@nestjs/common';
 import type { TrailerResponseDto } from '../dto/trailer.response.dto';
 import { TrailerRepository } from '../repositories/trailer.repository';
-import type { CreateTrailerInput, TrailerRecord } from '../types/trailer.types';
+import type {
+  CreateTrailerInput,
+  TrailerRecord,
+  UpdateTrailerInput,
+} from '../types/trailer.types';
 
 @Injectable()
 export class TrailerService {
@@ -34,7 +38,68 @@ export class TrailerService {
     return this.toTrailerResponse(createdTrailer);
   }
 
-  private validateOperationalCapacity(input: CreateTrailerInput): void {
+  async updateOwnTrailer(
+    accountId: string,
+    trailerId: string,
+    input: UpdateTrailerInput,
+  ): Promise<TrailerResponseDto> {
+    const existingTrailer = await this.trailerRepository.findOwnedById(
+      accountId,
+      trailerId,
+    );
+
+    if (!existingTrailer) {
+      throw new NotFoundException(
+        'Trailer not found for the authenticated account.',
+      );
+    }
+
+    this.validateOperationalCapacity(input);
+
+    const updatedTrailer = await this.trailerRepository.updateById(
+      trailerId,
+      input,
+    );
+
+    return this.toTrailerResponse(updatedTrailer);
+  }
+
+  async deactivateOwnTrailer(
+    accountId: string,
+    trailerId: string,
+  ): Promise<TrailerResponseDto> {
+    const existingTrailer = await this.trailerRepository.findOwnedById(
+      accountId,
+      trailerId,
+    );
+
+    if (!existingTrailer) {
+      throw new NotFoundException(
+        'Trailer not found for the authenticated account.',
+      );
+    }
+
+    if (!existingTrailer.isActive) {
+      return this.toTrailerResponse(existingTrailer);
+    }
+
+    const deactivatedTrailer = await this.trailerRepository.updateById(
+      trailerId,
+      {
+        isActive: false,
+      },
+    );
+
+    return this.toTrailerResponse(deactivatedTrailer);
+  }
+
+  private validateOperationalCapacity(
+    input: Pick<CreateTrailerInput, 'totalCapacity'> | UpdateTrailerInput,
+  ): void {
+    if (input.totalCapacity === undefined) {
+      return;
+    }
+
     if (!Number.isInteger(input.totalCapacity) || input.totalCapacity <= 0) {
       throw new BadRequestException(
         'Trailer total capacity must be a positive integer.',

--- a/apps/api/src/trailer/dto/update-trailer.dto.ts
+++ b/apps/api/src/trailer/dto/update-trailer.dto.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import type { IUpdateTrailerDto } from '@logistica/shared';
+
+export const TrailerParamsSchema = z.object({
+  id: z.string().cuid(),
+});
+
+export type TrailerParamsDto = z.infer<typeof TrailerParamsSchema>;
+export type UpdateTrailerDto = IUpdateTrailerDto;

--- a/apps/api/src/trailer/repositories/trailer.repository.ts
+++ b/apps/api/src/trailer/repositories/trailer.repository.ts
@@ -3,6 +3,7 @@ import { PrismaService } from '@logistica/database';
 import type {
   CreateTrailerInput,
   TrailerRecord,
+  TrailerUpdateData,
   TransporterProfileOwnerRecord,
 } from '../types/trailer.types';
 import {
@@ -38,6 +39,32 @@ export class TrailerRepository {
         cargoType: input.cargoType,
         capacityUnit: input.capacityUnit,
       },
+      select: trailerSelect,
+    });
+  }
+
+  async findOwnedById(
+    accountId: string,
+    trailerId: string,
+  ): Promise<TrailerRecord | null> {
+    return this.prisma.trailer.findFirst({
+      where: {
+        id: trailerId,
+        transporterProfile: {
+          accountId,
+        },
+      },
+      select: trailerSelect,
+    });
+  }
+
+  async updateById(
+    trailerId: string,
+    data: TrailerUpdateData,
+  ): Promise<TrailerRecord> {
+    return this.prisma.trailer.update({
+      where: { id: trailerId },
+      data,
       select: trailerSelect,
     });
   }

--- a/apps/api/src/trailer/trailer.controller.spec.ts
+++ b/apps/api/src/trailer/trailer.controller.spec.ts
@@ -1,6 +1,7 @@
 import {
   Injectable,
   type ExecutionContext,
+  NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
@@ -41,6 +42,8 @@ class TestJwtAuthGuard {
 describe('TrailerController', () => {
   const trailerService = {
     createOwnTrailer: jest.fn(),
+    updateOwnTrailer: jest.fn(),
+    deactivateOwnTrailer: jest.fn(),
   };
 
   beforeEach(() => {
@@ -161,6 +164,136 @@ describe('TrailerController', () => {
       .expect(403);
 
     expect(trailerService.createOwnTrailer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when updating with an invalid trailer id', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .patch('/trailers/trailer-id')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        totalCapacity: 16,
+      })
+      .expect(400);
+
+    expect(trailerService.updateOwnTrailer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('updates an owned trailer when the id is valid', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const trailerId = 'cm9trailer0000wqz5oy7k8ph1';
+
+    trailerService.updateOwnTrailer.mockResolvedValue({
+      id: trailerId,
+      totalCapacity: 16,
+      cargoType: 'GENERAL_CARGO',
+      capacityUnit: 'KG',
+      isActive: true,
+    });
+
+    await request(server)
+      .patch(`/trailers/${trailerId}`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        totalCapacity: 16,
+        cargoType: 'GENERAL_CARGO',
+        capacityUnit: 'KG',
+      })
+      .expect(200)
+      .expect({
+        id: trailerId,
+        totalCapacity: 16,
+        cargoType: 'GENERAL_CARGO',
+        capacityUnit: 'KG',
+        isActive: true,
+      });
+
+    expect(trailerService.updateOwnTrailer).toHaveBeenCalledWith(
+      'transporter-account-id',
+      trailerId,
+      {
+        totalCapacity: 16,
+        cargoType: 'GENERAL_CARGO',
+        capacityUnit: 'KG',
+      },
+    );
+
+    await app.close();
+  });
+
+  it('returns 404 when updating a trailer that is not owned by the account', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const trailerId = 'cm9trailer0000wqz5oy7k8ph1';
+
+    trailerService.updateOwnTrailer.mockRejectedValue(
+      new NotFoundException('Trailer not found for the authenticated account.'),
+    );
+
+    await request(server)
+      .patch(`/trailers/${trailerId}`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        totalCapacity: 16,
+      })
+      .expect(404);
+
+    await app.close();
+  });
+
+  it('deactivates an owned trailer for a transporter token', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const trailerId = 'cm9trailer0000wqz5oy7k8ph1';
+
+    trailerService.deactivateOwnTrailer.mockResolvedValue({
+      id: trailerId,
+      totalCapacity: 12,
+      cargoType: 'EQUINE',
+      capacityUnit: 'SLOT',
+      isActive: false,
+    });
+
+    await request(server)
+      .patch(`/trailers/${trailerId}/deactivate`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .expect(200)
+      .expect({
+        id: trailerId,
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+        isActive: false,
+      });
+
+    expect(trailerService.deactivateOwnTrailer).toHaveBeenCalledWith(
+      'transporter-account-id',
+      trailerId,
+    );
+
+    await app.close();
+  });
+
+  it('returns 404 when deactivating a trailer that is not owned by the account', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const trailerId = 'cm9trailer0000wqz5oy7k8ph1';
+
+    trailerService.deactivateOwnTrailer.mockRejectedValue(
+      new NotFoundException('Trailer not found for the authenticated account.'),
+    );
+
+    await request(server)
+      .patch(`/trailers/${trailerId}/deactivate`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .expect(404);
 
     await app.close();
   });

--- a/apps/api/src/trailer/trailer.controller.ts
+++ b/apps/api/src/trailer/trailer.controller.ts
@@ -1,5 +1,13 @@
-import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
-import { CreateTrailerSchema } from '@logistica/shared';
+import {
+  Body,
+  Controller,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { CreateTrailerSchema, UpdateTrailerSchema } from '@logistica/shared';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { Roles } from '../identity/authentication/decorators/roles.decorator';
 import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
@@ -7,6 +15,11 @@ import { RolesGuard } from '../identity/authentication/guards/roles.guard';
 import type { AuthenticatedAccount } from '../identity/authentication/types/authentication.types';
 import { TrailerService } from './application/trailer.service';
 import type { CreateTrailerDto } from './dto/create-trailer.dto';
+import type {
+  TrailerParamsDto,
+  UpdateTrailerDto,
+} from './dto/update-trailer.dto';
+import { TrailerParamsSchema } from './dto/update-trailer.dto';
 import type { TrailerResponseDto } from './dto/trailer.response.dto';
 
 interface AuthenticatedHttpRequest {
@@ -28,6 +41,37 @@ export class TrailerController {
     return this.trailerService.createOwnTrailer(
       request.user.accountId,
       createTrailerDto,
+    );
+  }
+
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async updateOwnTrailer(
+    @Req() request: AuthenticatedHttpRequest,
+    @Param(new ZodValidationPipe(TrailerParamsSchema))
+    params: TrailerParamsDto,
+    @Body(new ZodValidationPipe(UpdateTrailerSchema))
+    updateTrailerDto: UpdateTrailerDto,
+  ): Promise<TrailerResponseDto> {
+    return this.trailerService.updateOwnTrailer(
+      request.user.accountId,
+      params.id,
+      updateTrailerDto,
+    );
+  }
+
+  @Patch(':id/deactivate')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async deactivateOwnTrailer(
+    @Req() request: AuthenticatedHttpRequest,
+    @Param(new ZodValidationPipe(TrailerParamsSchema))
+    params: TrailerParamsDto,
+  ): Promise<TrailerResponseDto> {
+    return this.trailerService.deactivateOwnTrailer(
+      request.user.accountId,
+      params.id,
     );
   }
 }

--- a/apps/api/src/trailer/types/trailer.types.ts
+++ b/apps/api/src/trailer/types/trailer.types.ts
@@ -1,5 +1,5 @@
 import type { Prisma } from '@logistica/database';
-import type { ICreateTrailerDto } from '@logistica/shared';
+import type { ICreateTrailerDto, IUpdateTrailerDto } from '@logistica/shared';
 
 export const trailerSelect = {
   id: true,
@@ -14,6 +14,7 @@ export const transporterProfileOwnerSelect = {
 } satisfies Prisma.TransporterProfileSelect;
 
 export type CreateTrailerInput = ICreateTrailerDto;
+export type UpdateTrailerInput = IUpdateTrailerDto;
 export type TrailerRecord = Prisma.TrailerGetPayload<{
   select: typeof trailerSelect;
 }>;
@@ -21,3 +22,4 @@ export type TransporterProfileOwnerRecord =
   Prisma.TransporterProfileGetPayload<{
     select: typeof transporterProfileOwnerSelect;
   }>;
+export type TrailerUpdateData = Prisma.TrailerUpdateInput;

--- a/packages/shared/src/interfaces/interfaces.ts
+++ b/packages/shared/src/interfaces/interfaces.ts
@@ -13,6 +13,7 @@ import {
   CapacityUnitSchema,
   CargoTypeSchema,
   CreateTrailerSchema,
+  UpdateTrailerSchema,
 } from '../schemas/trailer.schema';
 
 const emailSchema = z.string().trim().email().max(320);
@@ -107,6 +108,9 @@ export type IUpdateVehicleDto = z.infer<typeof UpdateVehicleDtoSchema>;
 
 export const CreateTrailerDtoSchema = CreateTrailerSchema;
 export type ICreateTrailerDto = z.infer<typeof CreateTrailerDtoSchema>;
+
+export const UpdateTrailerDtoSchema = UpdateTrailerSchema;
+export type IUpdateTrailerDto = z.infer<typeof UpdateTrailerDtoSchema>;
 
 export const AuthProfileViewSchema = z
   .union([UserProfileViewSchema, TransporterProfileViewSchema])

--- a/packages/shared/src/schemas/trailer.schema.ts
+++ b/packages/shared/src/schemas/trailer.schema.ts
@@ -20,4 +20,20 @@ export const CreateTrailerSchema = z
   })
   .strict();
 
+export const UpdateTrailerSchema = z
+  .object({
+    totalCapacity: z
+      .number()
+      .int('La capacidad total debe ser un numero entero.')
+      .positive('La capacidad total debe ser mayor a cero.')
+      .optional(),
+    cargoType: CargoTypeSchema.optional(),
+    capacityUnit: CapacityUnitSchema.optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'Debes enviar al menos un campo para actualizar el trailer.',
+  });
+
 export type CreateTrailerDto = z.infer<typeof CreateTrailerSchema>;
+export type UpdateTrailerDto = z.infer<typeof UpdateTrailerSchema>;


### PR DESCRIPTION
## Summary

Closes #106
Lane: Backend E3
Branch: `feature/106-e3-trailer-update`
Issue: Implementar actualizacion y desactivacion de trailer

## What Changed

- Agrega `PATCH /trailers/:id` para actualizar trailers propios del transportista autenticado.
- Agrega `PATCH /trailers/:id/deactivate` para desactivar trailers sin hard delete.
- Extiende repository, service, controller y contratos Zod compartidos para validar ownership y capacidad.
- Cubre update/deactivate con tests unitarios del service y tests HTTP del controller.

## Acceptance Criteria

- [x] El transportista autenticado puede actualizar un trailer propio.
- [x] El transportista autenticado puede desactivar un trailer propio sin hard delete.
- [x] El endpoint rechaza trailers ajenos o inexistentes con 404.
- [x] El modulo deja tests de service y controller para update y deactivate.

## Validation

- pnpm --filter @logistica/shared build
- pnpm --filter @logistica/api exec eslint src/trailer src/app.module.ts
- pnpm --filter @logistica/api exec jest --config jest.config.cjs --runInBand src/trailer
- pnpm --filter @logistica/api exec tsc --noEmit -p tsconfig.json

## Risks

- No se agregaron endpoints de listado; la UI todavia depende de flujos posteriores para descubrir trailers existentes.

## UI Evidence

- No aplica.

## Notes For Review

- Se agrego `UpdateTrailerSchema` en `@logistica/shared` para mantener `ZodValidationPipe` consistente con el resto del modulo.
