### PR TITLE
feat(web): add transporter fleet hub

### DIFF
--- a/apps/web/app/(protected)/vehicles/page.tsx
+++ b/apps/web/app/(protected)/vehicles/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/features/vehicle/pages/vehicle-fleet-page';

--- a/apps/web/features/dashboard/components/dashboard-navigation.test.tsx
+++ b/apps/web/features/dashboard/components/dashboard-navigation.test.tsx
@@ -1,52 +1,64 @@
 /** @jest-environment jsdom */
 
-import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { DashboardNavigation } from "./dashboard-navigation";
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DashboardNavigation } from './dashboard-navigation';
 
 const push = jest.fn();
 
-jest.mock("next/navigation", () => ({
+jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push,
   }),
 }));
 
-describe("DashboardNavigation", () => {
+describe('DashboardNavigation', () => {
   beforeEach(() => {
     push.mockReset();
   });
 
-  it("navigates to the dashboard route", async () => {
+  it('navigates to the dashboard route', async () => {
     render(<DashboardNavigation />);
 
     const user = userEvent.setup();
 
     await user.click(
-      screen.getByRole("button", { name: /Ver panel del transportista/i }),
+      screen.getByRole('button', { name: /Ver panel del transportista/i }),
     );
 
-    expect(push).toHaveBeenCalledWith("/dashboard");
+    expect(push).toHaveBeenCalledWith('/dashboard');
   });
 
-  it("navigates to the transporter onboarding route", async () => {
+  it('navigates to the transporter onboarding route', async () => {
     render(<DashboardNavigation />);
 
     const user = userEvent.setup();
 
-    await user.click(screen.getByRole("button", { name: /Abrir onboarding/i }));
+    await user.click(screen.getByRole('button', { name: /Abrir onboarding/i }));
 
-    expect(push).toHaveBeenCalledWith("/onboarding/transporter");
+    expect(push).toHaveBeenCalledWith('/onboarding/transporter');
   });
 
-  it("navigates to the vehicle creation route", async () => {
+  it('navigates to the fleet hub route', async () => {
     render(<DashboardNavigation />);
 
     const user = userEvent.setup();
 
-    await user.click(screen.getByRole("button", { name: /Registrar vehicle/i }));
+    await user.click(screen.getByRole('button', { name: /Gestionar flota/i }));
 
-    expect(push).toHaveBeenCalledWith("/vehicles/new");
+    expect(push).toHaveBeenCalledWith('/vehicles');
+  });
+
+  it('navigates to the vehicle creation route', async () => {
+    render(<DashboardNavigation />);
+
+    const user = userEvent.setup();
+
+    await user.click(
+      screen.getByRole('button', { name: /Registrar vehicle/i }),
+    );
+
+    expect(push).toHaveBeenCalledWith('/vehicles/new');
   });
 });

--- a/apps/web/features/dashboard/components/dashboard-navigation.tsx
+++ b/apps/web/features/dashboard/components/dashboard-navigation.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { startTransition } from "react";
-import { useRouter } from "next/navigation";
-import { Button } from "@/components/ui/button";
+import { startTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
 
 type DashboardDestination = {
   eyebrow: string;
@@ -10,35 +10,44 @@ type DashboardDestination = {
   href: string;
   meta: string;
   title: string;
-  variant?: "ghost" | "primary";
+  variant?: 'ghost' | 'primary';
 };
 
 const DASHBOARD_DESTINATIONS: DashboardDestination[] = [
   {
     description:
-      "Consulta el resumen del estado actual, la hoja de ruta del area privada y los accesos mas usados.",
-    eyebrow: "Panel actual",
-    href: "/dashboard",
-    meta: "Ruta principal protegida",
-    title: "Ver panel del transportista",
+      'Consulta el resumen del estado actual, la hoja de ruta del area privada y los accesos mas usados.',
+    eyebrow: 'Panel actual',
+    href: '/dashboard',
+    meta: 'Ruta principal protegida',
+    title: 'Ver panel del transportista',
   },
   {
     description:
-      "Segui con la carga y revision del perfil transportista sin salir del flujo protegido actual.",
-    eyebrow: "Siguiente paso",
-    href: "/onboarding/transporter",
-    meta: "Continua donde lo dejaste",
-    title: "Abrir onboarding",
-    variant: "ghost",
+      'Abre la seccion de flota para ver vehicles y trailers separados desde el backend real.',
+    eyebrow: 'Flota',
+    href: '/vehicles',
+    meta: 'Hub operativo de vehiculos',
+    title: 'Gestionar flota',
+    variant: 'ghost',
   },
   {
     description:
-      "Carga el vehicle inicial del transportista con feedback de validacion y respuesta real del backend E3.",
-    eyebrow: "Nuevo flujo E3",
-    href: "/vehicles/new",
-    meta: "Alta minima usable",
-    title: "Registrar vehicle",
-    variant: "ghost",
+      'Segui con la carga y revision del perfil transportista sin salir del flujo protegido actual.',
+    eyebrow: 'Siguiente paso',
+    href: '/onboarding/transporter',
+    meta: 'Continua donde lo dejaste',
+    title: 'Abrir onboarding',
+    variant: 'ghost',
+  },
+  {
+    description:
+      'Carga el vehicle inicial del transportista con feedback de validacion y respuesta real del backend E3.',
+    eyebrow: 'Nuevo flujo E3',
+    href: '/vehicles/new',
+    meta: 'Alta minima usable',
+    title: 'Registrar vehicle',
+    variant: 'ghost',
   },
 ];
 
@@ -52,7 +61,10 @@ export function DashboardNavigation() {
   }
 
   return (
-    <section aria-labelledby="dashboard-navigation-title" className="mt-8 space-y-4">
+    <section
+      aria-labelledby="dashboard-navigation-title"
+      className="mt-8 space-y-4"
+    >
       <div className="space-y-2">
         <h2
           className="text-lg font-semibold text-foreground"
@@ -69,27 +81,29 @@ export function DashboardNavigation() {
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
         {DASHBOARD_DESTINATIONS.map(
           ({ description, eyebrow, href, meta, title, variant }) => (
-          <Button
-            className="h-auto min-h-[11rem] flex-col items-start justify-between rounded-[1.8rem] px-5 py-5 text-left"
-            key={href}
-            onClick={() => handleNavigation(href)}
-            type="button"
-            variant={variant}
-          >
-            <div className="space-y-3">
-              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-current/70">
-                {eyebrow}
-              </span>
-              <span className="block text-lg font-semibold leading-7">{title}</span>
-              <span className="block text-sm font-normal leading-6 text-current/80">
-                {description}
-              </span>
-            </div>
+            <Button
+              className="h-auto min-h-[11rem] flex-col items-start justify-between rounded-[1.8rem] px-5 py-5 text-left"
+              key={href}
+              onClick={() => handleNavigation(href)}
+              type="button"
+              variant={variant}
+            >
+              <div className="space-y-3">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-current/70">
+                  {eyebrow}
+                </span>
+                <span className="block text-lg font-semibold leading-7">
+                  {title}
+                </span>
+                <span className="block text-sm font-normal leading-6 text-current/80">
+                  {description}
+                </span>
+              </div>
 
-            <span className="inline-flex rounded-full border border-current/15 bg-black/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-current/80">
-              {meta}
-            </span>
-          </Button>
+              <span className="inline-flex rounded-full border border-current/15 bg-black/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-current/80">
+                {meta}
+              </span>
+            </Button>
           ),
         )}
       </div>

--- a/apps/web/features/dashboard/pages/dashboard-page.test.tsx
+++ b/apps/web/features/dashboard/pages/dashboard-page.test.tsx
@@ -1,27 +1,34 @@
 /** @jest-environment jsdom */
 
-import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
-import DashboardPageView from "./dashboard-page";
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import DashboardPageView from './dashboard-page';
 
-jest.mock("../components/dashboard-navigation", () => ({
+jest.mock('../components/dashboard-navigation', () => ({
   DashboardNavigation: () => <div>Mock dashboard navigation</div>,
 }));
 
-jest.mock("@/features/auth/components/feedback/logout-button", () => ({
+jest.mock('@/features/auth/components/feedback/logout-button', () => ({
   LogoutButton: () => <button type="button">Mock logout</button>,
 }));
 
-describe("DashboardPageView", () => {
-  it("renders the redesigned transporter dashboard summary", () => {
+describe('DashboardPageView', () => {
+  it('renders the redesigned transporter dashboard summary', () => {
     render(<DashboardPageView />);
 
     expect(
-      screen.getByRole("heading", { name: /Panel operativo del transportista/i }),
+      screen.getByRole('heading', {
+        name: /Panel operativo del transportista/i,
+      }),
     ).toBeInTheDocument();
     expect(screen.getByText(/Contrato E2/i)).toBeInTheDocument();
     expect(screen.getByText(/Mock dashboard navigation/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Mock logout/i })).toBeInTheDocument();
-    expect(screen.queryByText(/Placeholder de dashboard/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Flota y operacion/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Mock logout/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Placeholder de dashboard/i),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/features/dashboard/pages/dashboard-page.tsx
+++ b/apps/web/features/dashboard/pages/dashboard-page.tsx
@@ -1,43 +1,43 @@
-import { DashboardNavigation } from "../components/dashboard-navigation";
-import { LogoutButton } from "@/features/auth/components/feedback/logout-button";
+import { DashboardNavigation } from '../components/dashboard-navigation';
+import { LogoutButton } from '@/features/auth/components/feedback/logout-button';
 import {
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
+} from '@/components/ui/card';
 
 const dashboardSignals = [
   {
-    label: "Sesion protegida",
-    value: "Bootstrap restaurado",
+    label: 'Sesion protegida',
+    value: 'Bootstrap restaurado',
   },
   {
-    label: "Contrato activo",
-    value: "API E2 intacta",
+    label: 'Contrato activo',
+    value: 'API E2 intacta',
   },
   {
-    label: "Proximo foco",
-    value: "Perfil y operacion",
+    label: 'Proximo foco',
+    value: 'Flota y operacion',
   },
 ];
 
 const dashboardHighlights = [
   {
     description:
-      "Tu acceso privado ya esta funcionando y el flujo del onboarding sigue siendo la pieza central para dejar el perfil listo.",
-    title: "Base operativa estable",
+      'Tu acceso privado ya esta funcionando y el flujo del onboarding sigue siendo la pieza central para dejar el perfil listo.',
+    title: 'Base operativa estable',
   },
   {
     description:
-      "La nueva navegacion prioriza contexto, siguiente accion y lectura rapida sin tocar contratos backend.",
-    title: "Navegacion mas clara",
+      'La nueva navegacion prioriza contexto, siguiente accion y lectura rapida sin tocar contratos backend.',
+    title: 'Navegacion mas clara',
   },
   {
     description:
-      "El panel resume donde estas parado y te deja a un click de las rutas protegidas mas importantes.",
-    title: "Entrada mas util",
+      'El panel resume donde estas parado y te deja a un click de las rutas protegidas mas importantes.',
+    title: 'Entrada mas util',
   },
 ];
 
@@ -71,9 +71,9 @@ export default function DashboardPageView() {
                   Panel operativo del transportista
                 </h1>
                 <CardDescription className="max-w-2xl text-base leading-7 text-primary-foreground/76">
-                  La sesion ya se restauro correctamente. Este panel pone en primer
-                  plano el contexto, la proxima accion y los accesos protegidos
-                  mas importantes sin cambiar la API actual.
+                  La sesion ya se restauro correctamente. Este panel pone en
+                  primer plano el contexto, la proxima accion y los accesos
+                  protegidos mas importantes sin cambiar la API actual.
                 </CardDescription>
               </div>
             </CardHeader>
@@ -100,10 +100,13 @@ export default function DashboardPageView() {
               <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
                 Lo que ya esta resuelto
               </p>
-              <CardTitle className="text-[2rem]">Resumen rapido del flujo</CardTitle>
+              <CardTitle className="text-[2rem]">
+                Resumen rapido del flujo
+              </CardTitle>
               <CardDescription className="text-base leading-7">
                 El area protegida ya cuenta con bootstrap de sesion, guards y
-                onboarding conectado. Este dashboard mejora lectura y orientacion.
+                onboarding conectado. Este dashboard mejora lectura y
+                orientacion.
               </CardDescription>
             </CardHeader>
 
@@ -131,10 +134,12 @@ export default function DashboardPageView() {
               <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
                 Navegacion prioritaria
               </p>
-              <CardTitle className="text-[2rem]">Segui el recorrido protegido</CardTitle>
+              <CardTitle className="text-[2rem]">
+                Segui el recorrido protegido
+              </CardTitle>
               <CardDescription className="text-base leading-7">
-                Usa el panel como base y el onboarding como proxima accion natural
-                para dejar tu operacion lista.
+                Usa el panel como base y el onboarding como proxima accion
+                natural para dejar tu operacion lista.
               </CardDescription>
             </CardHeader>
 
@@ -148,10 +153,13 @@ export default function DashboardPageView() {
               <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
                 Control de sesion
               </p>
-              <CardTitle className="text-[2rem]">Sesion activa y contexto visible</CardTitle>
+              <CardTitle className="text-[2rem]">
+                Sesion activa y contexto visible
+              </CardTitle>
               <CardDescription className="text-base leading-7">
                 La proteccion de rutas sigue igual. Este bloque solo hace mas
-                evidente donde estas, que se conserva y como salir si hace falta.
+                evidente donde estas, que se conserva y como salir si hace
+                falta.
               </CardDescription>
             </CardHeader>
 
@@ -161,8 +169,9 @@ export default function DashboardPageView() {
                   Contrato E2
                 </p>
                 <p className="mt-2 text-sm leading-6 text-foreground/78">
-                  No se modifico el backend ni el shape de los datos. El cambio es
-                  visual, estructural y de experiencia dentro del area protegida.
+                  No se modifico el backend ni el shape de los datos. El cambio
+                  es visual, estructural y de experiencia dentro del area
+                  protegida.
                 </p>
               </div>
 

--- a/apps/web/features/vehicle/hooks/use-transporter-trailers.ts
+++ b/apps/web/features/vehicle/hooks/use-transporter-trailers.ts
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ApiError } from '@/src/lib/api';
+import { fetchOwnTrailers } from '../services/list-trailers-api';
+import type { TransporterTrailer } from '../types/fleet.types';
+
+type TransporterTrailersRequestStatus = 'loading' | 'success' | 'error';
+
+type TransporterTrailersState = {
+  error: string | null;
+  requestStatus: TransporterTrailersRequestStatus;
+  trailers: TransporterTrailer[];
+};
+
+const initialState: TransporterTrailersState = {
+  error: null,
+  requestStatus: 'loading',
+  trailers: [],
+};
+
+function getTrailersErrorMessage(error: unknown): string {
+  if (error instanceof ApiError && error.status === 403) {
+    return 'Tu sesion actual no tiene permisos para ver trailers desde el area protegida.';
+  }
+
+  if (error instanceof ApiError && error.status >= 500) {
+    return 'No pudimos cargar los trailers. Intenta nuevamente en unos segundos.';
+  }
+
+  return 'No pudimos cargar los trailers. Vuelve a intentarlo.';
+}
+
+export function useTransporterTrailers() {
+  const [state, setState] = useState<TransporterTrailersState>(initialState);
+  const [requestVersion, setRequestVersion] = useState(0);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    setState((currentState) => ({
+      ...currentState,
+      error: null,
+      requestStatus: 'loading',
+    }));
+
+    async function loadTrailers(): Promise<void> {
+      try {
+        const trailers = await fetchOwnTrailers();
+
+        if (isCancelled) {
+          return;
+        }
+
+        setState({
+          error: null,
+          requestStatus: 'success',
+          trailers,
+        });
+      } catch (error) {
+        if (isCancelled) {
+          return;
+        }
+
+        setState({
+          error: getTrailersErrorMessage(error),
+          requestStatus: 'error',
+          trailers: [],
+        });
+      }
+    }
+
+    void loadTrailers();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [requestVersion]);
+
+  return {
+    error: state.error,
+    refetch: () => {
+      setRequestVersion((currentVersion) => currentVersion + 1);
+    },
+    requestStatus: state.requestStatus,
+    trailers: state.trailers,
+  };
+}

--- a/apps/web/features/vehicle/hooks/use-transporter-vehicles.ts
+++ b/apps/web/features/vehicle/hooks/use-transporter-vehicles.ts
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ApiError } from '@/src/lib/api';
+import { fetchOwnVehicles } from '../services/list-vehicles-api';
+import type { TransporterVehicle } from '../types/fleet.types';
+
+type TransporterVehiclesRequestStatus = 'loading' | 'success' | 'error';
+
+type TransporterVehiclesState = {
+  error: string | null;
+  requestStatus: TransporterVehiclesRequestStatus;
+  vehicles: TransporterVehicle[];
+};
+
+const initialState: TransporterVehiclesState = {
+  error: null,
+  requestStatus: 'loading',
+  vehicles: [],
+};
+
+function getVehiclesErrorMessage(error: unknown): string {
+  if (error instanceof ApiError && error.status === 403) {
+    return 'Tu sesion actual no tiene permisos para ver vehicles desde el area protegida.';
+  }
+
+  if (error instanceof ApiError && error.status >= 500) {
+    return 'No pudimos cargar los vehicles. Intenta nuevamente en unos segundos.';
+  }
+
+  return 'No pudimos cargar los vehicles. Vuelve a intentarlo.';
+}
+
+export function useTransporterVehicles() {
+  const [state, setState] = useState<TransporterVehiclesState>(initialState);
+  const [requestVersion, setRequestVersion] = useState(0);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    setState((currentState) => ({
+      ...currentState,
+      error: null,
+      requestStatus: 'loading',
+    }));
+
+    async function loadVehicles(): Promise<void> {
+      try {
+        const vehicles = await fetchOwnVehicles();
+
+        if (isCancelled) {
+          return;
+        }
+
+        setState({
+          error: null,
+          requestStatus: 'success',
+          vehicles,
+        });
+      } catch (error) {
+        if (isCancelled) {
+          return;
+        }
+
+        setState({
+          error: getVehiclesErrorMessage(error),
+          requestStatus: 'error',
+          vehicles: [],
+        });
+      }
+    }
+
+    void loadVehicles();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [requestVersion]);
+
+  return {
+    error: state.error,
+    refetch: () => {
+      setRequestVersion((currentVersion) => currentVersion + 1);
+    },
+    requestStatus: state.requestStatus,
+    vehicles: state.vehicles,
+  };
+}

--- a/apps/web/features/vehicle/pages/vehicle-fleet-page.test.tsx
+++ b/apps/web/features/vehicle/pages/vehicle-fleet-page.test.tsx
@@ -1,0 +1,91 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { useTransporterTrailers } from '../hooks/use-transporter-trailers';
+import { useTransporterVehicles } from '../hooks/use-transporter-vehicles';
+import VehicleFleetPage from './vehicle-fleet-page';
+
+jest.mock('../hooks/use-transporter-vehicles', () => ({
+  useTransporterVehicles: jest.fn(),
+}));
+
+jest.mock('../hooks/use-transporter-trailers', () => ({
+  useTransporterTrailers: jest.fn(),
+}));
+
+const mockedUseTransporterVehicles = jest.mocked(useTransporterVehicles);
+const mockedUseTransporterTrailers = jest.mocked(useTransporterTrailers);
+
+describe('VehicleFleetPage', () => {
+  beforeEach(() => {
+    mockedUseTransporterVehicles.mockReset();
+    mockedUseTransporterTrailers.mockReset();
+  });
+
+  it('renders the loading state for both fleet sections', () => {
+    mockedUseTransporterVehicles.mockReturnValue({
+      error: null,
+      refetch: jest.fn(),
+      requestStatus: 'loading',
+      vehicles: [],
+    });
+    mockedUseTransporterTrailers.mockReturnValue({
+      error: null,
+      refetch: jest.fn(),
+      requestStatus: 'loading',
+      trailers: [],
+    });
+
+    render(<VehicleFleetPage />);
+
+    expect(
+      screen.getByRole('heading', {
+        name: /Gestiona tu flota desde un solo lugar/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Cargando vehicles/i)).toBeInTheDocument();
+    expect(screen.getByText(/Cargando trailers/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /Registrar vehicle/i }),
+    ).toHaveAttribute('href', '/vehicles/new');
+  });
+
+  it('renders the vehicles and trailers lists independently', () => {
+    mockedUseTransporterVehicles.mockReturnValue({
+      error: null,
+      refetch: jest.fn(),
+      requestStatus: 'success',
+      vehicles: [
+        {
+          brand: 'Scania',
+          id: 'cmavhcl110000wqz5oy7k8v01',
+          isActive: true,
+          licensePlate: 'AA123BB',
+          model: 'R450',
+        },
+      ],
+    });
+    mockedUseTransporterTrailers.mockReturnValue({
+      error: null,
+      refetch: jest.fn(),
+      requestStatus: 'success',
+      trailers: [
+        {
+          capacityUnit: 'SLOT',
+          cargoType: 'EQUINE',
+          id: 'cmavhcl110000wqz5oy7k8v02',
+          isActive: true,
+          totalCapacity: 12,
+        },
+      ],
+    });
+
+    render(<VehicleFleetPage />);
+
+    expect(screen.getByText('AA123BB')).toBeInTheDocument();
+    expect(screen.getByText(/Scania R450/i)).toBeInTheDocument();
+    expect(screen.getByText('12 slot')).toBeInTheDocument();
+    expect(screen.getByText(/Equino/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/features/vehicle/pages/vehicle-fleet-page.tsx
+++ b/apps/web/features/vehicle/pages/vehicle-fleet-page.tsx
@@ -1,0 +1,429 @@
+'use client';
+
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { useTransporterTrailers } from '../hooks/use-transporter-trailers';
+import { useTransporterVehicles } from '../hooks/use-transporter-vehicles';
+import type {
+  TransporterTrailer,
+  TransporterVehicle,
+} from '../types/fleet.types';
+
+const CARGO_TYPE_LABELS: Record<TransporterTrailer['cargoType'], string> = {
+  EQUINE: 'Equino',
+  FOOD: 'Alimentos',
+  GENERAL_CARGO: 'Carga general',
+  PEOPLE: 'Personas',
+};
+
+const CAPACITY_UNIT_LABELS: Record<TransporterTrailer['capacityUnit'], string> =
+  {
+    KG: 'kg',
+    M3: 'm3',
+    SEAT: 'asiento',
+    SLOT: 'slot',
+  };
+
+function getVehicleStatusLabel(isActive: boolean): string {
+  return isActive ? 'Activa' : 'Inactiva';
+}
+
+function getTrailerStatusLabel(isActive: boolean): string {
+  return isActive ? 'Activo' : 'Inactivo';
+}
+
+function LoadingStateCard({
+  description,
+  title,
+}: {
+  description: string;
+  title: string;
+}) {
+  return (
+    <div className="space-y-4 rounded-[1.6rem] border border-dashed border-border/70 bg-panel/45 p-5 animate-pulse">
+      <div className="space-y-2">
+        <div className="h-5 w-44 rounded-full bg-primary/8" />
+        <div className="h-4 w-80 max-w-full rounded-full bg-primary/5" />
+      </div>
+      <div className="space-y-3">
+        <div className="h-14 rounded-[1.2rem] bg-black/4" />
+        <div className="h-14 rounded-[1.2rem] bg-black/4" />
+      </div>
+      <p className="text-sm leading-6 text-muted">
+        {title}. {description}
+      </p>
+    </div>
+  );
+}
+
+function EmptyStateCard({
+  actionHref,
+  actionLabel,
+  description,
+  title,
+}: {
+  actionHref?: string;
+  actionLabel?: string;
+  description: string;
+  title: string;
+}) {
+  return (
+    <div className="rounded-[1.6rem] border border-border/70 bg-panel/55 p-5">
+      <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      <p className="mt-2 text-sm leading-6 text-muted">{description}</p>
+      {actionHref && actionLabel ? (
+        <Link
+          className="mt-4 inline-flex min-h-12 items-center justify-center rounded-[1.25rem] bg-primary/5 px-4 py-3 text-sm font-semibold text-foreground transition hover:bg-primary/8"
+          href={actionHref}
+        >
+          {actionLabel}
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
+function ErrorStateCard({
+  description,
+  onRetry,
+  title,
+}: {
+  description: string;
+  onRetry: () => void;
+  title: string;
+}) {
+  return (
+    <div className="rounded-[1.6rem] border border-destructive/20 bg-[rgba(177,88,63,0.06)] p-5">
+      <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      <p className="mt-2 text-sm leading-6 text-muted">{description}</p>
+      <Button
+        className="mt-4 max-w-[12rem]"
+        onClick={onRetry}
+        type="button"
+        variant="ghost"
+      >
+        Reintentar
+      </Button>
+    </div>
+  );
+}
+
+function FleetSectionShell({
+  description,
+  eyebrow,
+  title,
+  children,
+}: {
+  children: ReactNode;
+  description: string;
+  eyebrow: string;
+  title: string;
+}) {
+  return (
+    <Card className="overflow-hidden border-white/75 bg-white/86 shadow-[0_18px_40px_rgba(21,40,33,0.08)] backdrop-blur">
+      <CardHeader className="space-y-3 px-7 pt-7">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+          {eyebrow}
+        </p>
+        <CardTitle className="text-[2rem]">{title}</CardTitle>
+        <CardDescription className="text-base leading-7">
+          {description}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="px-7 pb-7">{children}</CardContent>
+    </Card>
+  );
+}
+
+function VehiclesList({ vehicles }: { vehicles: TransporterVehicle[] }) {
+  return (
+    <div className="overflow-hidden rounded-[1.6rem] border border-border/70">
+      <div className="grid grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_auto] gap-4 border-b border-border/70 bg-panel/80 px-5 py-4 text-sm font-semibold text-muted">
+        <span>Patente</span>
+        <span>Marca y modelo</span>
+        <span className="text-right">Estado</span>
+      </div>
+
+      <div className="divide-y divide-border/60 bg-white/55">
+        {vehicles.map((vehicle) => (
+          <div
+            className="grid grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_auto] gap-4 px-5 py-4 text-sm text-foreground"
+            key={vehicle.id}
+          >
+            <div className="min-w-0">
+              <p className="truncate text-base font-semibold text-foreground">
+                {vehicle.licensePlate}
+              </p>
+              <p className="mt-1 text-sm leading-6 text-muted">
+                Vehicle activo de la flota.
+              </p>
+            </div>
+
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-foreground">
+                {vehicle.brand} {vehicle.model}
+              </p>
+              <p className="mt-1 text-sm leading-6 text-muted">
+                Marca y modelo cargados.
+              </p>
+            </div>
+
+            <div className="flex items-center justify-end">
+              <span className="inline-flex rounded-full border border-border/70 bg-primary/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-foreground/80">
+                {getVehicleStatusLabel(vehicle.isActive)}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TrailersList({ trailers }: { trailers: TransporterTrailer[] }) {
+  return (
+    <div className="overflow-hidden rounded-[1.6rem] border border-border/70">
+      <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-4 border-b border-border/70 bg-panel/80 px-5 py-4 text-sm font-semibold text-muted">
+        <span>Capacidad</span>
+        <span>Rubro y unidad</span>
+        <span className="text-right">Estado</span>
+      </div>
+
+      <div className="divide-y divide-border/60 bg-white/55">
+        {trailers.map((trailer) => (
+          <div
+            className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-4 px-5 py-4 text-sm text-foreground"
+            key={trailer.id}
+          >
+            <div className="min-w-0">
+              <p className="truncate text-base font-semibold text-foreground">
+                {trailer.totalCapacity}{' '}
+                {CAPACITY_UNIT_LABELS[trailer.capacityUnit]}
+              </p>
+              <p className="mt-1 text-sm leading-6 text-muted">
+                Capacidad total declarada.
+              </p>
+            </div>
+
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-foreground">
+                {CARGO_TYPE_LABELS[trailer.cargoType]}
+              </p>
+              <p className="mt-1 text-sm leading-6 text-muted">
+                Unidad de capacidad:{' '}
+                {CAPACITY_UNIT_LABELS[trailer.capacityUnit]}.
+              </p>
+            </div>
+
+            <div className="flex items-center justify-end">
+              <span className="inline-flex rounded-full border border-border/70 bg-primary/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-foreground/80">
+                {getTrailerStatusLabel(trailer.isActive)}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function VehicleFleetPage() {
+  const {
+    error: vehiclesError,
+    refetch: refetchVehicles,
+    requestStatus: vehiclesStatus,
+    vehicles,
+  } = useTransporterVehicles();
+  const {
+    error: trailersError,
+    refetch: refetchTrailers,
+    requestStatus: trailersStatus,
+    trailers,
+  } = useTransporterTrailers();
+
+  return (
+    <main className="relative min-h-screen overflow-hidden bg-[linear-gradient(180deg,#eff4ef_0%,#e7efe7_44%,#d9e4da_100%)] px-6 py-10">
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+        <div className="absolute left-[-4rem] top-[-5rem] size-[18rem] rounded-full bg-[#c7ddd6]/50 blur-3xl" />
+        <div className="absolute right-[-5rem] top-[7rem] size-[15rem] rounded-full bg-[#f0d3ad]/42 blur-3xl" />
+        <div className="absolute bottom-[-8rem] left-[22%] size-[16rem] rounded-full bg-[#dbe9d6]/55 blur-3xl" />
+      </div>
+
+      <div className="relative mx-auto w-full max-w-6xl space-y-6">
+        <section className="grid gap-6 xl:grid-cols-[1.08fr_0.92fr]">
+          <Card className="overflow-hidden border-white/35 bg-[linear-gradient(160deg,#153f31_0%,#102d24_46%,#0b1b16_100%)] p-8 text-primary-foreground shadow-[0_28px_60px_rgba(16,39,33,0.18)]">
+            <CardHeader className="space-y-5">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-foreground/88">
+                  Fleet hub
+                </span>
+                <span className="rounded-full border border-white/10 bg-[rgba(255,255,255,0.08)] px-4 py-2 text-sm font-semibold text-primary-foreground/88">
+                  Vehicles y trailers separados
+                </span>
+              </div>
+
+              <div className="space-y-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-primary-foreground/62">
+                  Area protegida del transportista
+                </p>
+                <h1 className="max-w-3xl font-heading text-4xl font-semibold leading-tight text-primary-foreground sm:text-[2.9rem]">
+                  Gestiona tu flota desde un solo lugar
+                </h1>
+                <CardDescription className="max-w-2xl text-base leading-7 text-primary-foreground/76">
+                  Este hub consume los listados reales de vehicles y trailers
+                  para que veas la flota operativa sin salir del area protegida.
+                </CardDescription>
+              </div>
+            </CardHeader>
+
+            <CardContent className="mt-8 grid gap-3 sm:grid-cols-3">
+              <article className="rounded-[1.6rem] border border-white/10 bg-[rgba(10,26,22,0.52)] px-4 py-4">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-primary-foreground/58">
+                  Rutas conectadas
+                </p>
+                <p className="mt-2 text-sm font-semibold leading-6 text-primary-foreground">
+                  GET /vehicles y GET /trailers
+                </p>
+              </article>
+
+              <article className="rounded-[1.6rem] border border-white/10 bg-[rgba(10,26,22,0.52)] px-4 py-4">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-primary-foreground/58">
+                  Alta disponible
+                </p>
+                <p className="mt-2 text-sm font-semibold leading-6 text-primary-foreground">
+                  Seguimos usando /vehicles/new
+                </p>
+              </article>
+
+              <article className="rounded-[1.6rem] border border-white/10 bg-[rgba(10,26,22,0.52)] px-4 py-4">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-primary-foreground/58">
+                  Acceso rapido
+                </p>
+                <p className="mt-2 text-sm font-semibold leading-6 text-primary-foreground">
+                  Entradas claras para administrar la flota
+                </p>
+              </article>
+            </CardContent>
+          </Card>
+
+          <Card className="border-white/70 bg-white/84 p-7 shadow-[0_18px_40px_rgba(21,40,33,0.08)] backdrop-blur">
+            <CardHeader className="space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                Acciones de flota
+              </p>
+              <CardTitle className="text-[2rem]">
+                Entrada principal de gestion
+              </CardTitle>
+              <CardDescription className="text-base leading-7">
+                Desde aca tenes la vista general de la flota y el acceso al alta
+                minima cuando necesites registrar un vehicle nuevo.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent className="space-y-4">
+              <Link
+                className="inline-flex min-h-14 items-center justify-center rounded-[1.4rem] bg-primary px-5 py-3 text-[15px] font-semibold text-primary-foreground transition hover:bg-[#143428]"
+                href="/vehicles/new"
+              >
+                Registrar vehicle
+              </Link>
+
+              <Link
+                className="inline-flex min-h-14 items-center justify-center rounded-[1.4rem] bg-primary/5 px-5 py-3 text-[15px] font-semibold text-foreground transition hover:bg-primary/8"
+                href="/dashboard"
+              >
+                Volver al dashboard
+              </Link>
+
+              <div className="rounded-[1.5rem] border border-border/70 bg-panel/70 px-5 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                  Lo que cambia
+                </p>
+                <p className="mt-2 text-sm leading-6 text-foreground/78">
+                  La pagina separa vehicles y trailers visualmente y ya trabaja
+                  contra el backend real en lugar de mockear datos.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-2">
+          <FleetSectionShell
+            description="Listado operativo de vehicles propios, con estado y datos base para navegar la flota."
+            eyebrow="Vehicles"
+            title="Vehiculos cargados"
+          >
+            {vehiclesStatus === 'loading' ? (
+              <LoadingStateCard
+                description="Estamos consultando el estado actual de los vehicles del transportista."
+                title="Cargando vehicles"
+              />
+            ) : null}
+
+            {vehiclesStatus === 'error' ? (
+              <ErrorStateCard
+                description={vehiclesError ?? 'No pudimos cargar los vehicles.'}
+                onRetry={refetchVehicles}
+                title="No pudimos cargar vehicles"
+              />
+            ) : null}
+
+            {vehiclesStatus === 'success' && vehicles.length === 0 ? (
+              <EmptyStateCard
+                actionHref="/vehicles/new"
+                actionLabel="Registrar vehicle"
+                description="Aun no hay vehicles cargados para esta cuenta."
+                title="No encontramos vehicles"
+              />
+            ) : null}
+
+            {vehiclesStatus === 'success' && vehicles.length > 0 ? (
+              <VehiclesList vehicles={vehicles} />
+            ) : null}
+          </FleetSectionShell>
+
+          <FleetSectionShell
+            description="Trailers visibles desde el backend real, separados para leer capacidad y rubro sin mezclar con vehicles."
+            eyebrow="Trailers"
+            title="Trailers cargados"
+          >
+            {trailersStatus === 'loading' ? (
+              <LoadingStateCard
+                description="Estamos consultando el estado actual de los trailers del transportista."
+                title="Cargando trailers"
+              />
+            ) : null}
+
+            {trailersStatus === 'error' ? (
+              <ErrorStateCard
+                description={trailersError ?? 'No pudimos cargar los trailers.'}
+                onRetry={refetchTrailers}
+                title="No pudimos cargar trailers"
+              />
+            ) : null}
+
+            {trailersStatus === 'success' && trailers.length === 0 ? (
+              <EmptyStateCard
+                description="Aun no hay trailers cargados para esta cuenta."
+                title="No encontramos trailers"
+              />
+            ) : null}
+
+            {trailersStatus === 'success' && trailers.length > 0 ? (
+              <TrailersList trailers={trailers} />
+            ) : null}
+          </FleetSectionShell>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/features/vehicle/services/list-trailers-api.test.ts
+++ b/apps/web/features/vehicle/services/list-trailers-api.test.ts
@@ -1,0 +1,100 @@
+import { fetchOwnTrailers } from './list-trailers-api';
+
+jest.mock('@/features/auth/services/session/access-token-store', () => ({
+  getAccessToken: jest.fn(),
+}));
+
+const { getAccessToken } = jest.requireMock(
+  '@/features/auth/services/session/access-token-store',
+) as {
+  getAccessToken: jest.Mock;
+};
+
+describe('fetchOwnTrailers', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3001';
+    getAccessToken.mockReturnValue('access-token-value');
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+    delete process.env.NEXT_PUBLIC_API_URL;
+  });
+
+  it('returns the parsed trailers list', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            capacityUnit: 'SLOT',
+            cargoType: 'EQUINE',
+            id: 'cmavhcl110000wqz5oy7k8v02',
+            isActive: true,
+            totalCapacity: 12,
+          },
+        ]),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(fetchOwnTrailers()).resolves.toEqual([
+      {
+        capacityUnit: 'SLOT',
+        cargoType: 'EQUINE',
+        id: 'cmavhcl110000wqz5oy7k8v02',
+        isActive: true,
+        totalCapacity: 12,
+      },
+    ]);
+
+    const [, requestInit] = (global.fetch as jest.Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const headers = requestInit.headers as Headers;
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:3001/trailers',
+      expect.objectContaining({
+        credentials: 'include',
+        headers: expect.any(Headers),
+        method: 'GET',
+      }),
+    );
+    expect(headers.get('Authorization')).toBe('Bearer access-token-value');
+  });
+
+  it('throws when the trailers payload is invalid', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            capacityUnit: 'SLOT',
+            cargoType: 'EQUINE',
+            id: 'not-a-cuid',
+            isActive: true,
+            totalCapacity: 12,
+          },
+        ]),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(fetchOwnTrailers()).rejects.toThrow(
+      'payload invalido para GET /trailers',
+    );
+  });
+});

--- a/apps/web/features/vehicle/services/list-trailers-api.ts
+++ b/apps/web/features/vehicle/services/list-trailers-api.ts
@@ -1,0 +1,35 @@
+import { getAccessToken } from '@/features/auth/services/session/access-token-store';
+import { apiClient } from '@/src/lib/api';
+import {
+  TrailerListSchema,
+  type TransporterTrailer,
+} from '../types/fleet.types';
+
+const INVALID_TRAILERS_RESPONSE_MESSAGE =
+  'La API respondio con un payload invalido para GET /trailers.';
+
+function buildAuthorizationHeaders(
+  accessToken: string | null,
+): HeadersInit | undefined {
+  if (!accessToken) {
+    return undefined;
+  }
+
+  return {
+    Authorization: `Bearer ${accessToken}`,
+  };
+}
+
+export async function fetchOwnTrailers(): Promise<TransporterTrailer[]> {
+  const response = await apiClient.get<unknown>('/trailers', {
+    cache: 'no-store',
+    headers: buildAuthorizationHeaders(getAccessToken()),
+  });
+  const parsedResponse = TrailerListSchema.safeParse(response.data);
+
+  if (!parsedResponse.success) {
+    throw new Error(INVALID_TRAILERS_RESPONSE_MESSAGE);
+  }
+
+  return parsedResponse.data;
+}

--- a/apps/web/features/vehicle/services/list-vehicles-api.test.ts
+++ b/apps/web/features/vehicle/services/list-vehicles-api.test.ts
@@ -1,0 +1,100 @@
+import { fetchOwnVehicles } from './list-vehicles-api';
+
+jest.mock('@/features/auth/services/session/access-token-store', () => ({
+  getAccessToken: jest.fn(),
+}));
+
+const { getAccessToken } = jest.requireMock(
+  '@/features/auth/services/session/access-token-store',
+) as {
+  getAccessToken: jest.Mock;
+};
+
+describe('fetchOwnVehicles', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3001';
+    getAccessToken.mockReturnValue('access-token-value');
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+    delete process.env.NEXT_PUBLIC_API_URL;
+  });
+
+  it('returns the parsed vehicles list', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            brand: 'Scania',
+            id: 'cmavhcl110000wqz5oy7k8v01',
+            isActive: true,
+            licensePlate: 'AA123BB',
+            model: 'R450',
+          },
+        ]),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(fetchOwnVehicles()).resolves.toEqual([
+      {
+        brand: 'Scania',
+        id: 'cmavhcl110000wqz5oy7k8v01',
+        isActive: true,
+        licensePlate: 'AA123BB',
+        model: 'R450',
+      },
+    ]);
+
+    const [, requestInit] = (global.fetch as jest.Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const headers = requestInit.headers as Headers;
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:3001/vehicles',
+      expect.objectContaining({
+        credentials: 'include',
+        headers: expect.any(Headers),
+        method: 'GET',
+      }),
+    );
+    expect(headers.get('Authorization')).toBe('Bearer access-token-value');
+  });
+
+  it('throws when the vehicles payload is invalid', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            id: 'not-a-cuid',
+            licensePlate: 'AA123BB',
+            brand: 'Scania',
+            model: 'R450',
+            isActive: true,
+          },
+        ]),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(fetchOwnVehicles()).rejects.toThrow(
+      'payload invalido para GET /vehicles',
+    );
+  });
+});

--- a/apps/web/features/vehicle/services/list-vehicles-api.ts
+++ b/apps/web/features/vehicle/services/list-vehicles-api.ts
@@ -1,0 +1,35 @@
+import { getAccessToken } from '@/features/auth/services/session/access-token-store';
+import { apiClient } from '@/src/lib/api';
+import {
+  VehicleListSchema,
+  type TransporterVehicle,
+} from '../types/fleet.types';
+
+const INVALID_VEHICLES_RESPONSE_MESSAGE =
+  'La API respondio con un payload invalido para GET /vehicles.';
+
+function buildAuthorizationHeaders(
+  accessToken: string | null,
+): HeadersInit | undefined {
+  if (!accessToken) {
+    return undefined;
+  }
+
+  return {
+    Authorization: `Bearer ${accessToken}`,
+  };
+}
+
+export async function fetchOwnVehicles(): Promise<TransporterVehicle[]> {
+  const response = await apiClient.get<unknown>('/vehicles', {
+    cache: 'no-store',
+    headers: buildAuthorizationHeaders(getAccessToken()),
+  });
+  const parsedResponse = VehicleListSchema.safeParse(response.data);
+
+  if (!parsedResponse.success) {
+    throw new Error(INVALID_VEHICLES_RESPONSE_MESSAGE);
+  }
+
+  return parsedResponse.data;
+}

--- a/apps/web/features/vehicle/types/fleet.types.ts
+++ b/apps/web/features/vehicle/types/fleet.types.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+import {
+  TrailerViewSchema,
+  VehicleViewSchema,
+  type ITrailerView,
+  type IVehicleView,
+} from '@logistica/shared';
+
+export const VehicleListSchema = z.array(VehicleViewSchema);
+export const TrailerListSchema = z.array(TrailerViewSchema);
+
+export type TransporterVehicle = IVehicleView;
+export type TransporterTrailer = ITrailerView;


### PR DESCRIPTION
## Contexto
Resuelve la issue #109 de E3-FE para crear la seccion de flota del transportista consumiendo los listados reales de backend.

## Alcance
- agrega la ruta protegida `/vehicles` como hub de flota
- separa visualmente `vehicles` y `trailers` en bloques distintos
- incorpora servicios reales para `GET /vehicles` y `GET /trailers`
- agrega hooks de carga, estados de loading/error/empty y tests focalizados
- suma un acceso claro desde el dashboard hacia la nueva seccion

## Riesgos
- cambio acotado a `apps/web`
- no modifica contratos backend ni zonas protegidas
- mantiene `/vehicles/new` como alta inicial y usa `/vehicles` como punto principal de gestion

## Como testear
- autenticar como `TRANSPORTER`
- abrir `/vehicles` y verificar que la vista separa `vehicles` y `trailers`
- confirmar que los datos provienen de `GET /vehicles` y `GET /trailers`
- correr `pnpm --filter @logistica/web test -- --runTestsByPath features/vehicle/services/list-vehicles-api.test.ts features/vehicle/services/list-trailers-api.test.ts features/vehicle/pages/vehicle-fleet-page.test.tsx features/dashboard/components/dashboard-navigation.test.tsx features/dashboard/pages/dashboard-page.test.tsx`

## Validacion realizada
- `pnpm --filter @logistica/web test -- --runTestsByPath features/vehicle/services/list-vehicles-api.test.ts features/vehicle/services/list-trailers-api.test.ts features/vehicle/pages/vehicle-fleet-page.test.tsx features/dashboard/components/dashboard-navigation.test.tsx features/dashboard/pages/dashboard-page.test.tsx`
- `pnpm --filter @logistica/web test` corre casi completo, pero sigue chocando con un `EPERM` en un test existente de `next/navigation` fuera del alcance de esta issue (`features/auth/hooks/use-logout.test.ts`)
- `pnpm --filter @logistica/web typecheck` sigue fallando por una resolucion existente de `tailwindcss` en `apps/web/tailwind.config.ts`, tambien fuera del alcance de esta issue

Closes #109