### PR TITLE
feat(api): list authenticated transporter vehicles and trailers

### DIFF
--- a/apps/api/src/trailer/application/trailer.service.spec.ts
+++ b/apps/api/src/trailer/application/trailer.service.spec.ts
@@ -5,6 +5,7 @@ describe('TrailerService', () => {
   const trailerRepository = {
     findTransporterProfileByAccountId: jest.fn(),
     findOwnedById: jest.fn(),
+    findOwnedByAccountId: jest.fn(),
     create: jest.fn(),
     updateById: jest.fn(),
   };
@@ -14,6 +15,48 @@ describe('TrailerService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     trailerService = new TrailerService(trailerRepository as never);
+  });
+
+  it('lists the authenticated transporter trailers with active ones first', async () => {
+    trailerRepository.findOwnedByAccountId.mockResolvedValue([
+      {
+        id: 'trailer-active-id',
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+        isActive: true,
+      },
+      {
+        id: 'trailer-inactive-id',
+        totalCapacity: 16,
+        cargoType: 'GENERAL_CARGO',
+        capacityUnit: 'KG',
+        isActive: false,
+      },
+    ]);
+
+    await expect(trailerService.listOwnTrailers('account-id')).resolves.toEqual(
+      [
+        {
+          id: 'trailer-active-id',
+          totalCapacity: 12,
+          cargoType: 'EQUINE',
+          capacityUnit: 'SLOT',
+          isActive: true,
+        },
+        {
+          id: 'trailer-inactive-id',
+          totalCapacity: 16,
+          cargoType: 'GENERAL_CARGO',
+          capacityUnit: 'KG',
+          isActive: false,
+        },
+      ],
+    );
+
+    expect(trailerRepository.findOwnedByAccountId).toHaveBeenCalledWith(
+      'account-id',
+    );
   });
 
   it('creates a trailer for the authenticated transporter', async () => {

--- a/apps/api/src/trailer/application/trailer.service.ts
+++ b/apps/api/src/trailer/application/trailer.service.ts
@@ -15,6 +15,13 @@ import type {
 export class TrailerService {
   constructor(private readonly trailerRepository: TrailerRepository) {}
 
+  async listOwnTrailers(accountId: string): Promise<TrailerResponseDto[]> {
+    const trailers =
+      await this.trailerRepository.findOwnedByAccountId(accountId);
+
+    return trailers.map((trailer) => this.toTrailerResponse(trailer));
+  }
+
   async createOwnTrailer(
     accountId: string,
     input: CreateTrailerInput,

--- a/apps/api/src/trailer/repositories/trailer.repository.ts
+++ b/apps/api/src/trailer/repositories/trailer.repository.ts
@@ -58,6 +58,18 @@ export class TrailerRepository {
     });
   }
 
+  async findOwnedByAccountId(accountId: string): Promise<TrailerRecord[]> {
+    return this.prisma.trailer.findMany({
+      where: {
+        transporterProfile: {
+          accountId,
+        },
+      },
+      orderBy: [{ isActive: 'desc' }, { createdAt: 'desc' }],
+      select: trailerSelect,
+    });
+  }
+
   async updateById(
     trailerId: string,
     data: TrailerUpdateData,

--- a/apps/api/src/trailer/trailer.controller.spec.ts
+++ b/apps/api/src/trailer/trailer.controller.spec.ts
@@ -41,6 +41,7 @@ class TestJwtAuthGuard {
 
 describe('TrailerController', () => {
   const trailerService = {
+    listOwnTrailers: jest.fn(),
     createOwnTrailer: jest.fn(),
     updateOwnTrailer: jest.fn(),
     deactivateOwnTrailer: jest.fn(),
@@ -70,6 +71,55 @@ describe('TrailerController', () => {
 
     return app;
   }
+
+  it('lists the authenticated transporter trailers', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    trailerService.listOwnTrailers.mockResolvedValue([
+      {
+        id: 'trailer-active-id',
+        totalCapacity: 12,
+        cargoType: 'EQUINE',
+        capacityUnit: 'SLOT',
+        isActive: true,
+      },
+      {
+        id: 'trailer-inactive-id',
+        totalCapacity: 16,
+        cargoType: 'GENERAL_CARGO',
+        capacityUnit: 'KG',
+        isActive: false,
+      },
+    ]);
+
+    await request(server)
+      .get('/trailers')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .expect(200)
+      .expect([
+        {
+          id: 'trailer-active-id',
+          totalCapacity: 12,
+          cargoType: 'EQUINE',
+          capacityUnit: 'SLOT',
+          isActive: true,
+        },
+        {
+          id: 'trailer-inactive-id',
+          totalCapacity: 16,
+          cargoType: 'GENERAL_CARGO',
+          capacityUnit: 'KG',
+          isActive: false,
+        },
+      ]);
+
+    expect(trailerService.listOwnTrailers).toHaveBeenCalledWith(
+      'transporter-account-id',
+    );
+
+    await app.close();
+  });
 
   it('creates a trailer for a transporter token', async () => {
     const app = await createApp();

--- a/apps/api/src/trailer/trailer.controller.ts
+++ b/apps/api/src/trailer/trailer.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Get,
   Param,
   Patch,
   Post,
@@ -29,6 +30,15 @@ interface AuthenticatedHttpRequest {
 @Controller('trailers')
 export class TrailerController {
   constructor(private readonly trailerService: TrailerService) {}
+
+  @Get()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async listOwnTrailers(
+    @Req() request: AuthenticatedHttpRequest,
+  ): Promise<TrailerResponseDto[]> {
+    return this.trailerService.listOwnTrailers(request.user.accountId);
+  }
 
   @Post()
   @UseGuards(JwtAuthGuard, RolesGuard)

--- a/apps/api/src/vehicle/application/vehicle.service.spec.ts
+++ b/apps/api/src/vehicle/application/vehicle.service.spec.ts
@@ -7,6 +7,7 @@ describe('VehicleService', () => {
     findTransporterProfileByAccountId: jest.fn(),
     findByLicensePlate: jest.fn(),
     findOwnedById: jest.fn(),
+    findOwnedByAccountId: jest.fn(),
     create: jest.fn(),
     updateById: jest.fn(),
   };
@@ -16,6 +17,48 @@ describe('VehicleService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     vehicleService = new VehicleService(vehicleRepository as never);
+  });
+
+  it('lists the authenticated transporter vehicles with active ones first', async () => {
+    vehicleRepository.findOwnedByAccountId.mockResolvedValue([
+      {
+        id: 'vehicle-active-id',
+        licensePlate: 'AB123CD',
+        brand: 'Scania',
+        model: 'R450',
+        isActive: true,
+      },
+      {
+        id: 'vehicle-inactive-id',
+        licensePlate: 'EF456GH',
+        brand: 'Volvo',
+        model: 'FH',
+        isActive: false,
+      },
+    ]);
+
+    await expect(vehicleService.listOwnVehicles('account-id')).resolves.toEqual(
+      [
+        {
+          id: 'vehicle-active-id',
+          licensePlate: 'AB123CD',
+          brand: 'Scania',
+          model: 'R450',
+          isActive: true,
+        },
+        {
+          id: 'vehicle-inactive-id',
+          licensePlate: 'EF456GH',
+          brand: 'Volvo',
+          model: 'FH',
+          isActive: false,
+        },
+      ],
+    );
+
+    expect(vehicleRepository.findOwnedByAccountId).toHaveBeenCalledWith(
+      'account-id',
+    );
   });
 
   it('creates a vehicle for the authenticated transporter', async () => {

--- a/apps/api/src/vehicle/application/vehicle.service.ts
+++ b/apps/api/src/vehicle/application/vehicle.service.ts
@@ -17,6 +17,13 @@ import type {
 export class VehicleService {
   constructor(private readonly vehicleRepository: VehicleRepository) {}
 
+  async listOwnVehicles(accountId: string): Promise<VehicleResponseDto[]> {
+    const vehicles =
+      await this.vehicleRepository.findOwnedByAccountId(accountId);
+
+    return vehicles.map((vehicle) => this.toVehicleResponse(vehicle));
+  }
+
   async createOwnVehicle(
     accountId: string,
     input: CreateVehicleInput,

--- a/apps/api/src/vehicle/repositories/vehicle.repository.ts
+++ b/apps/api/src/vehicle/repositories/vehicle.repository.ts
@@ -48,6 +48,18 @@ export class VehicleRepository {
     });
   }
 
+  async findOwnedByAccountId(accountId: string): Promise<VehicleRecord[]> {
+    return this.prisma.vehicle.findMany({
+      where: {
+        transporterProfile: {
+          accountId,
+        },
+      },
+      orderBy: [{ isActive: 'desc' }, { createdAt: 'desc' }],
+      select: vehicleSelect,
+    });
+  }
+
   async create(
     transporterProfileId: string,
     input: CreateVehicleInput,

--- a/apps/api/src/vehicle/vehicle.controller.spec.ts
+++ b/apps/api/src/vehicle/vehicle.controller.spec.ts
@@ -42,6 +42,7 @@ class TestJwtAuthGuard {
 
 describe('VehicleController', () => {
   const vehicleService = {
+    listOwnVehicles: jest.fn(),
     createOwnVehicle: jest.fn(),
     updateOwnVehicle: jest.fn(),
     deactivateOwnVehicle: jest.fn(),
@@ -71,6 +72,55 @@ describe('VehicleController', () => {
 
     return app;
   }
+
+  it('lists the authenticated transporter vehicles', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    vehicleService.listOwnVehicles.mockResolvedValue([
+      {
+        id: 'vehicle-active-id',
+        licensePlate: 'AB123CD',
+        brand: 'Scania',
+        model: 'R450',
+        isActive: true,
+      },
+      {
+        id: 'vehicle-inactive-id',
+        licensePlate: 'EF456GH',
+        brand: 'Volvo',
+        model: 'FH',
+        isActive: false,
+      },
+    ]);
+
+    await request(server)
+      .get('/vehicles')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .expect(200)
+      .expect([
+        {
+          id: 'vehicle-active-id',
+          licensePlate: 'AB123CD',
+          brand: 'Scania',
+          model: 'R450',
+          isActive: true,
+        },
+        {
+          id: 'vehicle-inactive-id',
+          licensePlate: 'EF456GH',
+          brand: 'Volvo',
+          model: 'FH',
+          isActive: false,
+        },
+      ]);
+
+    expect(vehicleService.listOwnVehicles).toHaveBeenCalledWith(
+      'transporter-account-id',
+    );
+
+    await app.close();
+  });
 
   it('creates a vehicle for a transporter token', async () => {
     const app = await createApp();

--- a/apps/api/src/vehicle/vehicle.controller.ts
+++ b/apps/api/src/vehicle/vehicle.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Get,
   Param,
   Patch,
   Post,
@@ -29,6 +30,15 @@ interface AuthenticatedHttpRequest {
 @Controller('vehicles')
 export class VehicleController {
   constructor(private readonly vehicleService: VehicleService) {}
+
+  @Get()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async listOwnVehicles(
+    @Req() request: AuthenticatedHttpRequest,
+  ): Promise<VehicleResponseDto[]> {
+    return this.vehicleService.listOwnVehicles(request.user.accountId);
+  }
 
   @Post()
   @UseGuards(JwtAuthGuard, RolesGuard)


### PR DESCRIPTION
## Contexto
Resuelve la issue #107 de E3-BE para exponer los listados autenticados de flota del transportista.

## Alcance
- agrega `GET /vehicles` para listar los vehicles del transportista autenticado
- agrega `GET /trailers` para listar los trailers del transportista autenticado
- ordena ambos listados priorizando recursos activos
- suma tests de service y controller para ambos endpoints

## Riesgos
- cambio acotado a los modulos `vehicle` y `trailer`
- no toca auth, pagos ni logica transaccional critica
- el criterio secundario de orden usa `createdAt desc` para mantener estabilidad dentro de activos/inactivos

## Como testear
- autenticar como `TRANSPORTER`
- llamar `GET /vehicles` y verificar que devuelve solo resources propios con activos primero
- llamar `GET /trailers` y verificar que devuelve solo resources propios con activos primero
- correr `pnpm --filter @logistica/api lint`
- correr `pnpm --filter @logistica/api typecheck`
- correr `pnpm --filter @logistica/api exec jest --config jest.config.cjs --runInBand`

## Validacion realizada
- `pnpm --filter @logistica/api lint`
- `pnpm --filter @logistica/api typecheck`
- `pnpm --filter @logistica/api exec jest --config jest.config.cjs --runInBand`

Closes #107