### PR TITLE
feat(web): add vehicle fleet actions

### DIFF
--- a/apps/web/app/(protected)/vehicles/[id]/edit/page.tsx
+++ b/apps/web/app/(protected)/vehicles/[id]/edit/page.tsx
@@ -1,0 +1,15 @@
+import { VehicleEditPage } from '@/features/vehicle/pages/vehicle-edit-page';
+
+type VehicleEditRouteProps = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export default async function VehicleEditRoute({
+  params,
+}: VehicleEditRouteProps) {
+  const { id } = await params;
+
+  return <VehicleEditPage vehicleId={id} />;
+}

--- a/apps/web/features/vehicle/components/fleet-section-shell.tsx
+++ b/apps/web/features/vehicle/components/fleet-section-shell.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+export function LoadingStateCard({
+  description,
+  title,
+}: {
+  description: string;
+  title: string;
+}) {
+  return (
+    <div className="animate-pulse space-y-4 rounded-[1.6rem] border border-dashed border-border/70 bg-panel/45 p-5">
+      <div className="space-y-2">
+        <div className="h-5 w-44 rounded-full bg-primary/8" />
+        <div className="h-4 w-80 max-w-full rounded-full bg-primary/5" />
+      </div>
+      <div className="space-y-3">
+        <div className="h-14 rounded-[1.2rem] bg-black/4" />
+        <div className="h-14 rounded-[1.2rem] bg-black/4" />
+      </div>
+      <p className="text-sm leading-6 text-muted">
+        {title}. {description}
+      </p>
+    </div>
+  );
+}
+
+export function EmptyStateCard({
+  actionHref,
+  actionLabel,
+  description,
+  title,
+}: {
+  actionHref?: string;
+  actionLabel?: string;
+  description: string;
+  title: string;
+}) {
+  return (
+    <div className="rounded-[1.6rem] border border-border/70 bg-panel/55 p-5">
+      <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      <p className="mt-2 text-sm leading-6 text-muted">{description}</p>
+      {actionHref && actionLabel ? (
+        <Link
+          className="mt-4 inline-flex min-h-12 items-center justify-center rounded-[1.25rem] bg-primary/5 px-4 py-3 text-sm font-semibold text-foreground transition hover:bg-primary/8"
+          href={actionHref}
+        >
+          {actionLabel}
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
+export function ErrorStateCard({
+  description,
+  onRetry,
+  title,
+}: {
+  description: string;
+  onRetry: () => void;
+  title: string;
+}) {
+  return (
+    <div className="rounded-[1.6rem] border border-destructive/20 bg-[rgba(177,88,63,0.06)] p-5">
+      <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      <p className="mt-2 text-sm leading-6 text-muted">{description}</p>
+      <Button
+        className="mt-4 max-w-[12rem]"
+        onClick={onRetry}
+        type="button"
+        variant="ghost"
+      >
+        Reintentar
+      </Button>
+    </div>
+  );
+}
+
+export function FleetSectionShell({
+  children,
+  description,
+  eyebrow,
+  title,
+}: {
+  children: ReactNode;
+  description: string;
+  eyebrow: string;
+  title: string;
+}) {
+  return (
+    <Card className="overflow-hidden border-white/75 bg-white/86 shadow-[0_18px_40px_rgba(21,40,33,0.08)] backdrop-blur">
+      <CardHeader className="space-y-3 px-7 pt-7">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+          {eyebrow}
+        </p>
+        <CardTitle className="text-[2rem]">{title}</CardTitle>
+        <CardDescription className="text-base leading-7">
+          {description}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="px-7 pb-7">{children}</CardContent>
+    </Card>
+  );
+}

--- a/apps/web/features/vehicle/components/trailer-fleet-section.tsx
+++ b/apps/web/features/vehicle/components/trailer-fleet-section.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useTransporterTrailers } from '../hooks/use-transporter-trailers';
+import type { TransporterTrailer } from '../types/fleet.types';
+import {
+  EmptyStateCard,
+  ErrorStateCard,
+  FleetSectionShell,
+  LoadingStateCard,
+} from './fleet-section-shell';
+
+const CARGO_TYPE_LABELS: Record<TransporterTrailer['cargoType'], string> = {
+  EQUINE: 'Equino',
+  FOOD: 'Alimentos',
+  GENERAL_CARGO: 'Carga general',
+  PEOPLE: 'Personas',
+};
+
+const CAPACITY_UNIT_LABELS: Record<TransporterTrailer['capacityUnit'], string> =
+  {
+    KG: 'kg',
+    M3: 'm3',
+    SEAT: 'asiento',
+    SLOT: 'slot',
+  };
+
+function getTrailerStatusLabel(isActive: boolean): string {
+  return isActive ? 'Activo' : 'Inactivo';
+}
+
+function TrailersList({ trailers }: { trailers: TransporterTrailer[] }) {
+  return (
+    <div className="overflow-hidden rounded-[1.6rem] border border-border/70">
+      <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-4 border-b border-border/70 bg-panel/80 px-5 py-4 text-sm font-semibold text-muted">
+        <span>Capacidad</span>
+        <span>Rubro y unidad</span>
+        <span className="text-right">Estado</span>
+      </div>
+
+      <div className="divide-y divide-border/60 bg-white/55">
+        {trailers.map((trailer) => (
+          <div
+            className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-4 px-5 py-4 text-sm text-foreground"
+            key={trailer.id}
+          >
+            <div className="min-w-0">
+              <p className="truncate text-base font-semibold text-foreground">
+                {trailer.totalCapacity}{' '}
+                {CAPACITY_UNIT_LABELS[trailer.capacityUnit]}
+              </p>
+              <p className="mt-1 text-sm leading-6 text-muted">
+                Capacidad total declarada.
+              </p>
+            </div>
+
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-foreground">
+                {CARGO_TYPE_LABELS[trailer.cargoType]}
+              </p>
+              <p className="mt-1 text-sm leading-6 text-muted">
+                Unidad de capacidad:{' '}
+                {CAPACITY_UNIT_LABELS[trailer.capacityUnit]}.
+              </p>
+            </div>
+
+            <div className="flex items-center justify-end">
+              <span className="inline-flex rounded-full border border-border/70 bg-primary/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-foreground/80">
+                {getTrailerStatusLabel(trailer.isActive)}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function TrailerFleetSection() {
+  const {
+    error: trailersError,
+    refetch: refetchTrailers,
+    requestStatus: trailersStatus,
+    trailers,
+  } = useTransporterTrailers();
+
+  return (
+    <FleetSectionShell
+      description="Trailers visibles desde el backend real, separados para leer capacidad y rubro sin mezclar con vehicles."
+      eyebrow="Trailers"
+      title="Trailers cargados"
+    >
+      {trailersStatus === 'loading' ? (
+        <LoadingStateCard
+          description="Estamos consultando el estado actual de los trailers del transportista."
+          title="Cargando trailers"
+        />
+      ) : null}
+
+      {trailersStatus === 'error' ? (
+        <ErrorStateCard
+          description={trailersError ?? 'No pudimos cargar los trailers.'}
+          onRetry={refetchTrailers}
+          title="No pudimos cargar trailers"
+        />
+      ) : null}
+
+      {trailersStatus === 'success' && trailers.length === 0 ? (
+        <EmptyStateCard
+          description="Aun no hay trailers cargados para esta cuenta."
+          title="No encontramos trailers"
+        />
+      ) : null}
+
+      {trailersStatus === 'success' && trailers.length > 0 ? (
+        <TrailersList trailers={trailers} />
+      ) : null}
+    </FleetSectionShell>
+  );
+}

--- a/apps/web/features/vehicle/components/vehicle-edit-form.tsx
+++ b/apps/web/features/vehicle/components/vehicle-edit-form.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { UpdateVehicleSchema } from '@logistica/shared';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { useUpdateVehicle } from '../hooks/use-update-vehicle';
+import type { Vehicle, VehicleUpdateFormValues } from '../types/vehicle.types';
+
+type VehicleEditFormProps = {
+  vehicle: Vehicle;
+};
+
+export function VehicleEditForm({ vehicle }: VehicleEditFormProps) {
+  const router = useRouter();
+  const {
+    formState: { errors, isDirty, isSubmitted, isValid },
+    handleSubmit,
+    register,
+  } = useForm<VehicleUpdateFormValues>({
+    defaultValues: {
+      brand: vehicle.brand,
+      licensePlate: vehicle.licensePlate,
+      model: vehicle.model,
+    },
+    mode: 'onChange',
+    resolver: zodResolver(UpdateVehicleSchema),
+  });
+  const { isSubmitting, resetSubmitError, submitError, updateVehicle } =
+    useUpdateVehicle(vehicle.id, {
+      onSuccess: () => {
+        router.push('/vehicles');
+      },
+    });
+
+  async function onSubmit(values: VehicleUpdateFormValues): Promise<void> {
+    resetSubmitError();
+    await updateVehicle(values);
+  }
+
+  const licensePlateError =
+    isSubmitted || errors.licensePlate
+      ? errors.licensePlate?.message
+      : undefined;
+  const brandError =
+    isSubmitted || errors.brand ? errors.brand?.message : undefined;
+  const modelError =
+    isSubmitted || errors.model ? errors.model?.message : undefined;
+
+  return (
+    <Card className="border-white/75 bg-white/88 p-6 shadow-[0_18px_40px_rgba(21,40,33,0.08)] sm:p-8">
+      <CardHeader className="space-y-3">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.26em] text-muted">
+          Issue #111
+        </p>
+        <CardTitle>Editar vehicle operativo</CardTitle>
+        <CardDescription className="max-w-2xl text-base leading-7">
+          Ajusta la patente, marca o modelo con el mismo contrato de backend y
+          vuelve al hub de flota cuando termines.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="mt-2">
+        <form
+          className="space-y-6"
+          noValidate
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="space-y-2">
+              <label
+                className="text-[13px] font-semibold text-foreground/92"
+                htmlFor="licensePlate"
+              >
+                Patente
+              </label>
+              <Input
+                autoCapitalize="characters"
+                autoCorrect="off"
+                disabled={isSubmitting}
+                error={licensePlateError}
+                id="licensePlate"
+                maxLength={8}
+                placeholder="Ej: AA123BB"
+                {...register('licensePlate')}
+              />
+              <p className="text-sm leading-6 text-muted">
+                Se admiten entre 6 y 8 caracteres alfanumericos.
+              </p>
+              {licensePlateError ? (
+                <p className="text-sm text-destructive/90">
+                  {licensePlateError}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="space-y-2">
+              <label
+                className="text-[13px] font-semibold text-foreground/92"
+                htmlFor="brand"
+              >
+                Marca
+              </label>
+              <Input
+                autoComplete="organization"
+                disabled={isSubmitting}
+                error={brandError}
+                id="brand"
+                maxLength={80}
+                placeholder="Ej: Scania"
+                {...register('brand')}
+              />
+              {brandError ? (
+                <p className="text-sm text-destructive/90">{brandError}</p>
+              ) : null}
+            </div>
+
+            <div className="space-y-2 md:col-span-2">
+              <label
+                className="text-[13px] font-semibold text-foreground/92"
+                htmlFor="model"
+              >
+                Modelo
+              </label>
+              <Input
+                disabled={isSubmitting}
+                error={modelError}
+                id="model"
+                maxLength={80}
+                placeholder="Ej: R450"
+                {...register('model')}
+              />
+              {modelError ? (
+                <p className="text-sm text-destructive/90">{modelError}</p>
+              ) : null}
+            </div>
+          </div>
+
+          {submitError ? (
+            <div
+              aria-live="polite"
+              className="rounded-[1.4rem] border border-destructive/18 bg-[rgba(177,88,63,0.08)] px-4 py-3.5 text-sm leading-6 text-destructive"
+            >
+              {submitError}
+            </div>
+          ) : null}
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Button
+              disabled={!isDirty || !isValid || isSubmitting}
+              isLoading={isSubmitting}
+              loadingText="Guardando"
+              type="submit"
+            >
+              Guardar cambios
+            </Button>
+
+            <Button
+              className="sm:max-w-[14rem]"
+              disabled={isSubmitting}
+              onClick={() => router.push('/vehicles')}
+              type="button"
+              variant="ghost"
+            >
+              Cancelar
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/features/vehicle/components/vehicle-fleet-section.tsx
+++ b/apps/web/features/vehicle/components/vehicle-fleet-section.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useDeactivateVehicle } from '../hooks/use-deactivate-vehicle';
+import { useTransporterVehicles } from '../hooks/use-transporter-vehicles';
+import type { TransporterVehicle } from '../types/fleet.types';
+import {
+  EmptyStateCard,
+  ErrorStateCard,
+  FleetSectionShell,
+  LoadingStateCard,
+} from './fleet-section-shell';
+
+function getVehicleStatusLabel(isActive: boolean): string {
+  return isActive ? 'Activa' : 'Inactiva';
+}
+
+function VehiclesList({
+  onDeactivate,
+  pendingVehicleId,
+  vehicles,
+}: {
+  onDeactivate: (vehicle: TransporterVehicle) => Promise<void>;
+  pendingVehicleId: string | null;
+  vehicles: TransporterVehicle[];
+}) {
+  return (
+    <div className="overflow-hidden rounded-[1.6rem] border border-border/70">
+      <div className="grid grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)_auto_auto] gap-4 border-b border-border/70 bg-panel/80 px-5 py-4 text-sm font-semibold text-muted">
+        <span>Patente</span>
+        <span>Marca y modelo</span>
+        <span className="text-right">Estado</span>
+        <span className="text-right">Acciones</span>
+      </div>
+
+      <div className="divide-y divide-border/60 bg-white/55">
+        {vehicles.map((vehicle) => {
+          const isPending = pendingVehicleId === vehicle.id;
+
+          return (
+            <div
+              className="grid grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)_auto_auto] gap-4 px-5 py-4 text-sm text-foreground"
+              key={vehicle.id}
+            >
+              <div className="min-w-0">
+                <p className="truncate text-base font-semibold text-foreground">
+                  {vehicle.licensePlate}
+                </p>
+                <p className="mt-1 text-sm leading-6 text-muted">
+                  Vehicle operativo de la flota.
+                </p>
+              </div>
+
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-foreground">
+                  {vehicle.brand} {vehicle.model}
+                </p>
+                <p className="mt-1 text-sm leading-6 text-muted">
+                  Marca y modelo cargados.
+                </p>
+              </div>
+
+              <div className="flex items-center justify-end">
+                <span className="inline-flex rounded-full border border-border/70 bg-primary/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-foreground/80">
+                  {getVehicleStatusLabel(vehicle.isActive)}
+                </span>
+              </div>
+
+              <div className="flex flex-col items-end gap-2 sm:flex-row sm:items-center">
+                <Link
+                  className="inline-flex min-h-10 items-center justify-center rounded-[1rem] bg-primary/5 px-4 py-2 text-sm font-semibold text-foreground transition hover:bg-primary/8"
+                  href={`/vehicles/${vehicle.id}/edit`}
+                >
+                  Editar
+                </Link>
+                <Button
+                  className="h-10 w-auto rounded-[1rem] px-4 text-sm"
+                  disabled={!vehicle.isActive}
+                  isLoading={isPending}
+                  loadingText="Desactivando"
+                  onClick={() => void onDeactivate(vehicle)}
+                  type="button"
+                  variant="ghost"
+                >
+                  Desactivar
+                </Button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function VehicleFleetSection() {
+  const {
+    error: vehiclesError,
+    refetch: refetchVehicles,
+    requestStatus: vehiclesStatus,
+    vehicles,
+  } = useTransporterVehicles();
+  const [pendingVehicleId, setPendingVehicleId] = useState<string | null>(null);
+  const { deactivateVehicle, isSubmitting, resetSubmitError, submitError } =
+    useDeactivateVehicle();
+
+  async function handleDeactivate(vehicle: TransporterVehicle): Promise<void> {
+    if (!vehicle.isActive) {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Vas a desactivar el vehicle ${vehicle.licensePlate}. Podras verlo como inactivo en la flota.`,
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    resetSubmitError();
+    setPendingVehicleId(vehicle.id);
+
+    try {
+      const updatedVehicle = await deactivateVehicle(vehicle.id);
+
+      if (!updatedVehicle) {
+        return;
+      }
+
+      await refetchVehicles();
+    } finally {
+      setPendingVehicleId(null);
+    }
+  }
+
+  return (
+    <FleetSectionShell
+      description="Listado operativo de vehicles propios, con estado y acciones para mantener la flota al dia."
+      eyebrow="Vehicles"
+      title="Vehiculos cargados"
+    >
+      {vehiclesStatus === 'loading' ? (
+        <LoadingStateCard
+          description="Estamos consultando el estado actual de los vehicles del transportista."
+          title="Cargando vehicles"
+        />
+      ) : null}
+
+      {vehiclesStatus === 'error' ? (
+        <ErrorStateCard
+          description={vehiclesError ?? 'No pudimos cargar los vehicles.'}
+          onRetry={refetchVehicles}
+          title="No pudimos cargar vehicles"
+        />
+      ) : null}
+
+      {vehiclesStatus === 'success' && vehicles.length === 0 ? (
+        <EmptyStateCard
+          actionHref="/vehicles/new"
+          actionLabel="Registrar vehicle"
+          description="Aun no hay vehicles cargados para esta cuenta."
+          title="No encontramos vehicles"
+        />
+      ) : null}
+
+      {vehiclesStatus === 'success' && vehicles.length > 0 ? (
+        <div className="space-y-4">
+          {submitError ? (
+            <div
+              aria-live="polite"
+              className="rounded-[1.4rem] border border-destructive/18 bg-[rgba(177,88,63,0.08)] px-4 py-3.5 text-sm leading-6 text-destructive"
+            >
+              {submitError}
+            </div>
+          ) : null}
+
+          <VehiclesList
+            onDeactivate={handleDeactivate}
+            pendingVehicleId={isSubmitting ? pendingVehicleId : null}
+            vehicles={vehicles}
+          />
+        </div>
+      ) : null}
+    </FleetSectionShell>
+  );
+}

--- a/apps/web/features/vehicle/hooks/use-deactivate-vehicle.ts
+++ b/apps/web/features/vehicle/hooks/use-deactivate-vehicle.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { ApiError, NotFoundError } from '@/src/lib/api';
+import { useFormSubmit } from '@/src/lib/forms/hooks/useFormSubmit';
+import { deactivateVehicle } from '../services/deactivate-vehicle-api';
+import type { Vehicle } from '../types/vehicle.types';
+
+function getDeactivateVehicleErrorMessage(error: unknown): string {
+  if (error instanceof NotFoundError) {
+    return 'No encontramos el vehicle que intentas desactivar.';
+  }
+
+  if (
+    error instanceof ApiError &&
+    (error.status === 401 || error.status === 403)
+  ) {
+    return 'Tu sesion no tiene acceso para desactivar vehicles. Vuelve a ingresar e intenta otra vez.';
+  }
+
+  if (error instanceof ApiError && error.status >= 500) {
+    return 'No pudimos desactivar el vehicle por un problema del servidor. Intenta nuevamente en unos segundos.';
+  }
+
+  return 'No pudimos desactivar el vehicle. Vuelve a intentarlo.';
+}
+
+type UseDeactivateVehicleOptions = {
+  onSuccess?: (vehicle: Vehicle) => void;
+};
+
+export function useDeactivateVehicle({
+  onSuccess,
+}: UseDeactivateVehicleOptions = {}) {
+  const { isSubmitting, resetSubmitError, submit, submitError } = useFormSubmit(
+    async (vehicleId: string) => {
+      const vehicle = await deactivateVehicle(vehicleId);
+
+      onSuccess?.(vehicle);
+
+      return vehicle;
+    },
+    {
+      getErrorMessage: getDeactivateVehicleErrorMessage,
+    },
+  );
+
+  return {
+    deactivateVehicle: submit,
+    isSubmitting,
+    resetSubmitError,
+    submitError,
+  };
+}

--- a/apps/web/features/vehicle/hooks/use-update-vehicle.ts
+++ b/apps/web/features/vehicle/hooks/use-update-vehicle.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { ApiError, BadRequestError, ConflictError } from '@/src/lib/api';
+import { useFormSubmit } from '@/src/lib/forms/hooks/useFormSubmit';
+import { updateVehicle } from '../services/update-vehicle-api';
+import type { Vehicle, VehicleUpdateFormValues } from '../types/vehicle.types';
+
+function getUpdateVehicleErrorMessage(error: unknown): string {
+  if (error instanceof ConflictError) {
+    return 'Ya existe un vehicle con esa patente. Revisa el dato e intenta de nuevo.';
+  }
+
+  if (error instanceof BadRequestError) {
+    return 'Los datos del vehicle no son validos. Revisa los campos e intenta otra vez.';
+  }
+
+  if (
+    error instanceof ApiError &&
+    (error.status === 401 || error.status === 403)
+  ) {
+    return 'Tu sesion no tiene acceso para editar vehicles. Vuelve a ingresar e intenta otra vez.';
+  }
+
+  if (error instanceof ApiError && error.status >= 500) {
+    return 'No pudimos guardar el vehicle por un problema del servidor. Intenta nuevamente en unos segundos.';
+  }
+
+  return 'No pudimos guardar el vehicle. Vuelve a intentarlo.';
+}
+
+type UseUpdateVehicleOptions = {
+  onSuccess?: (vehicle: Vehicle) => void;
+};
+
+export function useUpdateVehicle(
+  vehicleId: string,
+  { onSuccess }: UseUpdateVehicleOptions = {},
+) {
+  const { isSubmitting, resetSubmitError, submit, submitError } = useFormSubmit(
+    async (values: VehicleUpdateFormValues) => {
+      const vehicle = await updateVehicle(vehicleId, values);
+
+      onSuccess?.(vehicle);
+
+      return vehicle;
+    },
+    {
+      getErrorMessage: getUpdateVehicleErrorMessage,
+    },
+  );
+
+  return {
+    isSubmitting,
+    resetSubmitError,
+    submitError,
+    updateVehicle: submit,
+  };
+}

--- a/apps/web/features/vehicle/pages/vehicle-edit-page.test.tsx
+++ b/apps/web/features/vehicle/pages/vehicle-edit-page.test.tsx
@@ -1,0 +1,122 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useTransporterVehicles } from '../hooks/use-transporter-vehicles';
+import { useUpdateVehicle } from '../hooks/use-update-vehicle';
+import { VehicleEditPage } from './vehicle-edit-page';
+
+const push = jest.fn();
+const updateVehicle = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push,
+  }),
+}));
+
+jest.mock('../hooks/use-transporter-vehicles', () => ({
+  useTransporterVehicles: jest.fn(),
+}));
+
+jest.mock('../hooks/use-update-vehicle', () => ({
+  useUpdateVehicle: jest.fn(),
+}));
+
+const mockedUseTransporterVehicles = jest.mocked(useTransporterVehicles);
+const mockedUseUpdateVehicle = jest.mocked(useUpdateVehicle);
+
+describe('VehicleEditPage', () => {
+  beforeEach(() => {
+    push.mockReset();
+    updateVehicle.mockReset();
+    mockedUseTransporterVehicles.mockReset();
+    mockedUseUpdateVehicle.mockReset();
+  });
+
+  it('renders the loading state while the vehicle list is being resolved', () => {
+    mockedUseTransporterVehicles.mockReturnValue({
+      error: null,
+      refetch: jest.fn(),
+      requestStatus: 'loading',
+      vehicles: [],
+    });
+    mockedUseUpdateVehicle.mockReturnValue({
+      isSubmitting: false,
+      resetSubmitError: jest.fn(),
+      submitError: null,
+      updateVehicle,
+    });
+
+    render(<VehicleEditPage vehicleId="cmavhcl110000wqz5oy7k8v01" />);
+
+    expect(
+      screen.getByRole('heading', {
+        name: /Ajusta un vehicle sin salir del flujo de flota/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Cargando el vehicle seleccionado para editar/i),
+    ).toBeInTheDocument();
+  });
+
+  it('submits the edited vehicle and returns to the fleet hub', async () => {
+    mockedUseTransporterVehicles.mockReturnValue({
+      error: null,
+      refetch: jest.fn(),
+      requestStatus: 'success',
+      vehicles: [
+        {
+          brand: 'Scania',
+          id: 'cmavhcl110000wqz5oy7k8v01',
+          isActive: true,
+          licensePlate: 'AA123BB',
+          model: 'R450',
+        },
+      ],
+    });
+    mockedUseUpdateVehicle.mockImplementation((_vehicleId, options = {}) => ({
+      isSubmitting: false,
+      resetSubmitError: jest.fn(),
+      submitError: null,
+      updateVehicle: jest.fn(async (values) => {
+        updateVehicle(values);
+        options.onSuccess?.({
+          brand: 'Scania',
+          id: 'cmavhcl110000wqz5oy7k8v01',
+          isActive: true,
+          licensePlate: 'AA123BB',
+          model: 'R500',
+        });
+
+        return {
+          brand: 'Scania',
+          id: 'cmavhcl110000wqz5oy7k8v01',
+          isActive: true,
+          licensePlate: 'AA123BB',
+          model: 'R500',
+        };
+      }),
+    }));
+
+    render(<VehicleEditPage vehicleId="cmavhcl110000wqz5oy7k8v01" />);
+
+    const user = userEvent.setup();
+
+    expect(screen.getByDisplayValue('AA123BB')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Scania')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('R450')).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText(/Modelo/i));
+    await user.type(screen.getByLabelText(/Modelo/i), 'R500');
+    await user.click(screen.getByRole('button', { name: /Guardar cambios/i }));
+
+    expect(updateVehicle).toHaveBeenCalledWith({
+      brand: 'Scania',
+      licensePlate: 'AA123BB',
+      model: 'R500',
+    });
+    expect(push).toHaveBeenCalledWith('/vehicles');
+  });
+});

--- a/apps/web/features/vehicle/pages/vehicle-edit-page.tsx
+++ b/apps/web/features/vehicle/pages/vehicle-edit-page.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { VehicleEditForm } from '../components/vehicle-edit-form';
+import { useTransporterVehicles } from '../hooks/use-transporter-vehicles';
+
+type VehicleEditPageProps = {
+  vehicleId: string;
+};
+
+function LoadingPanel() {
+  return (
+    <div className="rounded-[1.6rem] border border-dashed border-border/70 bg-panel/45 p-5">
+      <p className="text-sm leading-6 text-muted">
+        Cargando el vehicle seleccionado para editar.
+      </p>
+    </div>
+  );
+}
+
+function ErrorPanel({ message }: { message: string }) {
+  return (
+    <div className="rounded-[1.6rem] border border-destructive/20 bg-[rgba(177,88,63,0.06)] p-5">
+      <h2 className="text-base font-semibold text-foreground">
+        No pudimos abrir este vehicle
+      </h2>
+      <p className="mt-2 text-sm leading-6 text-muted">{message}</p>
+      <Link
+        className="mt-4 inline-flex min-h-12 items-center justify-center rounded-[1.25rem] bg-primary/5 px-4 py-3 text-sm font-semibold text-foreground transition hover:bg-primary/8"
+        href="/vehicles"
+      >
+        Volver a la flota
+      </Link>
+    </div>
+  );
+}
+
+export function VehicleEditPage({ vehicleId }: VehicleEditPageProps) {
+  const { error, requestStatus, vehicles } = useTransporterVehicles();
+  const vehicle = vehicles.find((item) => item.id === vehicleId) ?? null;
+
+  return (
+    <main className="relative min-h-screen overflow-hidden bg-[linear-gradient(180deg,#eef4ef_0%,#e7efe7_46%,#d9e4da_100%)] px-6 py-10">
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+        <div className="absolute left-[-4rem] top-[-5rem] size-[18rem] rounded-full bg-[#c7ddd6]/50 blur-3xl" />
+        <div className="absolute right-[-5rem] top-[7rem] size-[15rem] rounded-full bg-[#f0d3ad]/42 blur-3xl" />
+        <div className="absolute bottom-[-8rem] left-[22%] size-[16rem] rounded-full bg-[#dbe9d6]/55 blur-3xl" />
+      </div>
+
+      <div className="relative mx-auto w-full max-w-6xl space-y-6">
+        <section className="grid gap-6 xl:grid-cols-[1.08fr_0.92fr]">
+          <Card className="overflow-hidden border-white/35 bg-[linear-gradient(160deg,#153f31_0%,#102d24_46%,#0b1b16_100%)] p-8 text-primary-foreground shadow-[0_28px_60px_rgba(16,39,33,0.18)]">
+            <CardHeader className="space-y-5">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-foreground/88">
+                  Fleet actions
+                </span>
+                <span className="rounded-full border border-white/10 bg-[rgba(255,255,255,0.08)] px-4 py-2 text-sm font-semibold text-primary-foreground/88">
+                  Edicion dedicada de vehicle
+                </span>
+              </div>
+
+              <div className="space-y-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-primary-foreground/62">
+                  Area protegida del transportista
+                </p>
+                <h1 className="max-w-3xl font-heading text-4xl font-semibold leading-tight text-primary-foreground sm:text-[2.9rem]">
+                  Ajusta un vehicle sin salir del flujo de flota
+                </h1>
+                <CardDescription className="max-w-2xl text-base leading-7 text-primary-foreground/76">
+                  La edicion sigue el mismo contrato del backend E3 y vuelve al
+                  hub una vez que los cambios se guardan correctamente.
+                </CardDescription>
+              </div>
+            </CardHeader>
+
+            <CardContent className="mt-8 grid gap-3 sm:grid-cols-2">
+              <article className="rounded-[1.6rem] border border-white/10 bg-[rgba(10,26,22,0.52)] px-4 py-4">
+                <h2 className="text-sm font-semibold text-primary-foreground">
+                  Fuente de verdad del servidor
+                </h2>
+                <p className="mt-2 text-sm leading-6 text-primary-foreground/76">
+                  Abrimos el vehicle desde el listado autenticado y dejamos que
+                  la flota vuelva a consultar al backend cuando regreses.
+                </p>
+              </article>
+
+              <article className="rounded-[1.6rem] border border-white/10 bg-[rgba(10,26,22,0.52)] px-4 py-4">
+                <h2 className="text-sm font-semibold text-primary-foreground">
+                  Mismo contrato de validacion
+                </h2>
+                <p className="mt-2 text-sm leading-6 text-primary-foreground/76">
+                  El formulario usa `UpdateVehicleSchema`, asi que frontend y
+                  backend se mantienen alineados.
+                </p>
+              </article>
+            </CardContent>
+          </Card>
+
+          <Card className="border-white/70 bg-white/84 p-7 shadow-[0_18px_40px_rgba(21,40,33,0.08)] backdrop-blur">
+            <CardHeader className="space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                Antes de guardar
+              </p>
+              <CardTitle className="text-[2rem]">
+                Revisa la base del vehicle
+              </CardTitle>
+              <CardDescription className="text-base leading-7">
+                Esta vista mantiene el alcance acotado a patente, marca y modelo
+                para no mezclar la edicion con reglas de negocio posteriores.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent className="space-y-4">
+              <div className="rounded-[1.5rem] border border-border/70 bg-panel/70 px-5 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                  Flujo incluido
+                </p>
+                <p className="mt-2 text-sm leading-6 text-foreground/78">
+                  Carga del vehicle, validaciones compartidas, guardado con
+                  PATCH y retorno al hub de flota.
+                </p>
+              </div>
+
+              <Link
+                className="inline-flex min-h-14 items-center justify-center rounded-[1.4rem] bg-primary/5 px-5 py-3 text-[15px] font-semibold text-foreground transition hover:bg-primary/8"
+                href="/vehicles"
+              >
+                Volver a la flota
+              </Link>
+            </CardContent>
+          </Card>
+        </section>
+
+        {requestStatus === 'loading' ? <LoadingPanel /> : null}
+        {requestStatus === 'error' ? (
+          <ErrorPanel
+            message={error ?? 'No pudimos cargar el listado de vehicles.'}
+          />
+        ) : null}
+        {requestStatus === 'success' && !vehicle ? (
+          <ErrorPanel message="No encontramos el vehicle seleccionado dentro de tu flota." />
+        ) : null}
+        {requestStatus === 'success' && vehicle ? (
+          <VehicleEditForm vehicle={vehicle} />
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/features/vehicle/pages/vehicle-fleet-page.test.tsx
+++ b/apps/web/features/vehicle/pages/vehicle-fleet-page.test.tsx
@@ -2,9 +2,15 @@
 
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useDeactivateVehicle } from '../hooks/use-deactivate-vehicle';
 import { useTransporterTrailers } from '../hooks/use-transporter-trailers';
 import { useTransporterVehicles } from '../hooks/use-transporter-vehicles';
 import VehicleFleetPage from './vehicle-fleet-page';
+
+jest.mock('../hooks/use-deactivate-vehicle', () => ({
+  useDeactivateVehicle: jest.fn(),
+}));
 
 jest.mock('../hooks/use-transporter-vehicles', () => ({
   useTransporterVehicles: jest.fn(),
@@ -16,11 +22,14 @@ jest.mock('../hooks/use-transporter-trailers', () => ({
 
 const mockedUseTransporterVehicles = jest.mocked(useTransporterVehicles);
 const mockedUseTransporterTrailers = jest.mocked(useTransporterTrailers);
+const mockedUseDeactivateVehicle = jest.mocked(useDeactivateVehicle);
 
 describe('VehicleFleetPage', () => {
   beforeEach(() => {
     mockedUseTransporterVehicles.mockReset();
     mockedUseTransporterTrailers.mockReset();
+    mockedUseDeactivateVehicle.mockReset();
+    window.confirm = jest.fn().mockReturnValue(true);
   });
 
   it('renders the loading state for both fleet sections', () => {
@@ -29,6 +38,12 @@ describe('VehicleFleetPage', () => {
       refetch: jest.fn(),
       requestStatus: 'loading',
       vehicles: [],
+    });
+    mockedUseDeactivateVehicle.mockReturnValue({
+      deactivateVehicle: jest.fn(),
+      isSubmitting: false,
+      resetSubmitError: jest.fn(),
+      submitError: null,
     });
     mockedUseTransporterTrailers.mockReturnValue({
       error: null,
@@ -52,9 +67,11 @@ describe('VehicleFleetPage', () => {
   });
 
   it('renders the vehicles and trailers lists independently', () => {
+    const refetchVehicles = jest.fn();
+
     mockedUseTransporterVehicles.mockReturnValue({
       error: null,
-      refetch: jest.fn(),
+      refetch: refetchVehicles,
       requestStatus: 'success',
       vehicles: [
         {
@@ -65,6 +82,18 @@ describe('VehicleFleetPage', () => {
           model: 'R450',
         },
       ],
+    });
+    mockedUseDeactivateVehicle.mockReturnValue({
+      deactivateVehicle: jest.fn().mockResolvedValue({
+        brand: 'Scania',
+        id: 'cmavhcl110000wqz5oy7k8v01',
+        isActive: false,
+        licensePlate: 'AA123BB',
+        model: 'R450',
+      }),
+      isSubmitting: false,
+      resetSubmitError: jest.fn(),
+      submitError: null,
     });
     mockedUseTransporterTrailers.mockReturnValue({
       error: null,
@@ -85,7 +114,61 @@ describe('VehicleFleetPage', () => {
 
     expect(screen.getByText('AA123BB')).toBeInTheDocument();
     expect(screen.getByText(/Scania R450/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Editar/i })).toHaveAttribute(
+      'href',
+      '/vehicles/cmavhcl110000wqz5oy7k8v01/edit',
+    );
     expect(screen.getByText('12 slot')).toBeInTheDocument();
     expect(screen.getByText(/Equino/i)).toBeInTheDocument();
+  });
+
+  it('deactivates a vehicle from the fleet list and refetches the section', async () => {
+    const deactivateVehicle = jest.fn().mockResolvedValue({
+      brand: 'Scania',
+      id: 'cmavhcl110000wqz5oy7k8v01',
+      isActive: false,
+      licensePlate: 'AA123BB',
+      model: 'R450',
+    });
+    const refetchVehicles = jest.fn().mockResolvedValue(undefined);
+
+    mockedUseTransporterVehicles.mockReturnValue({
+      error: null,
+      refetch: refetchVehicles,
+      requestStatus: 'success',
+      vehicles: [
+        {
+          brand: 'Scania',
+          id: 'cmavhcl110000wqz5oy7k8v01',
+          isActive: true,
+          licensePlate: 'AA123BB',
+          model: 'R450',
+        },
+      ],
+    });
+    mockedUseDeactivateVehicle.mockReturnValue({
+      deactivateVehicle,
+      isSubmitting: false,
+      resetSubmitError: jest.fn(),
+      submitError: null,
+    });
+    mockedUseTransporterTrailers.mockReturnValue({
+      error: null,
+      refetch: jest.fn(),
+      requestStatus: 'success',
+      trailers: [],
+    });
+
+    render(<VehicleFleetPage />);
+
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: /Desactivar/i }));
+
+    expect(window.confirm).toHaveBeenCalledWith(
+      expect.stringContaining('AA123BB'),
+    );
+    expect(deactivateVehicle).toHaveBeenCalledWith('cmavhcl110000wqz5oy7k8v01');
+    expect(refetchVehicles).toHaveBeenCalled();
   });
 });

--- a/apps/web/features/vehicle/pages/vehicle-fleet-page.tsx
+++ b/apps/web/features/vehicle/pages/vehicle-fleet-page.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import Link from 'next/link';
-import type { ReactNode } from 'react';
-import { Button } from '@/components/ui/button';
 import {
   Card,
   CardContent,
@@ -10,245 +8,10 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { useTransporterTrailers } from '../hooks/use-transporter-trailers';
-import { useTransporterVehicles } from '../hooks/use-transporter-vehicles';
-import type {
-  TransporterTrailer,
-  TransporterVehicle,
-} from '../types/fleet.types';
-
-const CARGO_TYPE_LABELS: Record<TransporterTrailer['cargoType'], string> = {
-  EQUINE: 'Equino',
-  FOOD: 'Alimentos',
-  GENERAL_CARGO: 'Carga general',
-  PEOPLE: 'Personas',
-};
-
-const CAPACITY_UNIT_LABELS: Record<TransporterTrailer['capacityUnit'], string> =
-  {
-    KG: 'kg',
-    M3: 'm3',
-    SEAT: 'asiento',
-    SLOT: 'slot',
-  };
-
-function getVehicleStatusLabel(isActive: boolean): string {
-  return isActive ? 'Activa' : 'Inactiva';
-}
-
-function getTrailerStatusLabel(isActive: boolean): string {
-  return isActive ? 'Activo' : 'Inactivo';
-}
-
-function LoadingStateCard({
-  description,
-  title,
-}: {
-  description: string;
-  title: string;
-}) {
-  return (
-    <div className="space-y-4 rounded-[1.6rem] border border-dashed border-border/70 bg-panel/45 p-5 animate-pulse">
-      <div className="space-y-2">
-        <div className="h-5 w-44 rounded-full bg-primary/8" />
-        <div className="h-4 w-80 max-w-full rounded-full bg-primary/5" />
-      </div>
-      <div className="space-y-3">
-        <div className="h-14 rounded-[1.2rem] bg-black/4" />
-        <div className="h-14 rounded-[1.2rem] bg-black/4" />
-      </div>
-      <p className="text-sm leading-6 text-muted">
-        {title}. {description}
-      </p>
-    </div>
-  );
-}
-
-function EmptyStateCard({
-  actionHref,
-  actionLabel,
-  description,
-  title,
-}: {
-  actionHref?: string;
-  actionLabel?: string;
-  description: string;
-  title: string;
-}) {
-  return (
-    <div className="rounded-[1.6rem] border border-border/70 bg-panel/55 p-5">
-      <h3 className="text-base font-semibold text-foreground">{title}</h3>
-      <p className="mt-2 text-sm leading-6 text-muted">{description}</p>
-      {actionHref && actionLabel ? (
-        <Link
-          className="mt-4 inline-flex min-h-12 items-center justify-center rounded-[1.25rem] bg-primary/5 px-4 py-3 text-sm font-semibold text-foreground transition hover:bg-primary/8"
-          href={actionHref}
-        >
-          {actionLabel}
-        </Link>
-      ) : null}
-    </div>
-  );
-}
-
-function ErrorStateCard({
-  description,
-  onRetry,
-  title,
-}: {
-  description: string;
-  onRetry: () => void;
-  title: string;
-}) {
-  return (
-    <div className="rounded-[1.6rem] border border-destructive/20 bg-[rgba(177,88,63,0.06)] p-5">
-      <h3 className="text-base font-semibold text-foreground">{title}</h3>
-      <p className="mt-2 text-sm leading-6 text-muted">{description}</p>
-      <Button
-        className="mt-4 max-w-[12rem]"
-        onClick={onRetry}
-        type="button"
-        variant="ghost"
-      >
-        Reintentar
-      </Button>
-    </div>
-  );
-}
-
-function FleetSectionShell({
-  description,
-  eyebrow,
-  title,
-  children,
-}: {
-  children: ReactNode;
-  description: string;
-  eyebrow: string;
-  title: string;
-}) {
-  return (
-    <Card className="overflow-hidden border-white/75 bg-white/86 shadow-[0_18px_40px_rgba(21,40,33,0.08)] backdrop-blur">
-      <CardHeader className="space-y-3 px-7 pt-7">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
-          {eyebrow}
-        </p>
-        <CardTitle className="text-[2rem]">{title}</CardTitle>
-        <CardDescription className="text-base leading-7">
-          {description}
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="px-7 pb-7">{children}</CardContent>
-    </Card>
-  );
-}
-
-function VehiclesList({ vehicles }: { vehicles: TransporterVehicle[] }) {
-  return (
-    <div className="overflow-hidden rounded-[1.6rem] border border-border/70">
-      <div className="grid grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_auto] gap-4 border-b border-border/70 bg-panel/80 px-5 py-4 text-sm font-semibold text-muted">
-        <span>Patente</span>
-        <span>Marca y modelo</span>
-        <span className="text-right">Estado</span>
-      </div>
-
-      <div className="divide-y divide-border/60 bg-white/55">
-        {vehicles.map((vehicle) => (
-          <div
-            className="grid grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_auto] gap-4 px-5 py-4 text-sm text-foreground"
-            key={vehicle.id}
-          >
-            <div className="min-w-0">
-              <p className="truncate text-base font-semibold text-foreground">
-                {vehicle.licensePlate}
-              </p>
-              <p className="mt-1 text-sm leading-6 text-muted">
-                Vehicle activo de la flota.
-              </p>
-            </div>
-
-            <div className="min-w-0">
-              <p className="truncate text-sm font-medium text-foreground">
-                {vehicle.brand} {vehicle.model}
-              </p>
-              <p className="mt-1 text-sm leading-6 text-muted">
-                Marca y modelo cargados.
-              </p>
-            </div>
-
-            <div className="flex items-center justify-end">
-              <span className="inline-flex rounded-full border border-border/70 bg-primary/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-foreground/80">
-                {getVehicleStatusLabel(vehicle.isActive)}
-              </span>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function TrailersList({ trailers }: { trailers: TransporterTrailer[] }) {
-  return (
-    <div className="overflow-hidden rounded-[1.6rem] border border-border/70">
-      <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-4 border-b border-border/70 bg-panel/80 px-5 py-4 text-sm font-semibold text-muted">
-        <span>Capacidad</span>
-        <span>Rubro y unidad</span>
-        <span className="text-right">Estado</span>
-      </div>
-
-      <div className="divide-y divide-border/60 bg-white/55">
-        {trailers.map((trailer) => (
-          <div
-            className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-4 px-5 py-4 text-sm text-foreground"
-            key={trailer.id}
-          >
-            <div className="min-w-0">
-              <p className="truncate text-base font-semibold text-foreground">
-                {trailer.totalCapacity}{' '}
-                {CAPACITY_UNIT_LABELS[trailer.capacityUnit]}
-              </p>
-              <p className="mt-1 text-sm leading-6 text-muted">
-                Capacidad total declarada.
-              </p>
-            </div>
-
-            <div className="min-w-0">
-              <p className="truncate text-sm font-medium text-foreground">
-                {CARGO_TYPE_LABELS[trailer.cargoType]}
-              </p>
-              <p className="mt-1 text-sm leading-6 text-muted">
-                Unidad de capacidad:{' '}
-                {CAPACITY_UNIT_LABELS[trailer.capacityUnit]}.
-              </p>
-            </div>
-
-            <div className="flex items-center justify-end">
-              <span className="inline-flex rounded-full border border-border/70 bg-primary/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-foreground/80">
-                {getTrailerStatusLabel(trailer.isActive)}
-              </span>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
+import { TrailerFleetSection } from '../components/trailer-fleet-section';
+import { VehicleFleetSection } from '../components/vehicle-fleet-section';
 
 export default function VehicleFleetPage() {
-  const {
-    error: vehiclesError,
-    refetch: refetchVehicles,
-    requestStatus: vehiclesStatus,
-    vehicles,
-  } = useTransporterVehicles();
-  const {
-    error: trailersError,
-    refetch: refetchTrailers,
-    requestStatus: trailersStatus,
-    trailers,
-  } = useTransporterTrailers();
-
   return (
     <main className="relative min-h-screen overflow-hidden bg-[linear-gradient(180deg,#eff4ef_0%,#e7efe7_44%,#d9e4da_100%)] px-6 py-10">
       <div aria-hidden="true" className="pointer-events-none absolute inset-0">
@@ -305,10 +68,10 @@ export default function VehicleFleetPage() {
 
               <article className="rounded-[1.6rem] border border-white/10 bg-[rgba(10,26,22,0.52)] px-4 py-4">
                 <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-primary-foreground/58">
-                  Acceso rapido
+                  Acciones
                 </p>
                 <p className="mt-2 text-sm font-semibold leading-6 text-primary-foreground">
-                  Entradas claras para administrar la flota
+                  Editar y desactivar vehicles desde el listado
                 </p>
               </article>
             </CardContent>
@@ -323,8 +86,8 @@ export default function VehicleFleetPage() {
                 Entrada principal de gestion
               </CardTitle>
               <CardDescription className="text-base leading-7">
-                Desde aca tenes la vista general de la flota y el acceso al alta
-                minima cuando necesites registrar un vehicle nuevo.
+                Desde aca tenes la vista general de la flota, el acceso al alta
+                minima y ahora tambien el patron base de edicion para vehicles.
               </CardDescription>
             </CardHeader>
 
@@ -348,8 +111,9 @@ export default function VehicleFleetPage() {
                   Lo que cambia
                 </p>
                 <p className="mt-2 text-sm leading-6 text-foreground/78">
-                  La pagina separa vehicles y trailers visualmente y ya trabaja
-                  contra el backend real en lugar de mockear datos.
+                  La pagina mantiene separados vehicles y trailers, pero ahora
+                  fija un patron escalable: acciones inline para operar la flota
+                  y una ruta dedicada para editar.
                 </p>
               </div>
             </CardContent>
@@ -357,71 +121,8 @@ export default function VehicleFleetPage() {
         </section>
 
         <section className="grid gap-6 lg:grid-cols-2">
-          <FleetSectionShell
-            description="Listado operativo de vehicles propios, con estado y datos base para navegar la flota."
-            eyebrow="Vehicles"
-            title="Vehiculos cargados"
-          >
-            {vehiclesStatus === 'loading' ? (
-              <LoadingStateCard
-                description="Estamos consultando el estado actual de los vehicles del transportista."
-                title="Cargando vehicles"
-              />
-            ) : null}
-
-            {vehiclesStatus === 'error' ? (
-              <ErrorStateCard
-                description={vehiclesError ?? 'No pudimos cargar los vehicles.'}
-                onRetry={refetchVehicles}
-                title="No pudimos cargar vehicles"
-              />
-            ) : null}
-
-            {vehiclesStatus === 'success' && vehicles.length === 0 ? (
-              <EmptyStateCard
-                actionHref="/vehicles/new"
-                actionLabel="Registrar vehicle"
-                description="Aun no hay vehicles cargados para esta cuenta."
-                title="No encontramos vehicles"
-              />
-            ) : null}
-
-            {vehiclesStatus === 'success' && vehicles.length > 0 ? (
-              <VehiclesList vehicles={vehicles} />
-            ) : null}
-          </FleetSectionShell>
-
-          <FleetSectionShell
-            description="Trailers visibles desde el backend real, separados para leer capacidad y rubro sin mezclar con vehicles."
-            eyebrow="Trailers"
-            title="Trailers cargados"
-          >
-            {trailersStatus === 'loading' ? (
-              <LoadingStateCard
-                description="Estamos consultando el estado actual de los trailers del transportista."
-                title="Cargando trailers"
-              />
-            ) : null}
-
-            {trailersStatus === 'error' ? (
-              <ErrorStateCard
-                description={trailersError ?? 'No pudimos cargar los trailers.'}
-                onRetry={refetchTrailers}
-                title="No pudimos cargar trailers"
-              />
-            ) : null}
-
-            {trailersStatus === 'success' && trailers.length === 0 ? (
-              <EmptyStateCard
-                description="Aun no hay trailers cargados para esta cuenta."
-                title="No encontramos trailers"
-              />
-            ) : null}
-
-            {trailersStatus === 'success' && trailers.length > 0 ? (
-              <TrailersList trailers={trailers} />
-            ) : null}
-          </FleetSectionShell>
+          <VehicleFleetSection />
+          <TrailerFleetSection />
         </section>
       </div>
     </main>

--- a/apps/web/features/vehicle/services/deactivate-vehicle-api.test.ts
+++ b/apps/web/features/vehicle/services/deactivate-vehicle-api.test.ts
@@ -1,0 +1,90 @@
+import { deactivateVehicle } from './deactivate-vehicle-api';
+
+jest.mock('@/features/auth/services/session/access-token-store', () => ({
+  getAccessToken: jest.fn(),
+}));
+
+const { getAccessToken } = jest.requireMock(
+  '@/features/auth/services/session/access-token-store',
+) as {
+  getAccessToken: jest.Mock;
+};
+
+describe('deactivateVehicle', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3001';
+    getAccessToken.mockReturnValue('access-token-value');
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+    delete process.env.NEXT_PUBLIC_API_URL;
+  });
+
+  it('patches the deactivate endpoint and returns the parsed response', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          brand: 'Scania',
+          id: 'cmavhcl110000wqz5oy7k8v01',
+          isActive: false,
+          licensePlate: 'AA123BB',
+          model: 'R450',
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      deactivateVehicle('cmavhcl110000wqz5oy7k8v01'),
+    ).resolves.toMatchObject({
+      id: 'cmavhcl110000wqz5oy7k8v01',
+      isActive: false,
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:3001/vehicles/cmavhcl110000wqz5oy7k8v01/deactivate',
+      expect.objectContaining({
+        credentials: 'include',
+        headers: expect.any(Headers),
+        method: 'PATCH',
+      }),
+    );
+
+    const [, requestInit] = (global.fetch as jest.Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const headers = requestInit.headers as Headers;
+
+    expect(headers.get('Authorization')).toBe('Bearer access-token-value');
+  });
+
+  it('throws when the backend responds with an invalid vehicle payload', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          deactivated: true,
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      deactivateVehicle('cmavhcl110000wqz5oy7k8v01'),
+    ).rejects.toThrow('payload invalido');
+  });
+});

--- a/apps/web/features/vehicle/services/deactivate-vehicle-api.ts
+++ b/apps/web/features/vehicle/services/deactivate-vehicle-api.ts
@@ -1,0 +1,34 @@
+import { apiClient } from '@/src/lib/api';
+import { getAccessToken } from '@/features/auth/services/session/access-token-store';
+import { VehicleViewSchema, type Vehicle } from '../types/vehicle.types';
+
+const INVALID_DEACTIVATE_VEHICLE_RESPONSE_MESSAGE =
+  'La API respondio con un payload invalido para PATCH /vehicles/:id/deactivate.';
+
+function buildAuthorizationHeaders(
+  accessToken: string | null,
+): HeadersInit | undefined {
+  if (!accessToken) {
+    return undefined;
+  }
+
+  return {
+    Authorization: `Bearer ${accessToken}`,
+  };
+}
+
+export async function deactivateVehicle(vehicleId: string): Promise<Vehicle> {
+  const response = await apiClient.patch<unknown>(
+    `/vehicles/${vehicleId}/deactivate`,
+    {
+      headers: buildAuthorizationHeaders(getAccessToken()),
+    },
+  );
+  const parsed = VehicleViewSchema.safeParse(response.data);
+
+  if (!parsed.success) {
+    throw new Error(INVALID_DEACTIVATE_VEHICLE_RESPONSE_MESSAGE);
+  }
+
+  return parsed.data;
+}

--- a/apps/web/features/vehicle/services/update-vehicle-api.test.ts
+++ b/apps/web/features/vehicle/services/update-vehicle-api.test.ts
@@ -1,0 +1,97 @@
+import { updateVehicle } from './update-vehicle-api';
+
+jest.mock('@/features/auth/services/session/access-token-store', () => ({
+  getAccessToken: jest.fn(),
+}));
+
+const { getAccessToken } = jest.requireMock(
+  '@/features/auth/services/session/access-token-store',
+) as {
+  getAccessToken: jest.Mock;
+};
+
+describe('updateVehicle', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3001';
+    getAccessToken.mockReturnValue('access-token-value');
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+    delete process.env.NEXT_PUBLIC_API_URL;
+  });
+
+  it('patches the vehicle payload and returns the parsed response', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          brand: 'Scania',
+          id: 'cmavhcl110000wqz5oy7k8v01',
+          isActive: true,
+          licensePlate: 'AA123BB',
+          model: 'R500',
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      updateVehicle('cmavhcl110000wqz5oy7k8v01', {
+        model: 'R500',
+      }),
+    ).resolves.toMatchObject({
+      id: 'cmavhcl110000wqz5oy7k8v01',
+      model: 'R500',
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:3001/vehicles/cmavhcl110000wqz5oy7k8v01',
+      expect.objectContaining({
+        body: JSON.stringify({
+          model: 'R500',
+        }),
+        credentials: 'include',
+        headers: expect.any(Headers),
+        method: 'PATCH',
+      }),
+    );
+
+    const [, requestInit] = (global.fetch as jest.Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const headers = requestInit.headers as Headers;
+
+    expect(headers.get('Authorization')).toBe('Bearer access-token-value');
+  });
+
+  it('throws when the backend responds with an invalid vehicle payload', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          updated: true,
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      updateVehicle('cmavhcl110000wqz5oy7k8v01', {
+        brand: 'Scania',
+      }),
+    ).rejects.toThrow('payload invalido');
+  });
+});

--- a/apps/web/features/vehicle/services/update-vehicle-api.ts
+++ b/apps/web/features/vehicle/services/update-vehicle-api.ts
@@ -1,0 +1,36 @@
+import { type UpdateVehicleDto } from '@logistica/shared';
+import { apiClient } from '@/src/lib/api';
+import { getAccessToken } from '@/features/auth/services/session/access-token-store';
+import { VehicleViewSchema, type Vehicle } from '../types/vehicle.types';
+
+const INVALID_UPDATE_VEHICLE_RESPONSE_MESSAGE =
+  'La API respondio con un payload invalido para PATCH /vehicles/:id.';
+
+function buildAuthorizationHeaders(
+  accessToken: string | null,
+): HeadersInit | undefined {
+  if (!accessToken) {
+    return undefined;
+  }
+
+  return {
+    Authorization: `Bearer ${accessToken}`,
+  };
+}
+
+export async function updateVehicle(
+  vehicleId: string,
+  dto: UpdateVehicleDto,
+): Promise<Vehicle> {
+  const response = await apiClient.patch<unknown>(`/vehicles/${vehicleId}`, {
+    body: dto,
+    headers: buildAuthorizationHeaders(getAccessToken()),
+  });
+  const parsed = VehicleViewSchema.safeParse(response.data);
+
+  if (!parsed.success) {
+    throw new Error(INVALID_UPDATE_VEHICLE_RESPONSE_MESSAGE);
+  }
+
+  return parsed.data;
+}

--- a/apps/web/features/vehicle/types/vehicle.types.ts
+++ b/apps/web/features/vehicle/types/vehicle.types.ts
@@ -1,10 +1,12 @@
 import {
   type CreateVehicleDto,
+  type UpdateVehicleDto,
   type IVehicleView,
   VehicleViewSchema,
-} from "@logistica/shared";
+} from '@logistica/shared';
 
 export type Vehicle = IVehicleView;
 export type VehicleFormValues = CreateVehicleDto;
+export type VehicleUpdateFormValues = UpdateVehicleDto;
 
 export { VehicleViewSchema };


### PR DESCRIPTION
## Contexto
- implementa la issue #111 de E3 frontend
- fija el patron base de mutacion UI para `vehicle` antes de replicarlo en trailers
- parte del `develop` donde ya existe el fleet hub de #109

## Alcance
- agrega ruta dedicada de edicion `/vehicles/[id]/edit`
- agrega acciones inline de `Editar` y `Desactivar` en la seccion de vehicles
- separa el fleet hub en componentes mas chicos para escalar la flota sin seguir creciendo un unico archivo
- suma services y hooks de `update vehicle` y `deactivate vehicle`
- agrega tests focalizados para services y flujo UI de flota/edicion

## Patrones y estructura
- vertical slices por feature: `components/`, `hooks/`, `pages/`, `services/`, `types/`
- split query/mutation
- App Router con `page.tsx` minima
- `UpdateVehicleSchema` como contrato compartido con backend
- server truth after mutation: volver/refetch en lugar de optimistic UI

## Riesgos
- `pnpm --filter @logistica/web typecheck` sigue frenado por un baseline fuera de scope en `apps/web/tailwind.config.ts` (`Cannot find module 'tailwindcss'`)
- `pnpm --filter @logistica/web lint` sigue frenado por un `EPERM` de Next al leer dependencias dentro de `node_modules` en la worktree

## Como testear
- entrar a `/vehicles`
- verificar que cada vehicle tenga acciones `Editar` y `Desactivar`
- entrar a `/vehicles/[id]/edit`, editar datos base y confirmar retorno al hub
- desactivar un vehicle y verificar refetch de la seccion

## Validacion ejecutada
- `pnpm --filter @logistica/web test -- --runTestsByPath features/vehicle/services/update-vehicle-api.test.ts features/vehicle/services/deactivate-vehicle-api.test.ts features/vehicle/pages/vehicle-edit-page.test.tsx features/vehicle/pages/vehicle-fleet-page.test.tsx`