### PR TITLE
feat(api): add reusable active trailer criterion

### DIFF
--- a/apps/api/src/trailer/application/trailer.service.spec.ts
+++ b/apps/api/src/trailer/application/trailer.service.spec.ts
@@ -6,6 +6,7 @@ describe('TrailerService', () => {
     findTransporterProfileByAccountId: jest.fn(),
     findOwnedById: jest.fn(),
     findOwnedByAccountId: jest.fn(),
+    hasActiveTrailer: jest.fn(),
     create: jest.fn(),
     updateById: jest.fn(),
   };
@@ -55,6 +56,30 @@ describe('TrailerService', () => {
     );
 
     expect(trailerRepository.findOwnedByAccountId).toHaveBeenCalledWith(
+      'account-id',
+    );
+  });
+
+  it('returns whether the authenticated transporter has at least one active trailer', async () => {
+    trailerRepository.hasActiveTrailer.mockResolvedValue(true);
+
+    await expect(trailerService.hasActiveTrailer('account-id')).resolves.toBe(
+      true,
+    );
+
+    expect(trailerRepository.hasActiveTrailer).toHaveBeenCalledWith(
+      'account-id',
+    );
+  });
+
+  it('returns false when the authenticated transporter has no active trailer', async () => {
+    trailerRepository.hasActiveTrailer.mockResolvedValue(false);
+
+    await expect(trailerService.hasActiveTrailer('account-id')).resolves.toBe(
+      false,
+    );
+
+    expect(trailerRepository.hasActiveTrailer).toHaveBeenCalledWith(
       'account-id',
     );
   });

--- a/apps/api/src/trailer/application/trailer.service.ts
+++ b/apps/api/src/trailer/application/trailer.service.ts
@@ -22,6 +22,14 @@ export class TrailerService {
     return trailers.map((trailer) => this.toTrailerResponse(trailer));
   }
 
+  /**
+   * Reusable E4-facing criterion: tells whether the transporter owns at least
+   * one active trailer without materializing the trailer list.
+   */
+  async hasActiveTrailer(accountId: string): Promise<boolean> {
+    return this.trailerRepository.hasActiveTrailer(accountId);
+  }
+
   async createOwnTrailer(
     accountId: string,
     input: CreateTrailerInput,

--- a/apps/api/src/trailer/repositories/trailer.repository.ts
+++ b/apps/api/src/trailer/repositories/trailer.repository.ts
@@ -70,6 +70,22 @@ export class TrailerRepository {
     });
   }
 
+  async hasActiveTrailer(accountId: string): Promise<boolean> {
+    const activeTrailer = await this.prisma.trailer.findFirst({
+      where: {
+        isActive: true,
+        transporterProfile: {
+          accountId,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    return activeTrailer !== null;
+  }
+
   async updateById(
     trailerId: string,
     data: TrailerUpdateData,

--- a/docs/api.md
+++ b/docs/api.md
@@ -304,12 +304,76 @@ Mismo shape que `GET /admin/transporters/:id`.
 
 ---
 
+## Flota E3
+
+Todos los endpoints de esta seccion requieren:
+
+- bearer token valido
+- rol `TRANSPORTER`
+
+### `GET /vehicles`
+
+Lista los vehicles del transportista autenticado.
+
+**Respuesta 200**
+
+```json
+[
+  {
+    "id": "string",
+    "licensePlate": "string",
+    "brand": "string",
+    "model": "string",
+    "isActive": true
+  }
+]
+```
+
+Reglas actuales:
+
+- devuelve solo resources propios de la cuenta autenticada
+- ordena activos primero
+
+---
+
+### `GET /trailers`
+
+Lista los trailers del transportista autenticado.
+
+**Respuesta 200**
+
+```json
+[
+  {
+    "id": "string",
+    "totalCapacity": 12,
+    "cargoType": "EQUINE | GENERAL_CARGO | FOOD | PEOPLE",
+    "capacityUnit": "SLOT | KG | M3 | SEAT",
+    "isActive": true
+  }
+]
+```
+
+Reglas actuales:
+
+- devuelve solo resources propios de la cuenta autenticada
+- ordena activos primero
+
+### Contrato interno previsto para E4
+
+`TrailerService.hasActiveTrailer(accountId: string): Promise<boolean>`
+
+Uso esperado:
+
+- validar si el transportista tiene al menos un trailer activo antes de publicar una `TripOffer`
+- reutilizar el criterio desde futuros modulos sin duplicar queries ni materializar el listado completo
+
+---
+
 ## Fuera de alcance por ahora
 
 Todavia no existen en la API:
 
 - endpoints de documentos de transportista
 - `verificationNote`
-- endpoints de `Vehicle`
-- endpoints de `Trailer`
 - endpoints de `TripOffer`


### PR DESCRIPTION
## Contexto
Resuelve la issue #108 de E3-BE para dejar un criterio reutilizable de trailer activo de cara a E4, sin depender todavia de `TripOffer`.

## Alcance
- agrega `TrailerService.hasActiveTrailer(accountId)` como contrato reutilizable
- agrega `TrailerRepository.hasActiveTrailer(accountId)` con query de existencia
- evita materializar el listado completo de trailers para esta validacion
- documenta en `docs/api.md` el contrato interno previsto para E4 y actualiza la seccion de flota E3
- suma tests unitarios para los caminos `true` y `false`

## Riesgos
- cambio acotado al modulo `trailer` y documentacion
- no toca auth, pagos, webhooks ni logica transaccional critica
- el metodo queda exportado via `TrailerModule` al reutilizar `TrailerService`

## Como testear
- correr `pnpm --filter @logistica/api lint`
- correr `pnpm --filter @logistica/api typecheck`
- correr `node apps/api/node_modules/jest/bin/jest.js --config apps/api/jest.config.cjs --runInBand apps/api/src/trailer/application/trailer.service.spec.ts`

## Validacion realizada
- `pnpm --filter @logistica/api lint`
- `pnpm --filter @logistica/api typecheck`
- `node apps/api/node_modules/jest/bin/jest.js --config apps/api/jest.config.cjs --runInBand apps/api/src/trailer/application/trailer.service.spec.ts`

Closes #108