### PR TITLE
fix(auth): resolve legacy transporter role

### DIFF
--- a/apps/api/src/identity/authentication/application/auth-token.service.spec.ts
+++ b/apps/api/src/identity/authentication/application/auth-token.service.spec.ts
@@ -100,6 +100,64 @@ describe('AuthTokenService', () => {
     );
   });
 
+  it('upgrades inconsistent transporter accounts when signing refreshed access tokens', async () => {
+    jwtService.signAsync.mockResolvedValue('transporter-access-token');
+
+    await expect(
+      authTokenService.signAccessToken({
+        id: 'transporter-account-id',
+        email: 'transporter@example.com',
+        role: 'CLIENT',
+        isEmailVerified: true,
+        userProfile: null,
+        transporterProfile: {
+          id: 'transporter-profile-id',
+        },
+      } as never),
+    ).resolves.toBe('transporter-access-token');
+
+    expect(jwtService.signAsync).toHaveBeenCalledWith(
+      {
+        sub: 'transporter-account-id',
+        role: 'TRANSPORTER',
+      },
+      {
+        secret: 'access-secret',
+        expiresIn: 900,
+      },
+    );
+  });
+
+  it('keeps transporter precedence even when the legacy account still has a user profile', async () => {
+    jwtService.signAsync.mockResolvedValue('transporter-access-token');
+
+    await expect(
+      authTokenService.signAccessToken({
+        id: 'transporter-account-id',
+        email: 'transporter@example.com',
+        role: 'CLIENT',
+        isEmailVerified: true,
+        userProfile: {
+          id: 'user-profile-id',
+        },
+        transporterProfile: {
+          id: 'transporter-profile-id',
+        },
+      } as never),
+    ).resolves.toBe('transporter-access-token');
+
+    expect(jwtService.signAsync).toHaveBeenCalledWith(
+      {
+        sub: 'transporter-account-id',
+        role: 'TRANSPORTER',
+      },
+      {
+        secret: 'access-secret',
+        expiresIn: 900,
+      },
+    );
+  });
+
   it('verifies refresh tokens with the configured secret', async () => {
     jwtService.verifyAsync.mockResolvedValue({
       sub: 'client-account-id',

--- a/apps/api/src/identity/authentication/application/auth-token.service.ts
+++ b/apps/api/src/identity/authentication/application/auth-token.service.ts
@@ -2,6 +2,8 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
+import type { AccountWithProfiles } from '../../accounts/types/accounts.types';
+import { resolveEffectiveAccountRole } from '../authentication-role.utils';
 import { getAuthenticationConfiguration } from '../cookies/authentication-cookie.config';
 import type {
   AccessTokenPayload,
@@ -9,6 +11,10 @@ import type {
   AuthSessionAccount,
   RefreshTokenPayload,
 } from '../types/authentication.types';
+
+type SignableAccessTokenAccount = (AuthSessionAccount | AccountWithProfiles) & {
+  isMockAdmin?: boolean;
+};
 
 @Injectable()
 export class AuthTokenService {
@@ -49,10 +55,12 @@ export class AuthTokenService {
     return timingSafeEqual(storedHashBuffer, presentedHashBuffer);
   }
 
-  async signAccessToken(account: AuthSessionAccount): Promise<string> {
+  async signAccessToken(
+    account: SignableAccessTokenAccount,
+  ): Promise<string> {
     const payload: AccessTokenPayload = {
       sub: account.id,
-      role: account.role,
+      role: resolveEffectiveAccountRole(account),
       ...(account.isMockAdmin ? { mockAdmin: true } : {}),
     };
 

--- a/apps/api/src/identity/authentication/application/authentication.service.spec.ts
+++ b/apps/api/src/identity/authentication/application/authentication.service.spec.ts
@@ -232,6 +232,50 @@ describe('AuthenticationService', () => {
     );
   });
 
+  it('returns the effective transporter role when logging in with an inconsistent legacy account', async () => {
+    accountsService.findByEmail.mockResolvedValue({
+      id: 'legacy-transporter-account-id',
+      email: 'legacy.transporter@example.com',
+      role: 'CLIENT',
+      isEmailVerified: true,
+      passwordHash: 'stored-password-hash',
+      userProfile: null,
+      transporterProfile: {
+        id: 'transporter-profile-id',
+        displayName: 'Legacy Transportes',
+      },
+    });
+    passwordService.verify.mockResolvedValue(true);
+    authSessionService.createLoginSession.mockResolvedValue({
+      accessToken: 'transporter-access-token',
+      refreshToken: 'transporter-refresh-token',
+    });
+
+    await expect(
+      authenticationService.login(
+        {
+          email: 'legacy.transporter@example.com',
+          password: 'supersafe123',
+        },
+        {
+          ipAddress: '127.0.0.1',
+          userAgent: 'jest',
+        },
+      ),
+    ).resolves.toEqual({
+      response: {
+        account: {
+          id: 'legacy-transporter-account-id',
+          email: 'legacy.transporter@example.com',
+          role: 'TRANSPORTER',
+          isEmailVerified: true,
+        },
+        accessToken: 'transporter-access-token',
+      },
+      refreshToken: 'transporter-refresh-token',
+    });
+  });
+
   it('logs in with the development admin credentials without querying accounts', async () => {
     configService.get.mockImplementation((key: string) => {
       switch (key) {
@@ -438,6 +482,63 @@ describe('AuthenticationService', () => {
     });
 
     expect(accountsService.findById).toHaveBeenCalledWith('client-account-id');
+  });
+
+  it('returns the effective transporter role for auth/me on a legacy transporter account', async () => {
+    accountsService.findById.mockResolvedValue({
+      id: 'legacy-transporter-account-id',
+      email: 'legacy.transporter@example.com',
+      role: 'CLIENT',
+      isEmailVerified: true,
+      passwordHash: 'stored-password-hash',
+      userProfile: null,
+      transporterProfile: {
+        id: 'transporter-profile-id',
+        displayName: 'Legacy Transportes',
+      },
+    });
+
+    await expect(
+      authenticationService.getCurrentAccount({
+        accountId: 'legacy-transporter-account-id',
+        role: 'CLIENT',
+      }),
+    ).resolves.toEqual({
+      id: 'legacy-transporter-account-id',
+      email: 'legacy.transporter@example.com',
+      role: 'TRANSPORTER',
+    });
+  });
+
+  it('returns the effective transporter role for auth/me when the legacy account still has both profiles', async () => {
+    accountsService.findById.mockResolvedValue({
+      id: 'legacy-transporter-account-id',
+      email: 'legacy.transporter@example.com',
+      role: 'CLIENT',
+      isEmailVerified: true,
+      passwordHash: 'stored-password-hash',
+      userProfile: {
+        id: 'user-profile-id',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        phone: '+5491112345678',
+      },
+      transporterProfile: {
+        id: 'transporter-profile-id',
+        displayName: 'Legacy Transportes',
+      },
+    });
+
+    await expect(
+      authenticationService.getCurrentAccount({
+        accountId: 'legacy-transporter-account-id',
+        role: 'CLIENT',
+      }),
+    ).resolves.toEqual({
+      id: 'legacy-transporter-account-id',
+      email: 'legacy.transporter@example.com',
+      role: 'TRANSPORTER',
+    });
   });
 
   it('rejects auth/me when the authenticated account no longer exists', async () => {

--- a/apps/api/src/identity/authentication/application/authentication.service.ts
+++ b/apps/api/src/identity/authentication/application/authentication.service.ts
@@ -13,6 +13,7 @@ import {
   getDevelopmentAdminAuthConfiguration,
   type DevelopmentAdminAuthConfiguration,
 } from '../development-admin-auth.config';
+import { resolveEffectiveAccountRole } from '../authentication-role.utils';
 import type { LoginDto } from '../dto/login.dto';
 import type { RegisterDto } from '../dto/register.dto';
 import type {
@@ -247,7 +248,7 @@ export class AuthenticationService {
     return {
       id: account.id,
       email: account.email,
-      role: account.role,
+      role: resolveEffectiveAccountRole(account),
       isEmailVerified: account.isEmailVerified,
     };
   }
@@ -256,7 +257,7 @@ export class AuthenticationService {
     return {
       id: account.id,
       email: account.email,
-      role: account.role,
+      role: resolveEffectiveAccountRole(account),
     };
   }
 

--- a/apps/api/src/identity/authentication/authentication-role.utils.ts
+++ b/apps/api/src/identity/authentication/authentication-role.utils.ts
@@ -1,0 +1,21 @@
+import type { AccountRole } from '@logistica/shared';
+import type { AuthSessionAccount } from './types/authentication.types';
+
+type RoleAwareAccount = Pick<AuthSessionAccount, 'role'> & {
+  transporterProfile?: object | null;
+  userProfile?: object | null;
+};
+
+export function resolveEffectiveAccountRole(
+  account: RoleAwareAccount,
+): AccountRole {
+  if (account.role !== 'CLIENT') {
+    return account.role;
+  }
+
+  if (account.transporterProfile) {
+    return 'TRANSPORTER';
+  }
+
+  return account.role;
+}

--- a/apps/web/features/auth/services/bootstrap-session.test.ts
+++ b/apps/web/features/auth/services/bootstrap-session.test.ts
@@ -4,6 +4,21 @@ import { bootstrapSessionState } from "./bootstrap-session";
 const originalFetch = global.fetch;
 const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
 
+function createAccessToken(role: "CLIENT" | "TRANSPORTER" | "ADMIN"): string {
+  const encodedPayload = Buffer.from(
+    JSON.stringify({
+      role,
+      sub: "account-id",
+    }),
+  )
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+
+  return `header.${encodedPayload}.signature`;
+}
+
 function createJsonResponse(payload: unknown, init: ResponseInit): Response {
   return new Response(JSON.stringify(payload), {
     headers: {
@@ -116,6 +131,74 @@ describe("bootstrapSessionState", () => {
         id: "ckg1o2p3q0000b8jv1l8zmv6x",
         email: "client@example.com",
         role: "CLIENT",
+      },
+      status: "authenticated",
+    });
+  });
+
+  it("rotates the access token when auth/me resolves a different effective role", async () => {
+    setAccessToken(createAccessToken("CLIENT"));
+
+    const fetchMock = jest.fn<
+      ReturnType<typeof fetch>,
+      Parameters<typeof fetch>
+    >(async (input, init) => {
+      const url = String(input);
+
+      if (fetchMock.mock.calls.length === 1) {
+        expect(url).toBe("/api/auth/me");
+        expect((init?.headers as Headers).get("Authorization")).toContain(
+          "Bearer header.",
+        );
+
+        return createJsonResponse(
+          {
+            id: "ckg1o2p3q0000b8jv1l8zmv6x",
+            email: "transporter@example.com",
+            role: "TRANSPORTER",
+          },
+          { status: 200 },
+        );
+      }
+
+      if (fetchMock.mock.calls.length === 2) {
+        expect(url).toBe("/api/auth/refresh");
+
+        return createJsonResponse(
+          {
+            accessToken: "rotated-transporter-access-token",
+          },
+          { status: 200 },
+        );
+      }
+
+      expect(url).toBe("/api/auth/me");
+      expect((init?.headers as Headers).get("Authorization")).toBe(
+        "Bearer rotated-transporter-access-token",
+      );
+
+      return createJsonResponse(
+        {
+          id: "ckg1o2p3q0000b8jv1l8zmv6x",
+          email: "transporter@example.com",
+          role: "TRANSPORTER",
+        },
+        { status: 200 },
+      );
+    });
+
+    global.fetch = fetchMock;
+
+    const session = await bootstrapSessionState();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(getAccessToken()).toBe("rotated-transporter-access-token");
+    expect(session).toEqual({
+      accessToken: "rotated-transporter-access-token",
+      user: {
+        id: "ckg1o2p3q0000b8jv1l8zmv6x",
+        email: "transporter@example.com",
+        role: "TRANSPORTER",
       },
       status: "authenticated",
     });

--- a/apps/web/features/auth/services/session/access-token-role.ts
+++ b/apps/web/features/auth/services/session/access-token-role.ts
@@ -1,0 +1,71 @@
+import type { AuthRole } from "../../types/auth.types";
+
+type AccessTokenPayload = {
+  role?: unknown;
+};
+
+function decodeBase64Url(value: string): string | null {
+  const normalizedValue = value.replace(/-/g, "+").replace(/_/g, "/");
+  const paddedValue = normalizedValue.padEnd(
+    Math.ceil(normalizedValue.length / 4) * 4,
+    "=",
+  );
+
+  try {
+    if (typeof globalThis.atob === "function") {
+      const decodedValue = globalThis.atob(paddedValue);
+
+      return decodeURIComponent(
+        Array.from(decodedValue)
+          .map((character) =>
+            `%${character.charCodeAt(0).toString(16).padStart(2, "0")}`,
+          )
+          .join(""),
+      );
+    }
+
+    if (typeof Buffer !== "undefined") {
+      return Buffer.from(paddedValue, "base64").toString("utf-8");
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+export function getAccessTokenRole(
+  accessToken: string | null | undefined,
+): AuthRole | null {
+  if (!accessToken) {
+    return null;
+  }
+
+  const [, payloadSegment] = accessToken.split(".");
+
+  if (!payloadSegment) {
+    return null;
+  }
+
+  const decodedPayload = decodeBase64Url(payloadSegment);
+
+  if (!decodedPayload) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(decodedPayload) as AccessTokenPayload;
+
+    if (
+      payload.role === "CLIENT" ||
+      payload.role === "TRANSPORTER" ||
+      payload.role === "ADMIN"
+    ) {
+      return payload.role;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}

--- a/apps/web/features/auth/services/session/bootstrap-session.ts
+++ b/apps/web/features/auth/services/session/bootstrap-session.ts
@@ -1,6 +1,7 @@
 import type { AuthSessionSnapshot } from "../../types/auth.types";
 import { getMe, isUnauthorizedApiError, refreshSession } from "../api/auth-api";
 import { clearAccessToken, getAccessToken } from "./access-token-store";
+import { getAccessTokenRole } from "./access-token-role";
 
 const UNAUTHENTICATED_SESSION: AuthSessionSnapshot = {
   accessToken: null,
@@ -8,12 +9,29 @@ const UNAUTHENTICATED_SESSION: AuthSessionSnapshot = {
   status: "unauthenticated",
 };
 
+async function refreshAuthenticatedSession(): Promise<AuthSessionSnapshot> {
+  const refreshResult = await refreshSession();
+  const user = await getMe(refreshResult.accessToken);
+
+  return {
+    accessToken: refreshResult.accessToken,
+    user,
+    status: "authenticated",
+  };
+}
+
 export async function bootstrapSessionState(): Promise<AuthSessionSnapshot> {
   try {
-    const user = await getMe();
+    const currentAccessToken = getAccessToken();
+    const user = await getMe(currentAccessToken);
+    const tokenRole = getAccessTokenRole(currentAccessToken);
+
+    if (tokenRole && tokenRole !== user.role) {
+      return await refreshAuthenticatedSession();
+    }
 
     return {
-      accessToken: getAccessToken(),
+      accessToken: currentAccessToken,
       user,
       status: "authenticated",
     };
@@ -25,14 +43,7 @@ export async function bootstrapSessionState(): Promise<AuthSessionSnapshot> {
   }
 
   try {
-    const refreshResult = await refreshSession();
-    const user = await getMe(refreshResult.accessToken);
-
-    return {
-      accessToken: refreshResult.accessToken,
-      user,
-      status: "authenticated",
-    };
+    return await refreshAuthenticatedSession();
   } catch {
     clearAccessToken();
     return UNAUTHENTICATED_SESSION;


### PR DESCRIPTION
Título:                                                                                                                                      
                                                                                                                                               
  fix(auth): resolve legacy transporter session role                                                                                           
                                                                                                                                               
  Descripción:                                                                                                                                 
                                                                                                                                               
  ## Contexto                                                                                                                                  
  Algunas cuentas legacy de transportista quedaban autenticando con `role = CLIENT` aunque ya tuvieran `transporterProfile`. Eso rompía el     
  acceso a rutas protegidas del transportista y disparaba errores 403 al entrar a `vehicles`, `trailers` y onboarding.                         
                                                                                                                                               
  Durante el diagnóstico también apareció un error 500 al crear vehicles en local, pero ese caso no requería cambio de código: la causa fue una
  migración de flota pendiente (`20260406154425_add_fleet_entities`) en la base local.                                                         
                                                                                                                                               
  ## Alcance                                                                                                                                   
  - resolver el rol efectivo de cuentas legacy con `transporterProfile`                                                                        
  - emitir access tokens con el rol efectivo correcto                                                                                          
  - hacer que el bootstrap del frontend rote tokens viejos cuando `auth/me` devuelve un rol distinto al embebido en el token                   
  - agregar cobertura de tests para cuentas legacy con uno o ambos perfiles                                                                    
                                                                                                                                               
  ## Cambios principales                                                                                                                       
  - `auth` ahora trata como `TRANSPORTER` a cuentas legacy que tengan `transporterProfile`                                                     
  - `auth/me` y `login` devuelven el rol efectivo, no el rol legacy inconsistente                                                              
  - la firma de access token usa ese rol efectivo                                                                                              
  - el frontend detecta desajustes entre el rol del token y el rol de `auth/me`, fuerza `refresh` y continúa con la sesión corregida           
                                                                                                                                               
  ## Riesgos                                                                                                                                   
  - toca zona protegida de `auth`                                                                                                              
  - no cambia permisos de negocio ni endpoints públicos; solo corrige la resolución de identidad de sesiones legacy                            
                                                                                                                                               
  ## Cómo testear                                                                                                                              
  1. Ingresar con una cuenta transportista legacy.                                                                                             
  2. Abrir `/vehicles`, `/trailers` y `/onboarding/transporter`.                                                                               
  3. Confirmar que ya no aparece el 403 del guard.                                                                                             
  4. Cerrar sesión, volver a ingresar y verificar que la sesión se restablece correctamente.                                                   
                                                                                                                                               
  ## Validación ejecutada                                                                                                                      
  - `pnpm --filter @logistica/api exec jest --config jest.config.cjs --runInBand src/identity/authentication/application/auth-                 
  token.service.spec.ts src/identity/authentication/application/authentication.service.spec.ts`                                                
  - `pnpm --filter @logistica/web exec jest --config jest.config.cjs --runInBand features/auth/services/bootstrap-session.test.ts`             
  - `pnpm --filter @logistica/api exec tsc --noEmit`                                  