### PR TITLE
feat(web): add trailer fleet actions

### DIFF
--- a/apps/web/app/(protected)/trailers/[id]/edit/page.tsx
+++ b/apps/web/app/(protected)/trailers/[id]/edit/page.tsx
@@ -1,0 +1,15 @@
+import { TrailerEditPage } from '@/features/vehicle/pages/trailer-edit-page';
+
+type TrailerEditRouteProps = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export default async function TrailerEditRoute({
+  params,
+}: TrailerEditRouteProps) {
+  const { id } = await params;
+
+  return <TrailerEditPage trailerId={id} />;
+}

--- a/apps/web/features/vehicle/components/trailer-edit-form.tsx
+++ b/apps/web/features/vehicle/components/trailer-edit-form.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  CapacityUnitSchema,
+  CargoTypeSchema,
+  UpdateTrailerSchema,
+} from '@logistica/shared';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import {
+  TRAILER_CAPACITY_UNIT_LABELS,
+  TRAILER_CARGO_TYPE_LABELS,
+} from '../config/trailer-option-labels';
+import { useUpdateTrailer } from '../hooks/use-update-trailer';
+import type { Trailer, TrailerUpdateFormValues } from '../types/trailer.types';
+
+const cargoTypeOptions = CargoTypeSchema.options;
+const capacityUnitOptions = CapacityUnitSchema.options;
+
+type TrailerEditFormProps = {
+  trailer: Trailer;
+};
+
+export function TrailerEditForm({ trailer }: TrailerEditFormProps) {
+  const router = useRouter();
+  const {
+    formState: { errors, isDirty, isSubmitted, isValid },
+    handleSubmit,
+    register,
+  } = useForm<TrailerUpdateFormValues>({
+    defaultValues: {
+      capacityUnit: trailer.capacityUnit,
+      cargoType: trailer.cargoType,
+      totalCapacity: trailer.totalCapacity,
+    },
+    mode: 'onChange',
+    resolver: zodResolver(UpdateTrailerSchema),
+  });
+  const { isSubmitting, resetSubmitError, submitError, updateTrailer } =
+    useUpdateTrailer(trailer.id, {
+      onSuccess: () => {
+        router.push('/vehicles');
+      },
+    });
+
+  async function onSubmit(values: TrailerUpdateFormValues): Promise<void> {
+    resetSubmitError();
+    await updateTrailer(values);
+  }
+
+  const totalCapacityError =
+    isSubmitted || errors.totalCapacity
+      ? errors.totalCapacity?.message
+      : undefined;
+  const cargoTypeError =
+    isSubmitted || errors.cargoType ? errors.cargoType?.message : undefined;
+  const capacityUnitError =
+    isSubmitted || errors.capacityUnit
+      ? errors.capacityUnit?.message
+      : undefined;
+
+  return (
+    <Card className="border-white/75 bg-white/88 p-6 shadow-[0_18px_40px_rgba(21,40,33,0.08)] sm:p-8">
+      <CardHeader className="space-y-3">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.26em] text-muted">
+          Issue #113
+        </p>
+        <CardTitle>Editar trailer operativo</CardTitle>
+        <CardDescription className="max-w-2xl text-base leading-7">
+          Ajusta la capacidad, el rubro y la unidad del trailer con el mismo
+          contrato del backend y vuelve al hub cuando termines.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="mt-2">
+        <form
+          className="space-y-6"
+          noValidate
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="space-y-2 md:col-span-2">
+              <label
+                className="text-[13px] font-semibold text-foreground/92"
+                htmlFor="totalCapacity"
+              >
+                Capacidad total
+              </label>
+              <Input
+                disabled={isSubmitting}
+                error={totalCapacityError}
+                id="totalCapacity"
+                min={1}
+                placeholder="Ej: 4"
+                step={1}
+                type="number"
+                {...register('totalCapacity', { valueAsNumber: true })}
+              />
+              <p className="text-sm leading-6 text-muted">
+                Ajusta la capacidad total operativa del trailer.
+              </p>
+              {totalCapacityError ? (
+                <p className="text-sm text-destructive/90">
+                  {totalCapacityError}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="space-y-2">
+              <label
+                className="text-[13px] font-semibold text-foreground/92"
+                htmlFor="cargoType"
+              >
+                Rubro
+              </label>
+              <select
+                aria-invalid={cargoTypeError ? 'true' : 'false'}
+                className="flex h-14 w-full rounded-[1.2rem] border border-border/80 bg-input px-4 text-[15px] text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.32)] outline-none transition focus-visible:border-tertiary focus-visible:ring-4 focus-visible:ring-primary/12"
+                disabled={isSubmitting}
+                id="cargoType"
+                {...register('cargoType')}
+              >
+                {cargoTypeOptions.map((option) => (
+                  <option key={option} value={option}>
+                    {TRAILER_CARGO_TYPE_LABELS[option]}
+                  </option>
+                ))}
+              </select>
+              {cargoTypeError ? (
+                <p className="text-sm text-destructive/90">{cargoTypeError}</p>
+              ) : null}
+            </div>
+
+            <div className="space-y-2">
+              <label
+                className="text-[13px] font-semibold text-foreground/92"
+                htmlFor="capacityUnit"
+              >
+                Unidad
+              </label>
+              <select
+                aria-invalid={capacityUnitError ? 'true' : 'false'}
+                className="flex h-14 w-full rounded-[1.2rem] border border-border/80 bg-input px-4 text-[15px] text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.32)] outline-none transition focus-visible:border-tertiary focus-visible:ring-4 focus-visible:ring-primary/12"
+                disabled={isSubmitting}
+                id="capacityUnit"
+                {...register('capacityUnit')}
+              >
+                {capacityUnitOptions.map((option) => (
+                  <option key={option} value={option}>
+                    {TRAILER_CAPACITY_UNIT_LABELS[option]}
+                  </option>
+                ))}
+              </select>
+              {capacityUnitError ? (
+                <p className="text-sm text-destructive/90">
+                  {capacityUnitError}
+                </p>
+              ) : null}
+            </div>
+          </div>
+
+          {submitError ? (
+            <div
+              aria-live="polite"
+              className="rounded-[1.4rem] border border-destructive/18 bg-[rgba(177,88,63,0.08)] px-4 py-3.5 text-sm leading-6 text-destructive"
+            >
+              {submitError}
+            </div>
+          ) : null}
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Button
+              disabled={!isDirty || !isValid || isSubmitting}
+              isLoading={isSubmitting}
+              loadingText="Guardando"
+              type="submit"
+            >
+              Guardar cambios
+            </Button>
+
+            <Button
+              className="sm:max-w-[14rem]"
+              disabled={isSubmitting}
+              onClick={() => router.push('/vehicles')}
+              type="button"
+              variant="ghost"
+            >
+              Cancelar
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/features/vehicle/components/trailer-fleet-section.test.tsx
+++ b/apps/web/features/vehicle/components/trailer-fleet-section.test.tsx
@@ -101,4 +101,44 @@ describe('TrailerFleetSection', () => {
     expect(deactivateTrailer).toHaveBeenCalledWith('cmavhcl110000wqz5oy7k8v02');
     expect(refetchTrailers).toHaveBeenCalled();
   });
+
+  it('disables every deactivate action while one request is in flight', () => {
+    mockedUseTransporterTrailers.mockReturnValue({
+      error: null,
+      refetch: jest.fn(),
+      requestStatus: 'success',
+      trailers: [
+        {
+          capacityUnit: 'SLOT',
+          cargoType: 'EQUINE',
+          id: 'cmavhcl110000wqz5oy7k8v02',
+          isActive: true,
+          totalCapacity: 6,
+        },
+        {
+          capacityUnit: 'SLOT',
+          cargoType: 'EQUINE',
+          id: 'cmavhcl110000wqz5oy7k8v03',
+          isActive: true,
+          totalCapacity: 8,
+        },
+      ],
+    });
+    mockedUseDeactivateTrailer.mockReturnValue({
+      deactivateTrailer: jest.fn(),
+      isSubmitting: true,
+      resetSubmitError: jest.fn(),
+      submitError: null,
+    });
+
+    render(<TrailerFleetSection />);
+
+    const deactivateButtons = screen.getAllByRole('button', {
+      name: /Desactivar/i,
+    });
+
+    expect(deactivateButtons).toHaveLength(2);
+    expect(deactivateButtons[0]).toBeDisabled();
+    expect(deactivateButtons[1]).toBeDisabled();
+  });
 });

--- a/apps/web/features/vehicle/components/trailer-fleet-section.test.tsx
+++ b/apps/web/features/vehicle/components/trailer-fleet-section.test.tsx
@@ -1,0 +1,104 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useDeactivateTrailer } from '../hooks/use-deactivate-trailer';
+import { useTransporterTrailers } from '../hooks/use-transporter-trailers';
+import { TrailerFleetSection } from './trailer-fleet-section';
+
+jest.mock('../hooks/use-deactivate-trailer', () => ({
+  useDeactivateTrailer: jest.fn(),
+}));
+
+jest.mock('../hooks/use-transporter-trailers', () => ({
+  useTransporterTrailers: jest.fn(),
+}));
+
+const mockedUseTransporterTrailers = jest.mocked(useTransporterTrailers);
+const mockedUseDeactivateTrailer = jest.mocked(useDeactivateTrailer);
+
+describe('TrailerFleetSection', () => {
+  beforeEach(() => {
+    mockedUseTransporterTrailers.mockReset();
+    mockedUseDeactivateTrailer.mockReset();
+    window.confirm = jest.fn().mockReturnValue(true);
+  });
+
+  it('renders trailer actions in the fleet list', () => {
+    mockedUseTransporterTrailers.mockReturnValue({
+      error: null,
+      refetch: jest.fn(),
+      requestStatus: 'success',
+      trailers: [
+        {
+          capacityUnit: 'SLOT',
+          cargoType: 'EQUINE',
+          id: 'cmavhcl110000wqz5oy7k8v02',
+          isActive: true,
+          totalCapacity: 6,
+        },
+      ],
+    });
+    mockedUseDeactivateTrailer.mockReturnValue({
+      deactivateTrailer: jest.fn(),
+      isSubmitting: false,
+      resetSubmitError: jest.fn(),
+      submitError: null,
+    });
+
+    render(<TrailerFleetSection />);
+
+    expect(screen.getByRole('link', { name: /Editar/i })).toHaveAttribute(
+      'href',
+      '/trailers/cmavhcl110000wqz5oy7k8v02/edit',
+    );
+    expect(
+      screen.getByRole('button', { name: /Desactivar/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('deactivates a trailer from the fleet section and refetches the list', async () => {
+    const deactivateTrailer = jest.fn().mockResolvedValue({
+      capacityUnit: 'SLOT',
+      cargoType: 'EQUINE',
+      id: 'cmavhcl110000wqz5oy7k8v02',
+      isActive: false,
+      totalCapacity: 6,
+    });
+    const refetchTrailers = jest.fn().mockResolvedValue(undefined);
+
+    mockedUseTransporterTrailers.mockReturnValue({
+      error: null,
+      refetch: refetchTrailers,
+      requestStatus: 'success',
+      trailers: [
+        {
+          capacityUnit: 'SLOT',
+          cargoType: 'EQUINE',
+          id: 'cmavhcl110000wqz5oy7k8v02',
+          isActive: true,
+          totalCapacity: 6,
+        },
+      ],
+    });
+    mockedUseDeactivateTrailer.mockReturnValue({
+      deactivateTrailer,
+      isSubmitting: false,
+      resetSubmitError: jest.fn(),
+      submitError: null,
+    });
+
+    render(<TrailerFleetSection />);
+
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: /Desactivar/i }));
+
+    expect(window.confirm).toHaveBeenCalledWith(
+      expect.stringContaining('6 slot'),
+    );
+    expect(deactivateTrailer).toHaveBeenCalledWith('cmavhcl110000wqz5oy7k8v02');
+    expect(refetchTrailers).toHaveBeenCalled();
+  });
+});

--- a/apps/web/features/vehicle/components/trailer-fleet-section.tsx
+++ b/apps/web/features/vehicle/components/trailer-fleet-section.tsx
@@ -1,10 +1,14 @@
 'use client';
 
+import Link from 'next/link';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
 import { useTransporterTrailers } from '../hooks/use-transporter-trailers';
 import {
   TRAILER_CAPACITY_UNIT_LABELS,
   TRAILER_CARGO_TYPE_LABELS,
 } from '../config/trailer-option-labels';
+import { useDeactivateTrailer } from '../hooks/use-deactivate-trailer';
 import type { TransporterTrailer } from '../types/fleet.types';
 import {
   EmptyStateCard,
@@ -17,48 +21,81 @@ function getTrailerStatusLabel(isActive: boolean): string {
   return isActive ? 'Activo' : 'Inactivo';
 }
 
-function TrailersList({ trailers }: { trailers: TransporterTrailer[] }) {
+function TrailersList({
+  onDeactivate,
+  pendingTrailerId,
+  trailers,
+}: {
+  onDeactivate: (trailer: TransporterTrailer) => Promise<void>;
+  pendingTrailerId: string | null;
+  trailers: TransporterTrailer[];
+}) {
   return (
     <div className="overflow-hidden rounded-[1.6rem] border border-border/70">
-      <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-4 border-b border-border/70 bg-panel/80 px-5 py-4 text-sm font-semibold text-muted">
+      <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto] gap-4 border-b border-border/70 bg-panel/80 px-5 py-4 text-sm font-semibold text-muted">
         <span>Capacidad</span>
         <span>Rubro y unidad</span>
         <span className="text-right">Estado</span>
+        <span className="text-right">Acciones</span>
       </div>
 
       <div className="divide-y divide-border/60 bg-white/55">
-        {trailers.map((trailer) => (
-          <div
-            className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-4 px-5 py-4 text-sm text-foreground"
-            key={trailer.id}
-          >
-            <div className="min-w-0">
-              <p className="truncate text-base font-semibold text-foreground">
-                {trailer.totalCapacity}{' '}
-                {TRAILER_CAPACITY_UNIT_LABELS[trailer.capacityUnit]}
-              </p>
-              <p className="mt-1 text-sm leading-6 text-muted">
-                Capacidad total declarada.
-              </p>
-            </div>
+        {trailers.map((trailer) => {
+          const isPending = pendingTrailerId === trailer.id;
 
-            <div className="min-w-0">
-              <p className="truncate text-sm font-medium text-foreground">
-                {TRAILER_CARGO_TYPE_LABELS[trailer.cargoType]}
-              </p>
-              <p className="mt-1 text-sm leading-6 text-muted">
-                Unidad de capacidad:{' '}
-                {TRAILER_CAPACITY_UNIT_LABELS[trailer.capacityUnit]}.
-              </p>
-            </div>
+          return (
+            <div
+              className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto] gap-4 px-5 py-4 text-sm text-foreground"
+              key={trailer.id}
+            >
+              <div className="min-w-0">
+                <p className="truncate text-base font-semibold text-foreground">
+                  {trailer.totalCapacity}{' '}
+                  {TRAILER_CAPACITY_UNIT_LABELS[trailer.capacityUnit]}
+                </p>
+                <p className="mt-1 text-sm leading-6 text-muted">
+                  Capacidad total declarada.
+                </p>
+              </div>
 
-            <div className="flex items-center justify-end">
-              <span className="inline-flex rounded-full border border-border/70 bg-primary/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-foreground/80">
-                {getTrailerStatusLabel(trailer.isActive)}
-              </span>
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-foreground">
+                  {TRAILER_CARGO_TYPE_LABELS[trailer.cargoType]}
+                </p>
+                <p className="mt-1 text-sm leading-6 text-muted">
+                  Unidad de capacidad:{' '}
+                  {TRAILER_CAPACITY_UNIT_LABELS[trailer.capacityUnit]}.
+                </p>
+              </div>
+
+              <div className="flex items-center justify-end">
+                <span className="inline-flex rounded-full border border-border/70 bg-primary/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-foreground/80">
+                  {getTrailerStatusLabel(trailer.isActive)}
+                </span>
+              </div>
+
+              <div className="flex flex-col items-end gap-2 sm:flex-row sm:items-center">
+                <Link
+                  className="inline-flex min-h-10 items-center justify-center rounded-[1rem] bg-primary/5 px-4 py-2 text-sm font-semibold text-foreground transition hover:bg-primary/8"
+                  href={`/trailers/${trailer.id}/edit`}
+                >
+                  Editar
+                </Link>
+                <Button
+                  className="h-10 w-auto rounded-[1rem] px-4 text-sm"
+                  disabled={!trailer.isActive}
+                  isLoading={isPending}
+                  loadingText="Desactivando"
+                  onClick={() => void onDeactivate(trailer)}
+                  type="button"
+                  variant="ghost"
+                >
+                  Desactivar
+                </Button>
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );
@@ -71,6 +108,38 @@ export function TrailerFleetSection() {
     requestStatus: trailersStatus,
     trailers,
   } = useTransporterTrailers();
+  const [pendingTrailerId, setPendingTrailerId] = useState<string | null>(null);
+  const { deactivateTrailer, isSubmitting, resetSubmitError, submitError } =
+    useDeactivateTrailer();
+
+  async function handleDeactivate(trailer: TransporterTrailer): Promise<void> {
+    if (!trailer.isActive) {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Vas a desactivar el trailer de ${trailer.totalCapacity} ${TRAILER_CAPACITY_UNIT_LABELS[trailer.capacityUnit]}. Podras verlo como inactivo en la flota.`,
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    resetSubmitError();
+    setPendingTrailerId(trailer.id);
+
+    try {
+      const updatedTrailer = await deactivateTrailer(trailer.id);
+
+      if (!updatedTrailer) {
+        return;
+      }
+
+      await refetchTrailers();
+    } finally {
+      setPendingTrailerId(null);
+    }
+  }
 
   return (
     <FleetSectionShell
@@ -103,7 +172,22 @@ export function TrailerFleetSection() {
       ) : null}
 
       {trailersStatus === 'success' && trailers.length > 0 ? (
-        <TrailersList trailers={trailers} />
+        <div className="space-y-4">
+          {submitError ? (
+            <div
+              aria-live="polite"
+              className="rounded-[1.4rem] border border-destructive/18 bg-[rgba(177,88,63,0.08)] px-4 py-3.5 text-sm leading-6 text-destructive"
+            >
+              {submitError}
+            </div>
+          ) : null}
+
+          <TrailersList
+            onDeactivate={handleDeactivate}
+            pendingTrailerId={isSubmitting ? pendingTrailerId : null}
+            trailers={trailers}
+          />
+        </div>
       ) : null}
     </FleetSectionShell>
   );

--- a/apps/web/features/vehicle/components/trailer-fleet-section.tsx
+++ b/apps/web/features/vehicle/components/trailer-fleet-section.tsx
@@ -22,10 +22,12 @@ function getTrailerStatusLabel(isActive: boolean): string {
 }
 
 function TrailersList({
+  isSubmitting,
   onDeactivate,
   pendingTrailerId,
   trailers,
 }: {
+  isSubmitting: boolean;
   onDeactivate: (trailer: TransporterTrailer) => Promise<void>;
   pendingTrailerId: string | null;
   trailers: TransporterTrailer[];
@@ -83,7 +85,7 @@ function TrailersList({
                 </Link>
                 <Button
                   className="h-10 w-auto rounded-[1rem] px-4 text-sm"
-                  disabled={!trailer.isActive}
+                  disabled={isSubmitting || !trailer.isActive}
                   isLoading={isPending}
                   loadingText="Desactivando"
                   onClick={() => void onDeactivate(trailer)}
@@ -183,6 +185,7 @@ export function TrailerFleetSection() {
           ) : null}
 
           <TrailersList
+            isSubmitting={isSubmitting}
             onDeactivate={handleDeactivate}
             pendingTrailerId={isSubmitting ? pendingTrailerId : null}
             trailers={trailers}

--- a/apps/web/features/vehicle/hooks/use-deactivate-trailer.ts
+++ b/apps/web/features/vehicle/hooks/use-deactivate-trailer.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { ApiError, NotFoundError } from '@/src/lib/api';
+import { useFormSubmit } from '@/src/lib/forms/hooks/useFormSubmit';
+import { deactivateTrailer } from '../services/deactivate-trailer-api';
+import type { Trailer } from '../types/trailer.types';
+
+function getDeactivateTrailerErrorMessage(error: unknown): string {
+  if (error instanceof NotFoundError) {
+    return 'No encontramos el trailer que intentas desactivar.';
+  }
+
+  if (
+    error instanceof ApiError &&
+    (error.status === 401 || error.status === 403)
+  ) {
+    return 'Tu sesion no tiene acceso para desactivar trailers. Vuelve a ingresar e intenta otra vez.';
+  }
+
+  if (error instanceof ApiError && error.status >= 500) {
+    return 'No pudimos desactivar el trailer por un problema del servidor. Intenta nuevamente en unos segundos.';
+  }
+
+  return 'No pudimos desactivar el trailer. Vuelve a intentarlo.';
+}
+
+type UseDeactivateTrailerOptions = {
+  onSuccess?: (trailer: Trailer) => void;
+};
+
+export function useDeactivateTrailer({
+  onSuccess,
+}: UseDeactivateTrailerOptions = {}) {
+  const { isSubmitting, resetSubmitError, submit, submitError } = useFormSubmit(
+    async (trailerId: string) => {
+      const trailer = await deactivateTrailer(trailerId);
+
+      onSuccess?.(trailer);
+
+      return trailer;
+    },
+    {
+      getErrorMessage: getDeactivateTrailerErrorMessage,
+    },
+  );
+
+  return {
+    deactivateTrailer: submit,
+    isSubmitting,
+    resetSubmitError,
+    submitError,
+  };
+}

--- a/apps/web/features/vehicle/hooks/use-update-trailer.ts
+++ b/apps/web/features/vehicle/hooks/use-update-trailer.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { ApiError, BadRequestError } from '@/src/lib/api';
+import { useFormSubmit } from '@/src/lib/forms/hooks/useFormSubmit';
+import { updateTrailer } from '../services/update-trailer-api';
+import type { Trailer, TrailerUpdateFormValues } from '../types/trailer.types';
+
+function getUpdateTrailerErrorMessage(error: unknown): string {
+  if (error instanceof BadRequestError) {
+    return 'Los datos del trailer no son validos. Revisa los campos e intenta otra vez.';
+  }
+
+  if (
+    error instanceof ApiError &&
+    (error.status === 401 || error.status === 403)
+  ) {
+    return 'Tu sesion no tiene acceso para editar trailers. Vuelve a ingresar e intenta otra vez.';
+  }
+
+  if (error instanceof ApiError && error.status >= 500) {
+    return 'No pudimos guardar el trailer por un problema del servidor. Intenta nuevamente en unos segundos.';
+  }
+
+  return 'No pudimos guardar el trailer. Vuelve a intentarlo.';
+}
+
+type UseUpdateTrailerOptions = {
+  onSuccess?: (trailer: Trailer) => void;
+};
+
+export function useUpdateTrailer(
+  trailerId: string,
+  { onSuccess }: UseUpdateTrailerOptions = {},
+) {
+  const { isSubmitting, resetSubmitError, submit, submitError } = useFormSubmit(
+    async (values: TrailerUpdateFormValues) => {
+      const trailer = await updateTrailer(trailerId, values);
+
+      onSuccess?.(trailer);
+
+      return trailer;
+    },
+    {
+      getErrorMessage: getUpdateTrailerErrorMessage,
+    },
+  );
+
+  return {
+    isSubmitting,
+    resetSubmitError,
+    submitError,
+    updateTrailer: submit,
+  };
+}

--- a/apps/web/features/vehicle/pages/trailer-edit-page.test.tsx
+++ b/apps/web/features/vehicle/pages/trailer-edit-page.test.tsx
@@ -1,0 +1,124 @@
+/** @jest-environment jsdom */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useTransporterTrailers } from '../hooks/use-transporter-trailers';
+import { useUpdateTrailer } from '../hooks/use-update-trailer';
+import { TrailerEditPage } from './trailer-edit-page';
+
+const push = jest.fn();
+const updateTrailer = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push,
+  }),
+}));
+
+jest.mock('../hooks/use-transporter-trailers', () => ({
+  useTransporterTrailers: jest.fn(),
+}));
+
+jest.mock('../hooks/use-update-trailer', () => ({
+  useUpdateTrailer: jest.fn(),
+}));
+
+const mockedUseTransporterTrailers = jest.mocked(useTransporterTrailers);
+const mockedUseUpdateTrailer = jest.mocked(useUpdateTrailer);
+
+describe('TrailerEditPage', () => {
+  beforeEach(() => {
+    push.mockReset();
+    updateTrailer.mockReset();
+    mockedUseTransporterTrailers.mockReset();
+    mockedUseUpdateTrailer.mockReset();
+  });
+
+  it('renders the loading state while the trailer list is being resolved', () => {
+    mockedUseTransporterTrailers.mockReturnValue({
+      error: null,
+      refetch: jest.fn(),
+      requestStatus: 'loading',
+      trailers: [],
+    });
+    mockedUseUpdateTrailer.mockReturnValue({
+      isSubmitting: false,
+      resetSubmitError: jest.fn(),
+      submitError: null,
+      updateTrailer,
+    });
+
+    render(<TrailerEditPage trailerId="cmavhcl110000wqz5oy7k8v02" />);
+
+    expect(
+      screen.getByRole('heading', {
+        name: /Ajusta un trailer sin salir del flujo de flota/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Cargando el trailer seleccionado para editar/i),
+    ).toBeInTheDocument();
+  });
+
+  it('submits the edited trailer and returns to the fleet hub', async () => {
+    mockedUseTransporterTrailers.mockReturnValue({
+      error: null,
+      refetch: jest.fn(),
+      requestStatus: 'success',
+      trailers: [
+        {
+          capacityUnit: 'SLOT',
+          cargoType: 'EQUINE',
+          id: 'cmavhcl110000wqz5oy7k8v02',
+          isActive: true,
+          totalCapacity: 6,
+        },
+      ],
+    });
+    mockedUseUpdateTrailer.mockImplementation((_trailerId, options = {}) => ({
+      isSubmitting: false,
+      resetSubmitError: jest.fn(),
+      submitError: null,
+      updateTrailer: jest.fn(async (values) => {
+        updateTrailer(values);
+        options.onSuccess?.({
+          capacityUnit: 'M3' as const,
+          cargoType: 'GENERAL_CARGO' as const,
+          id: 'cmavhcl110000wqz5oy7k8v02',
+          isActive: true,
+          totalCapacity: 8,
+        });
+
+        return {
+          capacityUnit: 'M3' as const,
+          cargoType: 'GENERAL_CARGO' as const,
+          id: 'cmavhcl110000wqz5oy7k8v02',
+          isActive: true,
+          totalCapacity: 8,
+        };
+      }),
+    }));
+
+    render(<TrailerEditPage trailerId="cmavhcl110000wqz5oy7k8v02" />);
+
+    const user = userEvent.setup();
+
+    expect(screen.getByDisplayValue('6')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Equino')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('slot')).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText(/Capacidad total/i));
+    await user.type(screen.getByLabelText(/Capacidad total/i), '8');
+    await user.selectOptions(screen.getByLabelText(/Rubro/i), 'GENERAL_CARGO');
+    await user.selectOptions(screen.getByLabelText(/Unidad/i), 'M3');
+    await user.click(screen.getByRole('button', { name: /Guardar cambios/i }));
+
+    expect(updateTrailer).toHaveBeenCalledWith({
+      capacityUnit: 'M3',
+      cargoType: 'GENERAL_CARGO',
+      totalCapacity: 8,
+    });
+    expect(push).toHaveBeenCalledWith('/vehicles');
+  });
+});

--- a/apps/web/features/vehicle/pages/trailer-edit-page.tsx
+++ b/apps/web/features/vehicle/pages/trailer-edit-page.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { TrailerEditForm } from '../components/trailer-edit-form';
+import { useTransporterTrailers } from '../hooks/use-transporter-trailers';
+
+type TrailerEditPageProps = {
+  trailerId: string;
+};
+
+function LoadingPanel() {
+  return (
+    <div className="rounded-[1.6rem] border border-dashed border-border/70 bg-panel/45 p-5">
+      <p className="text-sm leading-6 text-muted">
+        Cargando el trailer seleccionado para editar.
+      </p>
+    </div>
+  );
+}
+
+function ErrorPanel({ message }: { message: string }) {
+  return (
+    <div className="rounded-[1.6rem] border border-destructive/20 bg-[rgba(177,88,63,0.06)] p-5">
+      <h2 className="text-base font-semibold text-foreground">
+        No pudimos abrir este trailer
+      </h2>
+      <p className="mt-2 text-sm leading-6 text-muted">{message}</p>
+      <Link
+        className="mt-4 inline-flex min-h-12 items-center justify-center rounded-[1.25rem] bg-primary/5 px-4 py-3 text-sm font-semibold text-foreground transition hover:bg-primary/8"
+        href="/vehicles"
+      >
+        Volver a la flota
+      </Link>
+    </div>
+  );
+}
+
+export function TrailerEditPage({ trailerId }: TrailerEditPageProps) {
+  const { error, requestStatus, trailers } = useTransporterTrailers();
+  const trailer = trailers.find((item) => item.id === trailerId) ?? null;
+
+  return (
+    <main className="relative min-h-screen overflow-hidden bg-[linear-gradient(180deg,#eef4ef_0%,#e7efe7_46%,#d9e4da_100%)] px-6 py-10">
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+        <div className="absolute left-[-4rem] top-[-5rem] size-[18rem] rounded-full bg-[#c7ddd6]/50 blur-3xl" />
+        <div className="absolute right-[-5rem] top-[7rem] size-[15rem] rounded-full bg-[#f0d3ad]/42 blur-3xl" />
+        <div className="absolute bottom-[-8rem] left-[22%] size-[16rem] rounded-full bg-[#dbe9d6]/55 blur-3xl" />
+      </div>
+
+      <div className="relative mx-auto w-full max-w-6xl space-y-6">
+        <section className="grid gap-6 xl:grid-cols-[1.08fr_0.92fr]">
+          <Card className="overflow-hidden border-white/35 bg-[linear-gradient(160deg,#153f31_0%,#102d24_46%,#0b1b16_100%)] p-8 text-primary-foreground shadow-[0_28px_60px_rgba(16,39,33,0.18)]">
+            <CardHeader className="space-y-5">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-foreground/88">
+                  Fleet actions
+                </span>
+                <span className="rounded-full border border-white/10 bg-[rgba(255,255,255,0.08)] px-4 py-2 text-sm font-semibold text-primary-foreground/88">
+                  Edicion dedicada de trailer
+                </span>
+              </div>
+
+              <div className="space-y-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-primary-foreground/62">
+                  Area protegida del transportista
+                </p>
+                <h1 className="max-w-3xl font-heading text-4xl font-semibold leading-tight text-primary-foreground sm:text-[2.9rem]">
+                  Ajusta un trailer sin salir del flujo de flota
+                </h1>
+                <CardDescription className="max-w-2xl text-base leading-7 text-primary-foreground/76">
+                  La edicion sigue el mismo contrato del backend E3 y vuelve al
+                  hub una vez que los cambios se guardan correctamente.
+                </CardDescription>
+              </div>
+            </CardHeader>
+
+            <CardContent className="mt-8 grid gap-3 sm:grid-cols-2">
+              <article className="rounded-[1.6rem] border border-white/10 bg-[rgba(10,26,22,0.52)] px-4 py-4">
+                <h2 className="text-sm font-semibold text-primary-foreground">
+                  Fuente de verdad del servidor
+                </h2>
+                <p className="mt-2 text-sm leading-6 text-primary-foreground/76">
+                  Abrimos el trailer desde el listado autenticado y dejamos que
+                  la flota vuelva a consultar al backend cuando regreses.
+                </p>
+              </article>
+
+              <article className="rounded-[1.6rem] border border-white/10 bg-[rgba(10,26,22,0.52)] px-4 py-4">
+                <h2 className="text-sm font-semibold text-primary-foreground">
+                  Mismo contrato de validacion
+                </h2>
+                <p className="mt-2 text-sm leading-6 text-primary-foreground/76">
+                  El formulario usa `UpdateTrailerSchema`, asi que frontend y
+                  backend se mantienen alineados.
+                </p>
+              </article>
+            </CardContent>
+          </Card>
+
+          <Card className="border-white/70 bg-white/84 p-7 shadow-[0_18px_40px_rgba(21,40,33,0.08)] backdrop-blur">
+            <CardHeader className="space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                Antes de guardar
+              </p>
+              <CardTitle className="text-[2rem]">
+                Revisa la operacion del trailer
+              </CardTitle>
+              <CardDescription className="text-base leading-7">
+                Esta vista mantiene el alcance acotado a capacidad, rubro y
+                unidad para no mezclar la edicion con otras reglas operativas.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent className="space-y-4">
+              <div className="rounded-[1.5rem] border border-border/70 bg-panel/70 px-5 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted">
+                  Flujo incluido
+                </p>
+                <p className="mt-2 text-sm leading-6 text-foreground/78">
+                  Carga del trailer, validaciones compartidas, guardado con
+                  PATCH y retorno al hub de flota.
+                </p>
+              </div>
+
+              <Link
+                className="inline-flex min-h-14 items-center justify-center rounded-[1.4rem] bg-primary/5 px-5 py-3 text-[15px] font-semibold text-foreground transition hover:bg-primary/8"
+                href="/vehicles"
+              >
+                Volver a la flota
+              </Link>
+            </CardContent>
+          </Card>
+        </section>
+
+        {requestStatus === 'loading' ? <LoadingPanel /> : null}
+        {requestStatus === 'error' ? (
+          <ErrorPanel
+            message={error ?? 'No pudimos cargar el listado de trailers.'}
+          />
+        ) : null}
+        {requestStatus === 'success' && !trailer ? (
+          <ErrorPanel message="No encontramos el trailer seleccionado dentro de tu flota." />
+        ) : null}
+        {requestStatus === 'success' && trailer ? (
+          <TrailerEditForm trailer={trailer} />
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/features/vehicle/pages/vehicle-fleet-page.test.tsx
+++ b/apps/web/features/vehicle/pages/vehicle-fleet-page.test.tsx
@@ -117,10 +117,24 @@ describe('VehicleFleetPage', () => {
 
     expect(screen.getByText('AA123BB')).toBeInTheDocument();
     expect(screen.getByText(/Scania R450/i)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Editar/i })).toHaveAttribute(
-      'href',
-      '/vehicles/cmavhcl110000wqz5oy7k8v01/edit',
-    );
+    expect(
+      screen
+        .getAllByRole('link', { name: /Editar/i })
+        .some(
+          (link) =>
+            link.getAttribute('href') ===
+            '/vehicles/cmavhcl110000wqz5oy7k8v01/edit',
+        ),
+    ).toBe(true);
+    expect(
+      screen
+        .getAllByRole('link', { name: /Editar/i })
+        .some(
+          (link) =>
+            link.getAttribute('href') ===
+            '/trailers/cmavhcl110000wqz5oy7k8v02/edit',
+        ),
+    ).toBe(true);
     expect(
       screen.getByRole('link', { name: /Registrar trailer/i }),
     ).toHaveAttribute('href', '/trailers/new');

--- a/apps/web/features/vehicle/services/deactivate-trailer-api.test.ts
+++ b/apps/web/features/vehicle/services/deactivate-trailer-api.test.ts
@@ -1,0 +1,82 @@
+import { deactivateTrailer } from './deactivate-trailer-api';
+
+jest.mock('@/features/auth/services/session/access-token-store', () => ({
+  getAccessToken: jest.fn(),
+}));
+
+const { getAccessToken } = jest.requireMock(
+  '@/features/auth/services/session/access-token-store',
+) as {
+  getAccessToken: jest.Mock;
+};
+
+describe('deactivateTrailer', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3001';
+    getAccessToken.mockReturnValue('access-token-value');
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+    delete process.env.NEXT_PUBLIC_API_URL;
+  });
+
+  it('patches the deactivate endpoint and returns the parsed response', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          capacityUnit: 'SLOT',
+          cargoType: 'EQUINE',
+          id: 'cmavhcl110000wqz5oy7k8v02',
+          isActive: false,
+          totalCapacity: 6,
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      deactivateTrailer('cmavhcl110000wqz5oy7k8v02'),
+    ).resolves.toMatchObject({
+      id: 'cmavhcl110000wqz5oy7k8v02',
+      isActive: false,
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:3001/trailers/cmavhcl110000wqz5oy7k8v02/deactivate',
+      expect.objectContaining({
+        credentials: 'include',
+        headers: expect.any(Headers),
+        method: 'PATCH',
+      }),
+    );
+  });
+
+  it('throws when the backend responds with an invalid trailer payload', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          deactivated: true,
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      deactivateTrailer('cmavhcl110000wqz5oy7k8v02'),
+    ).rejects.toThrow('payload invalido');
+  });
+});

--- a/apps/web/features/vehicle/services/deactivate-trailer-api.ts
+++ b/apps/web/features/vehicle/services/deactivate-trailer-api.ts
@@ -1,0 +1,34 @@
+import { getAccessToken } from '@/features/auth/services/session/access-token-store';
+import { apiClient } from '@/src/lib/api';
+import { TrailerViewSchema, type Trailer } from '../types/trailer.types';
+
+const INVALID_DEACTIVATE_TRAILER_RESPONSE_MESSAGE =
+  'La API respondio con un payload invalido para PATCH /trailers/:id/deactivate.';
+
+function buildAuthorizationHeaders(
+  accessToken: string | null,
+): HeadersInit | undefined {
+  if (!accessToken) {
+    return undefined;
+  }
+
+  return {
+    Authorization: `Bearer ${accessToken}`,
+  };
+}
+
+export async function deactivateTrailer(trailerId: string): Promise<Trailer> {
+  const response = await apiClient.patch<unknown>(
+    `/trailers/${trailerId}/deactivate`,
+    {
+      headers: buildAuthorizationHeaders(getAccessToken()),
+    },
+  );
+  const parsed = TrailerViewSchema.safeParse(response.data);
+
+  if (!parsed.success) {
+    throw new Error(INVALID_DEACTIVATE_TRAILER_RESPONSE_MESSAGE);
+  }
+
+  return parsed.data;
+}

--- a/apps/web/features/vehicle/services/update-trailer-api.test.ts
+++ b/apps/web/features/vehicle/services/update-trailer-api.test.ts
@@ -1,0 +1,95 @@
+import { updateTrailer } from './update-trailer-api';
+
+jest.mock('@/features/auth/services/session/access-token-store', () => ({
+  getAccessToken: jest.fn(),
+}));
+
+const { getAccessToken } = jest.requireMock(
+  '@/features/auth/services/session/access-token-store',
+) as {
+  getAccessToken: jest.Mock;
+};
+
+describe('updateTrailer', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3001';
+    getAccessToken.mockReturnValue('access-token-value');
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+    delete process.env.NEXT_PUBLIC_API_URL;
+  });
+
+  it('patches the trailer payload and returns the parsed response', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          capacityUnit: 'M3',
+          cargoType: 'GENERAL_CARGO',
+          id: 'cmavhcl110000wqz5oy7k8v02',
+          isActive: true,
+          totalCapacity: 8,
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      updateTrailer('cmavhcl110000wqz5oy7k8v02', {
+        capacityUnit: 'M3',
+        cargoType: 'GENERAL_CARGO',
+        totalCapacity: 8,
+      }),
+    ).resolves.toMatchObject({
+      capacityUnit: 'M3',
+      cargoType: 'GENERAL_CARGO',
+      id: 'cmavhcl110000wqz5oy7k8v02',
+      totalCapacity: 8,
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:3001/trailers/cmavhcl110000wqz5oy7k8v02',
+      expect.objectContaining({
+        body: JSON.stringify({
+          capacityUnit: 'M3',
+          cargoType: 'GENERAL_CARGO',
+          totalCapacity: 8,
+        }),
+        credentials: 'include',
+        headers: expect.any(Headers),
+        method: 'PATCH',
+      }),
+    );
+  });
+
+  it('throws when the backend responds with an invalid trailer payload', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          updated: true,
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      updateTrailer('cmavhcl110000wqz5oy7k8v02', {
+        totalCapacity: 8,
+      }),
+    ).rejects.toThrow('payload invalido');
+  });
+});

--- a/apps/web/features/vehicle/services/update-trailer-api.ts
+++ b/apps/web/features/vehicle/services/update-trailer-api.ts
@@ -1,0 +1,36 @@
+import { type UpdateTrailerDto } from '@logistica/shared';
+import { getAccessToken } from '@/features/auth/services/session/access-token-store';
+import { apiClient } from '@/src/lib/api';
+import { TrailerViewSchema, type Trailer } from '../types/trailer.types';
+
+const INVALID_UPDATE_TRAILER_RESPONSE_MESSAGE =
+  'La API respondio con un payload invalido para PATCH /trailers/:id.';
+
+function buildAuthorizationHeaders(
+  accessToken: string | null,
+): HeadersInit | undefined {
+  if (!accessToken) {
+    return undefined;
+  }
+
+  return {
+    Authorization: `Bearer ${accessToken}`,
+  };
+}
+
+export async function updateTrailer(
+  trailerId: string,
+  dto: UpdateTrailerDto,
+): Promise<Trailer> {
+  const response = await apiClient.patch<unknown>(`/trailers/${trailerId}`, {
+    body: dto,
+    headers: buildAuthorizationHeaders(getAccessToken()),
+  });
+  const parsed = TrailerViewSchema.safeParse(response.data);
+
+  if (!parsed.success) {
+    throw new Error(INVALID_UPDATE_TRAILER_RESPONSE_MESSAGE);
+  }
+
+  return parsed.data;
+}


### PR DESCRIPTION
## Contexto
- implementa la issue #113 de E3 frontend
- extiende la base de trailer agregada en `#112`
- replica para trailers el patron de mutacion UI ya cerrado antes para vehicles

## Alcance
- agrega ruta dedicada `/trailers/[id]/edit`
- crea services y hooks para `update trailer` y `deactivate trailer`
- agrega acciones `Editar` y `Desactivar` en la seccion de trailers del hub de flota
- agrega refetch del listado luego de desactivar
- crea formulario y pagina de edicion de trailer
- suma tests focalizados para services, pagina y seccion de trailers

## Patrones y estructura
- vertical slices por feature: `components/`, `hooks/`, `pages/`, `services/`
- split query/mutation
- App Router con `page.tsx` minima
- contrato compartido con Zod usando `UpdateTrailerSchema`
- server truth after mutation: volver al hub o refetch de la seccion
- controles nativos simples para editar `cargoType` y `capacityUnit`, respetando los enums compartidos

## Riesgos
- `pnpm --filter @logistica/web typecheck` sigue frenado por un baseline fuera de scope en `apps/web/tailwind.config.ts` (`Cannot find module 'tailwindcss'`)
- `pnpm --filter @logistica/web lint` sigue frenado por un `EPERM` de Next al leer dependencias dentro de `node_modules` en la worktree

## Como testear
- entrar a `/vehicles`
- verificar que cada trailer tenga acciones `Editar` y `Desactivar`
- entrar a `/trailers/[id]/edit`, editar capacidad/rubro/unidad y confirmar retorno al hub
- desactivar un trailer y verificar refetch de la seccion y estado visible inactivo

## Validacion ejecutada
- `pnpm --filter @logistica/web test -- --runTestsByPath features/vehicle/services/update-trailer-api.test.ts features/vehicle/services/deactivate-trailer-api.test.ts features/vehicle/pages/trailer-edit-page.test.tsx features/vehicle/components/trailer-fleet-section.test.tsx`