### PR TITLE
feat(web): add trailer create form

### DIFF
--- a/apps/web/app/(protected)/trailers/layout.tsx
+++ b/apps/web/app/(protected)/trailers/layout.tsx
@@ -1,0 +1,15 @@
+import { AuthRouteGuard } from '@/features/auth/components/guards/auth-route-guard';
+
+type TrailersLayoutProps = {
+  children: React.ReactNode;
+};
+
+const ALLOWED_TRANSPORTER_ROLES = ['TRANSPORTER'] as const;
+
+export default function TrailersLayout({ children }: TrailersLayoutProps) {
+  return (
+    <AuthRouteGuard allowedRoles={ALLOWED_TRANSPORTER_ROLES} mode="protected">
+      {children}
+    </AuthRouteGuard>
+  );
+}

--- a/apps/web/app/(protected)/trailers/new/page.tsx
+++ b/apps/web/app/(protected)/trailers/new/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/features/vehicle/pages/trailer-create-page';

--- a/apps/web/features/vehicle/components/trailer-fleet-section.tsx
+++ b/apps/web/features/vehicle/components/trailer-fleet-section.tsx
@@ -1,6 +1,10 @@
 'use client';
 
 import { useTransporterTrailers } from '../hooks/use-transporter-trailers';
+import {
+  TRAILER_CAPACITY_UNIT_LABELS,
+  TRAILER_CARGO_TYPE_LABELS,
+} from '../config/trailer-option-labels';
 import type { TransporterTrailer } from '../types/fleet.types';
 import {
   EmptyStateCard,
@@ -8,21 +12,6 @@ import {
   FleetSectionShell,
   LoadingStateCard,
 } from './fleet-section-shell';
-
-const CARGO_TYPE_LABELS: Record<TransporterTrailer['cargoType'], string> = {
-  EQUINE: 'Equino',
-  FOOD: 'Alimentos',
-  GENERAL_CARGO: 'Carga general',
-  PEOPLE: 'Personas',
-};
-
-const CAPACITY_UNIT_LABELS: Record<TransporterTrailer['capacityUnit'], string> =
-  {
-    KG: 'kg',
-    M3: 'm3',
-    SEAT: 'asiento',
-    SLOT: 'slot',
-  };
 
 function getTrailerStatusLabel(isActive: boolean): string {
   return isActive ? 'Activo' : 'Inactivo';
@@ -46,7 +35,7 @@ function TrailersList({ trailers }: { trailers: TransporterTrailer[] }) {
             <div className="min-w-0">
               <p className="truncate text-base font-semibold text-foreground">
                 {trailer.totalCapacity}{' '}
-                {CAPACITY_UNIT_LABELS[trailer.capacityUnit]}
+                {TRAILER_CAPACITY_UNIT_LABELS[trailer.capacityUnit]}
               </p>
               <p className="mt-1 text-sm leading-6 text-muted">
                 Capacidad total declarada.
@@ -55,11 +44,11 @@ function TrailersList({ trailers }: { trailers: TransporterTrailer[] }) {
 
             <div className="min-w-0">
               <p className="truncate text-sm font-medium text-foreground">
-                {CARGO_TYPE_LABELS[trailer.cargoType]}
+                {TRAILER_CARGO_TYPE_LABELS[trailer.cargoType]}
               </p>
               <p className="mt-1 text-sm leading-6 text-muted">
                 Unidad de capacidad:{' '}
-                {CAPACITY_UNIT_LABELS[trailer.capacityUnit]}.
+                {TRAILER_CAPACITY_UNIT_LABELS[trailer.capacityUnit]}.
               </p>
             </div>
 
@@ -106,6 +95,8 @@ export function TrailerFleetSection() {
 
       {trailersStatus === 'success' && trailers.length === 0 ? (
         <EmptyStateCard
+          actionHref="/trailers/new"
+          actionLabel="Registrar trailer"
           description="Aun no hay trailers cargados para esta cuenta."
           title="No encontramos trailers"
         />

--- a/apps/web/features/vehicle/components/trailer-form.test.tsx
+++ b/apps/web/features/vehicle/components/trailer-form.test.tsx
@@ -1,0 +1,116 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useCreateTrailer } from '../hooks/use-create-trailer';
+import type { Trailer, TrailerFormValues } from '../types/trailer.types';
+import { TrailerForm } from './trailer-form';
+
+jest.mock('../hooks/use-create-trailer', () => ({
+  useCreateTrailer: jest.fn(),
+}));
+
+const mockedUseCreateTrailer = jest.mocked(useCreateTrailer);
+type CreateTrailerMock = (values: TrailerFormValues) => Promise<Trailer | null>;
+
+describe('TrailerForm', () => {
+  beforeEach(() => {
+    mockedUseCreateTrailer.mockReset();
+  });
+
+  it('shows client validation feedback and keeps submit disabled for invalid values', async () => {
+    const createTrailer: jest.MockedFunction<CreateTrailerMock> = jest.fn(
+      async (_values: TrailerFormValues) => null,
+    );
+
+    mockedUseCreateTrailer.mockReturnValue({
+      createTrailer,
+      isSubmitting: false,
+      resetSubmitError: jest.fn(),
+      submitError: null,
+    });
+
+    render(<TrailerForm />);
+
+    const user = userEvent.setup();
+    const submitButton = screen.getByRole('button', {
+      name: /Registrar trailer/i,
+    });
+
+    expect(submitButton).toBeDisabled();
+
+    await user.clear(screen.getByLabelText('Capacidad total'));
+    await user.type(screen.getByLabelText('Capacidad total'), '0');
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('La capacidad total debe ser mayor a cero.'),
+      ).toBeInTheDocument();
+    });
+
+    expect(submitButton).toBeDisabled();
+    expect(createTrailer).not.toHaveBeenCalled();
+  });
+
+  it('submits valid values with MVP defaults and shows the created trailer feedback', async () => {
+    const createTrailer: jest.MockedFunction<CreateTrailerMock> = jest.fn(
+      async (_values: TrailerFormValues) => ({
+        capacityUnit: 'SLOT' as const,
+        cargoType: 'EQUINE' as const,
+        id: 'cmavhcl110000wqz5oy7k8v02',
+        isActive: true,
+        totalCapacity: 6,
+      }),
+    );
+
+    mockedUseCreateTrailer.mockReturnValue({
+      createTrailer,
+      isSubmitting: false,
+      resetSubmitError: jest.fn(),
+      submitError: null,
+    });
+
+    render(<TrailerForm />);
+
+    const user = userEvent.setup();
+
+    await user.clear(screen.getByLabelText('Capacidad total'));
+    await user.type(screen.getByLabelText('Capacidad total'), '6');
+
+    await user.click(
+      screen.getByRole('button', { name: /Registrar trailer/i }),
+    );
+
+    await waitFor(() => {
+      expect(createTrailer).toHaveBeenCalledWith({
+        capacityUnit: 'SLOT',
+        cargoType: 'EQUINE',
+        totalCapacity: 6,
+      });
+    });
+
+    expect(
+      await screen.findByText(
+        /Trailer registrado correctamente: 6 slot para Equino./i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('shows loading feedback while the request is in flight', () => {
+    const createTrailer: jest.MockedFunction<CreateTrailerMock> = jest.fn(
+      async (_values: TrailerFormValues) => null,
+    );
+
+    mockedUseCreateTrailer.mockReturnValue({
+      createTrailer,
+      isSubmitting: true,
+      resetSubmitError: jest.fn(),
+      submitError: null,
+    });
+
+    render(<TrailerForm />);
+
+    expect(screen.getByRole('button', { name: /Registrando/i })).toBeDisabled();
+  });
+});

--- a/apps/web/features/vehicle/components/trailer-form.tsx
+++ b/apps/web/features/vehicle/components/trailer-form.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { CreateTrailerSchema } from '@logistica/shared';
+import { useForm } from 'react-hook-form';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import {
+  TRAILER_CAPACITY_UNIT_LABELS,
+  TRAILER_CARGO_TYPE_LABELS,
+} from '../config/trailer-option-labels';
+import { useCreateTrailer } from '../hooks/use-create-trailer';
+import type { Trailer, TrailerFormValues } from '../types/trailer.types';
+
+const DEFAULT_VALUES: TrailerFormValues = {
+  capacityUnit: 'SLOT',
+  cargoType: 'EQUINE',
+  totalCapacity: 4,
+};
+
+export function TrailerForm() {
+  const [createdTrailer, setCreatedTrailer] = useState<Trailer | null>(null);
+  const {
+    formState: { errors, isDirty, isSubmitted, isValid },
+    handleSubmit,
+    register,
+    reset,
+  } = useForm<TrailerFormValues>({
+    defaultValues: DEFAULT_VALUES,
+    mode: 'onChange',
+    resolver: zodResolver(CreateTrailerSchema),
+  });
+  const { createTrailer, isSubmitting, resetSubmitError, submitError } =
+    useCreateTrailer();
+
+  async function onSubmit(values: TrailerFormValues): Promise<void> {
+    setCreatedTrailer(null);
+    resetSubmitError();
+    const trailer = await createTrailer(values);
+
+    if (!trailer) {
+      return;
+    }
+
+    setCreatedTrailer(trailer);
+    reset(DEFAULT_VALUES);
+  }
+
+  const totalCapacityError =
+    isSubmitted || errors.totalCapacity
+      ? errors.totalCapacity?.message
+      : undefined;
+
+  return (
+    <Card className="border-white/75 bg-white/88 p-6 shadow-[0_18px_40px_rgba(21,40,33,0.08)] sm:p-8">
+      <CardHeader className="space-y-3">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.26em] text-muted">
+          Issue #112
+        </p>
+        <CardTitle>Registrar un trailer operativo</CardTitle>
+        <CardDescription className="max-w-2xl text-base leading-7">
+          Esta alta deja visible la capacidad operativa minima del trailer para
+          el MVP, manteniendo alineados frontend y backend con el mismo
+          contrato.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="mt-2">
+        <form
+          className="space-y-6"
+          noValidate
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <input type="hidden" {...register('cargoType')} />
+          <input type="hidden" {...register('capacityUnit')} />
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="space-y-2 md:col-span-2">
+              <label
+                className="text-[13px] font-semibold text-foreground/92"
+                htmlFor="totalCapacity"
+              >
+                Capacidad total
+              </label>
+              <Input
+                disabled={isSubmitting}
+                error={totalCapacityError}
+                id="totalCapacity"
+                min={1}
+                placeholder="Ej: 4"
+                step={1}
+                type="number"
+                {...register('totalCapacity', { valueAsNumber: true })}
+              />
+              <p className="text-sm leading-6 text-muted">
+                Define la cantidad total operativa del trailer para el MVP.
+              </p>
+              {totalCapacityError ? (
+                <p className="text-sm text-destructive/90">
+                  {totalCapacityError}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="rounded-[1.4rem] border border-border/70 bg-panel/70 p-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                Rubro activo en MVP
+              </p>
+              <p className="mt-2 text-base font-semibold text-foreground">
+                {TRAILER_CARGO_TYPE_LABELS[DEFAULT_VALUES.cargoType]}
+              </p>
+              <p className="mt-1 text-sm leading-6 text-muted">
+                Esta alta usa el rubro operativo actual sin abrir seleccion
+                adicional todavia.
+              </p>
+            </div>
+
+            <div className="rounded-[1.4rem] border border-border/70 bg-panel/70 p-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                Unidad activa en MVP
+              </p>
+              <p className="mt-2 text-base font-semibold text-foreground">
+                {TRAILER_CAPACITY_UNIT_LABELS[DEFAULT_VALUES.capacityUnit]}
+              </p>
+              <p className="mt-1 text-sm leading-6 text-muted">
+                La capacidad se expresa en slots para mantener consistencia con
+                el flujo operativo actual.
+              </p>
+            </div>
+          </div>
+
+          {submitError ? (
+            <div
+              aria-live="polite"
+              className="rounded-[1.4rem] border border-destructive/18 bg-[rgba(177,88,63,0.08)] px-4 py-3.5 text-sm leading-6 text-destructive"
+            >
+              {submitError}
+            </div>
+          ) : null}
+
+          {createdTrailer ? (
+            <div
+              aria-live="polite"
+              className="rounded-[1.4rem] border border-primary/20 bg-primary/5 px-4 py-3.5 text-sm leading-6 text-primary"
+            >
+              Trailer registrado correctamente: {createdTrailer.totalCapacity}{' '}
+              {TRAILER_CAPACITY_UNIT_LABELS[createdTrailer.capacityUnit]} para{' '}
+              {TRAILER_CARGO_TYPE_LABELS[createdTrailer.cargoType]}.
+            </div>
+          ) : null}
+
+          <Button
+            disabled={!isDirty || !isValid || isSubmitting}
+            isLoading={isSubmitting}
+            loadingText="Registrando"
+            type="submit"
+          >
+            Registrar trailer
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/features/vehicle/config/trailer-option-labels.ts
+++ b/apps/web/features/vehicle/config/trailer-option-labels.ts
@@ -1,0 +1,21 @@
+import type { TrailerFormValues } from '../types/trailer.types';
+
+export const TRAILER_CARGO_TYPE_LABELS: Record<
+  TrailerFormValues['cargoType'],
+  string
+> = {
+  EQUINE: 'Equino',
+  FOOD: 'Alimentos',
+  GENERAL_CARGO: 'Carga general',
+  PEOPLE: 'Personas',
+};
+
+export const TRAILER_CAPACITY_UNIT_LABELS: Record<
+  TrailerFormValues['capacityUnit'],
+  string
+> = {
+  KG: 'kg',
+  M3: 'm3',
+  SEAT: 'asiento',
+  SLOT: 'slot',
+};

--- a/apps/web/features/vehicle/hooks/use-create-trailer.ts
+++ b/apps/web/features/vehicle/hooks/use-create-trailer.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { ApiError, BadRequestError } from '@/src/lib/api';
+import { useFormSubmit } from '@/src/lib/forms/hooks/useFormSubmit';
+import { createTrailer } from '../services/create-trailer-api';
+import type { Trailer, TrailerFormValues } from '../types/trailer.types';
+
+function getCreateTrailerErrorMessage(error: unknown): string {
+  if (error instanceof BadRequestError) {
+    return 'Los datos del trailer no son validos. Revisa los campos e intenta otra vez.';
+  }
+
+  if (
+    error instanceof ApiError &&
+    (error.status === 401 || error.status === 403)
+  ) {
+    return 'Tu sesion no tiene acceso para registrar trailers. Vuelve a ingresar e intenta otra vez.';
+  }
+
+  if (error instanceof ApiError && error.status >= 500) {
+    return 'No pudimos registrar el trailer por un problema del servidor. Intenta nuevamente en unos segundos.';
+  }
+
+  return 'No pudimos registrar el trailer. Vuelve a intentarlo.';
+}
+
+type UseCreateTrailerOptions = {
+  onSuccess?: (trailer: Trailer) => void;
+};
+
+export function useCreateTrailer({ onSuccess }: UseCreateTrailerOptions = {}) {
+  const { isSubmitting, resetSubmitError, submit, submitError } = useFormSubmit(
+    async (values: TrailerFormValues) => {
+      const trailer = await createTrailer(values);
+
+      onSuccess?.(trailer);
+
+      return trailer;
+    },
+    {
+      getErrorMessage: getCreateTrailerErrorMessage,
+    },
+  );
+
+  return {
+    createTrailer: submit,
+    isSubmitting,
+    resetSubmitError,
+    submitError,
+  };
+}

--- a/apps/web/features/vehicle/pages/trailer-create-page.test.tsx
+++ b/apps/web/features/vehicle/pages/trailer-create-page.test.tsx
@@ -1,0 +1,23 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import TrailerCreatePage from './trailer-create-page';
+
+describe('TrailerCreatePage', () => {
+  it('renders the trailer create content and the return CTA', () => {
+    render(<TrailerCreatePage />);
+
+    expect(
+      screen.getByRole('heading', {
+        name: /Declara la capacidad operativa de tu trailer/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Rubro: Equino. Unidad: slot./i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /Volver a la flota/i }),
+    ).toHaveAttribute('href', '/vehicles');
+  });
+});

--- a/apps/web/features/vehicle/pages/trailer-create-page.tsx
+++ b/apps/web/features/vehicle/pages/trailer-create-page.tsx
@@ -1,0 +1,142 @@
+import Link from 'next/link';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { TrailerForm } from '../components/trailer-form';
+import {
+  TRAILER_CAPACITY_UNIT_LABELS,
+  TRAILER_CARGO_TYPE_LABELS,
+} from '../config/trailer-option-labels';
+
+const MVP_TRAILER_DEFAULTS = {
+  capacityUnit: 'SLOT',
+  cargoType: 'EQUINE',
+} as const;
+
+const setupHighlights = [
+  {
+    description:
+      'El contrato backend ya esta listo para crear un trailer propio del transportista autenticado.',
+    title: 'Integracion real con E3',
+  },
+  {
+    description:
+      'En MVP el alta deja fijo el rubro Equino y la unidad slot para priorizar consistencia operativa.',
+    title: 'Defaults claros del MVP',
+  },
+];
+
+export default function TrailerCreatePage() {
+  return (
+    <main className="relative min-h-screen overflow-hidden bg-[linear-gradient(180deg,#eef4ef_0%,#e7efe7_46%,#d9e4da_100%)] px-6 py-10">
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+        <div className="absolute left-[-4rem] top-[-5rem] size-[18rem] rounded-full bg-[#c7ddd6]/50 blur-3xl" />
+        <div className="absolute right-[-5rem] top-[7rem] size-[15rem] rounded-full bg-[#f0d3ad]/42 blur-3xl" />
+        <div className="absolute bottom-[-8rem] left-[22%] size-[16rem] rounded-full bg-[#dbe9d6]/55 blur-3xl" />
+      </div>
+
+      <div className="relative mx-auto w-full max-w-6xl space-y-6">
+        <section className="grid gap-6 xl:grid-cols-[1.08fr_0.92fr]">
+          <Card className="overflow-hidden border-white/35 bg-[linear-gradient(160deg,#153f31_0%,#102d24_46%,#0b1b16_100%)] p-8 text-primary-foreground shadow-[0_28px_60px_rgba(16,39,33,0.18)]">
+            <CardHeader className="space-y-5">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-foreground/88">
+                  Frontend E3
+                </span>
+                <span className="rounded-full border border-white/10 bg-[rgba(255,255,255,0.08)] px-4 py-2 text-sm font-semibold text-primary-foreground/88">
+                  Alta inicial de trailer
+                </span>
+              </div>
+
+              <div className="space-y-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-primary-foreground/62">
+                  Area protegida del transportista
+                </p>
+                <h1 className="max-w-3xl font-heading text-4xl font-semibold leading-tight text-primary-foreground sm:text-[2.9rem]">
+                  Declara la capacidad operativa de tu trailer
+                </h1>
+                <CardDescription className="max-w-2xl text-base leading-7 text-primary-foreground/76">
+                  Esta vista deja lista el alta inicial del trailer con una
+                  capacidad valida y defaults coherentes con el MVP actual.
+                </CardDescription>
+              </div>
+            </CardHeader>
+
+            <CardContent className="mt-8 grid gap-3 sm:grid-cols-2">
+              {setupHighlights.map((highlight) => (
+                <article
+                  className="rounded-[1.6rem] border border-white/10 bg-[rgba(10,26,22,0.52)] px-4 py-4"
+                  key={highlight.title}
+                >
+                  <h2 className="text-sm font-semibold text-primary-foreground">
+                    {highlight.title}
+                  </h2>
+                  <p className="mt-2 text-sm leading-6 text-primary-foreground/76">
+                    {highlight.description}
+                  </p>
+                </article>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card className="border-white/70 bg-white/84 p-7 shadow-[0_18px_40px_rgba(21,40,33,0.08)] backdrop-blur">
+            <CardHeader className="space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                Antes de guardar
+              </p>
+              <CardTitle className="text-[2rem]">
+                Revisa la configuracion operativa
+              </CardTitle>
+              <CardDescription className="text-base leading-7">
+                Esta alta deja visibles los defaults del MVP para que sepas con
+                que rubro y unidad va a operar el trailer cargado.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent className="space-y-4">
+              <div className="rounded-[1.5rem] border border-border/70 bg-panel/70 px-5 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                  Defaults activos
+                </p>
+                <p className="mt-2 text-sm leading-6 text-foreground/78">
+                  Rubro:{' '}
+                  {TRAILER_CARGO_TYPE_LABELS[MVP_TRAILER_DEFAULTS.cargoType]}.
+                  Unidad:{' '}
+                  {
+                    TRAILER_CAPACITY_UNIT_LABELS[
+                      MVP_TRAILER_DEFAULTS.capacityUnit
+                    ]
+                  }
+                  .
+                </p>
+              </div>
+
+              <div className="rounded-[1.5rem] border border-primary/12 bg-primary/5 px-5 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-primary/70">
+                  Siguiente capa
+                </p>
+                <p className="mt-2 text-sm leading-6 text-foreground/78">
+                  Despues de esta alta, la gestion de trailers en la flota va a
+                  sumar acciones de edicion y desactivacion en la issue #113.
+                </p>
+              </div>
+
+              <Link
+                className="inline-flex min-h-14 items-center justify-center rounded-[1.4rem] bg-primary/5 px-5 py-3 text-[15px] font-semibold text-foreground transition hover:bg-primary/8"
+                href="/vehicles"
+              >
+                Volver a la flota
+              </Link>
+            </CardContent>
+          </Card>
+        </section>
+
+        <TrailerForm />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/features/vehicle/pages/vehicle-fleet-page.test.tsx
+++ b/apps/web/features/vehicle/pages/vehicle-fleet-page.test.tsx
@@ -64,6 +64,9 @@ describe('VehicleFleetPage', () => {
     expect(
       screen.getByRole('link', { name: /Registrar vehicle/i }),
     ).toHaveAttribute('href', '/vehicles/new');
+    expect(
+      screen.getByRole('link', { name: /Registrar trailer/i }),
+    ).toHaveAttribute('href', '/trailers/new');
   });
 
   it('renders the vehicles and trailers lists independently', () => {
@@ -118,6 +121,9 @@ describe('VehicleFleetPage', () => {
       'href',
       '/vehicles/cmavhcl110000wqz5oy7k8v01/edit',
     );
+    expect(
+      screen.getByRole('link', { name: /Registrar trailer/i }),
+    ).toHaveAttribute('href', '/trailers/new');
     expect(screen.getByText('12 slot')).toBeInTheDocument();
     expect(screen.getByText(/Equino/i)).toBeInTheDocument();
   });

--- a/apps/web/features/vehicle/pages/vehicle-fleet-page.tsx
+++ b/apps/web/features/vehicle/pages/vehicle-fleet-page.tsx
@@ -62,7 +62,7 @@ export default function VehicleFleetPage() {
                   Alta disponible
                 </p>
                 <p className="mt-2 text-sm font-semibold leading-6 text-primary-foreground">
-                  Seguimos usando /vehicles/new
+                  Vehicles en /vehicles/new y trailers en /trailers/new
                 </p>
               </article>
 
@@ -97,6 +97,13 @@ export default function VehicleFleetPage() {
                 href="/vehicles/new"
               >
                 Registrar vehicle
+              </Link>
+
+              <Link
+                className="inline-flex min-h-14 items-center justify-center rounded-[1.4rem] bg-primary/5 px-5 py-3 text-[15px] font-semibold text-foreground transition hover:bg-primary/8"
+                href="/trailers/new"
+              >
+                Registrar trailer
               </Link>
 
               <Link

--- a/apps/web/features/vehicle/services/create-trailer-api.test.ts
+++ b/apps/web/features/vehicle/services/create-trailer-api.test.ts
@@ -1,0 +1,103 @@
+import { createTrailer } from './create-trailer-api';
+
+jest.mock('@/features/auth/services/session/access-token-store', () => ({
+  getAccessToken: jest.fn(),
+}));
+
+const { getAccessToken } = jest.requireMock(
+  '@/features/auth/services/session/access-token-store',
+) as {
+  getAccessToken: jest.Mock;
+};
+
+describe('createTrailer', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3001';
+    getAccessToken.mockReturnValue('access-token-value');
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+    delete process.env.NEXT_PUBLIC_API_URL;
+  });
+
+  it('posts the trailer payload and returns the parsed response', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          capacityUnit: 'SLOT',
+          cargoType: 'EQUINE',
+          id: 'cmavhcl110000wqz5oy7k8v02',
+          isActive: true,
+          totalCapacity: 4,
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 201,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      createTrailer({
+        capacityUnit: 'SLOT',
+        cargoType: 'EQUINE',
+        totalCapacity: 4,
+      }),
+    ).resolves.toMatchObject({
+      id: 'cmavhcl110000wqz5oy7k8v02',
+      totalCapacity: 4,
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:3001/trailers',
+      expect.objectContaining({
+        body: JSON.stringify({
+          capacityUnit: 'SLOT',
+          cargoType: 'EQUINE',
+          totalCapacity: 4,
+        }),
+        credentials: 'include',
+        headers: expect.any(Headers),
+        method: 'POST',
+      }),
+    );
+
+    const [, requestInit] = (global.fetch as jest.Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const headers = requestInit.headers as Headers;
+
+    expect(headers.get('Authorization')).toBe('Bearer access-token-value');
+  });
+
+  it('throws when the backend responds with an invalid trailer payload', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          created: true,
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 201,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      createTrailer({
+        capacityUnit: 'SLOT',
+        cargoType: 'EQUINE',
+        totalCapacity: 4,
+      }),
+    ).rejects.toThrow('payload invalido');
+  });
+});

--- a/apps/web/features/vehicle/services/create-trailer-api.ts
+++ b/apps/web/features/vehicle/services/create-trailer-api.ts
@@ -1,0 +1,33 @@
+import { type CreateTrailerDto } from '@logistica/shared';
+import { getAccessToken } from '@/features/auth/services/session/access-token-store';
+import { apiClient } from '@/src/lib/api';
+import { TrailerViewSchema, type Trailer } from '../types/trailer.types';
+
+const INVALID_CREATE_TRAILER_RESPONSE_MESSAGE =
+  'La API respondio con un payload invalido para POST /trailers.';
+
+function buildAuthorizationHeaders(
+  accessToken: string | null,
+): HeadersInit | undefined {
+  if (!accessToken) {
+    return undefined;
+  }
+
+  return {
+    Authorization: `Bearer ${accessToken}`,
+  };
+}
+
+export async function createTrailer(dto: CreateTrailerDto): Promise<Trailer> {
+  const response = await apiClient.post<unknown>('/trailers', {
+    body: dto,
+    headers: buildAuthorizationHeaders(getAccessToken()),
+  });
+  const parsed = TrailerViewSchema.safeParse(response.data);
+
+  if (!parsed.success) {
+    throw new Error(INVALID_CREATE_TRAILER_RESPONSE_MESSAGE);
+  }
+
+  return parsed.data;
+}

--- a/apps/web/features/vehicle/types/trailer.types.ts
+++ b/apps/web/features/vehicle/types/trailer.types.ts
@@ -1,0 +1,12 @@
+import {
+  type CreateTrailerDto,
+  type ITrailerView,
+  TrailerViewSchema,
+  type UpdateTrailerDto,
+} from '@logistica/shared';
+
+export type Trailer = ITrailerView;
+export type TrailerFormValues = CreateTrailerDto;
+export type TrailerUpdateFormValues = UpdateTrailerDto;
+
+export { TrailerViewSchema };


### PR DESCRIPTION
## Contexto
- implementa la issue #112 de E3 frontend
- agrega la base de alta de trailer sobre `develop`, ya con `#111` mergeada
- deja preparado el terreno para que `#113` reutilice el formulario y la convencion de rutas

## Alcance
- agrega ruta protegida `/trailers/new`
- crea service y hook de `create trailer`
- crea formulario tipado de trailer con `CreateTrailerSchema`
- muestra `cargoType` y `capacityUnit` de forma entendible con defaults MVP (`EQUINE` y `SLOT`)
- agrega CTA de `Registrar trailer` en el hub de flota y en el empty state de trailers
- suma tests focalizados de service, formulario, pagina y hub

## Patrones y estructura
- vertical slices por feature: `config/`, `components/`, `hooks/`, `pages/`, `services/`, `types/`
- split query/mutation
- App Router con `page.tsx` minima
- contrato compartido con Zod desde `@logistica/shared`
- sin abrir selector extra de rubro/unidad en MVP; se muestran defaults operativos claros

## Riesgos
- `pnpm --filter @logistica/web typecheck` sigue frenado por un baseline fuera de scope en `apps/web/tailwind.config.ts` (`Cannot find module 'tailwindcss'`)
- `pnpm --filter @logistica/web lint` sigue frenado por un `EPERM` de Next al leer dependencias dentro de `node_modules` en la worktree

## Como testear
- entrar a `/trailers/new`
- validar que `totalCapacity` sea editable y que rubro/unidad se muestren como `Equino` y `slot`
- crear un trailer y verificar feedback de exito
- entrar a `/vehicles` y verificar el acceso `Registrar trailer`
- si no hay trailers, verificar CTA de alta desde el empty state

## Validacion ejecutada
- `pnpm --filter @logistica/web test -- --runTestsByPath features/vehicle/services/create-trailer-api.test.ts features/vehicle/components/trailer-form.test.tsx features/vehicle/pages/trailer-create-page.test.tsx features/vehicle/pages/vehicle-fleet-page.test.tsx`