### PR TITLE
feat(database): add TripOffer base model for E4-BE-01

### DIFF
--- a/packages/database/prisma/migrations/20260421173000_add_trip_offer_model/migration.sql
+++ b/packages/database/prisma/migrations/20260421173000_add_trip_offer_model/migration.sql
@@ -1,0 +1,65 @@
+-- CreateEnum
+CREATE TYPE "TripOfferStatus" AS ENUM (
+    'DRAFT',
+    'PUBLISHED',
+    'FULL',
+    'CLOSED',
+    'CANCELLED'
+);
+
+-- CreateTable
+CREATE TABLE "trip_offers" (
+    "id" TEXT NOT NULL,
+    "transporterProfileId" TEXT NOT NULL,
+    "originLabel" TEXT NOT NULL,
+    "originLat" DECIMAL(9,6) NOT NULL,
+    "originLng" DECIMAL(9,6) NOT NULL,
+    "destinationLabel" TEXT NOT NULL,
+    "destinationLat" DECIMAL(9,6) NOT NULL,
+    "destinationLng" DECIMAL(9,6) NOT NULL,
+    "departureDate" TIMESTAMP(3),
+    "departureWindowStart" TIMESTAMP(3),
+    "departureWindowEnd" TIMESTAMP(3),
+    "capacityTotal" INTEGER NOT NULL,
+    "availableCapacity" INTEGER NOT NULL,
+    "pricePerSlot" INTEGER NOT NULL,
+    "maxDetourKm" INTEGER,
+    "notes" TEXT,
+    "cancellationPolicy" TEXT,
+    "cargoType" "CargoType" NOT NULL DEFAULT 'EQUINE',
+    "isReturn" BOOLEAN NOT NULL DEFAULT false,
+    "status" "TripOfferStatus" NOT NULL DEFAULT 'DRAFT',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "trip_offers_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "trip_offers_capacityTotal_check" CHECK ("capacityTotal" > 0),
+    CONSTRAINT "trip_offers_availableCapacity_check" CHECK (
+        "availableCapacity" >= 0
+        AND "availableCapacity" <= "capacityTotal"
+    )
+);
+
+-- CreateIndex
+CREATE INDEX "trip_offers_transporterProfileId_idx"
+ON "trip_offers"("transporterProfileId");
+
+-- CreateIndex
+CREATE INDEX "trip_offers_transporterProfileId_status_idx"
+ON "trip_offers"("transporterProfileId", "status");
+
+-- CreateIndex
+CREATE INDEX "trip_offers_status_idx"
+ON "trip_offers"("status");
+
+-- CreateIndex
+CREATE INDEX "trip_offers_cargoType_status_idx"
+ON "trip_offers"("cargoType", "status");
+
+-- AddForeignKey
+ALTER TABLE "trip_offers"
+ADD CONSTRAINT "trip_offers_transporterProfileId_fkey"
+FOREIGN KEY ("transporterProfileId")
+REFERENCES "transporter_profiles"("id")
+ON DELETE CASCADE
+ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -41,6 +41,14 @@ enum CapacityUnit {
   SEAT
 }
 
+enum TripOfferStatus {
+  DRAFT
+  PUBLISHED
+  FULL
+  CLOSED
+  CANCELLED
+}
+
 model Account {
   id                 String              @id @default(cuid())
   email              String              @unique
@@ -92,6 +100,7 @@ model TransporterProfile {
   account            Account   @relation(fields: [accountId], references: [id], onDelete: Cascade)
   vehicles           Vehicle[]
   trailers           Trailer[]
+  tripOffers         TripOffer[]
 
   @@map("transporter_profiles")
 }
@@ -133,6 +142,39 @@ model Trailer {
   @@index([transporterProfileId, isActive])
   @@index([vehicleId])
   @@map("trailers")
+}
+
+model TripOffer {
+  id                   String           @id @default(cuid())
+  transporterProfileId String
+  originLabel          String
+  originLat            Decimal          @db.Decimal(9, 6)
+  originLng            Decimal          @db.Decimal(9, 6)
+  destinationLabel     String
+  destinationLat       Decimal          @db.Decimal(9, 6)
+  destinationLng       Decimal          @db.Decimal(9, 6)
+  departureDate        DateTime?
+  departureWindowStart DateTime?
+  departureWindowEnd   DateTime?
+  capacityTotal        Int
+  availableCapacity    Int
+  pricePerSlot         Int
+  maxDetourKm          Int?
+  notes                String?
+  cancellationPolicy   String?
+  cargoType            CargoType        @default(EQUINE)
+  isReturn             Boolean          @default(false)
+  status               TripOfferStatus  @default(DRAFT)
+  createdAt            DateTime         @default(now())
+  updatedAt            DateTime         @updatedAt
+
+  transporterProfile   TransporterProfile @relation(fields: [transporterProfileId], references: [id], onDelete: Cascade)
+
+  @@index([transporterProfileId])
+  @@index([transporterProfileId, status])
+  @@index([status])
+  @@index([cargoType, status])
+  @@map("trip_offers")
 }
 
 model Session {

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -3,10 +3,13 @@ export { PrismaService } from './prisma.service';
 export {
   AccountRole,
   AccountStatus,
+  CargoType,
   Prisma,
+  TripOfferStatus,
   TransporterVerificationStatus,
   type Account,
   type Session,
+  type TripOffer,
   type TransporterProfile,
   type UserProfile,
 } from '../generated/prisma';


### PR DESCRIPTION
## Contexto

Resuelve la issue `E4-BE-01` de la épica `E4-BE - Publicación de ofertas backend`.

El objetivo de esta PR es dejar lista la base de datos para la siguiente issue de crear/editar borradores de ofertas, sin agregar endpoints, services, DTOs ni lógica de negocio fuera del alcance.

## Alcance

Incluye únicamente:

- modelado Prisma de `TripOffer`
- enum `TripOfferStatus`
- relación correcta con la entidad real del transportista ya existente
- migración SQL versionada
- regeneración del Prisma Client
- exports públicos necesarios desde `@logistica/database`

No incluye:

- controllers
- services
- DTOs
- endpoints
- lógica de publicación
- lógica de edición
- búsqueda pública
- booking
- pagos

## Análisis previo aplicado

Antes del cambio se revisó el estado real del repo para no rediseñar el dominio:

- el transportista existente es `TransporterProfile`
- `CargoType` ya existía en el schema base
- el proyecto ya usa `cuid()` para ids
- el patrón actual usa `createdAt` / `updatedAt`
- las relaciones hijas de `TransporterProfile` usan `onDelete: Cascade`
- las tablas usan `@@map` en plural snake_case

## Decisiones de modelado

### Relación con transportista

`TripOffer` se relaciona con `TransporterProfile`, no con `Account`, para seguir la misma convención que ya usan `Vehicle` y `Trailer`.

### Origen y destino

Se eligió una forma explícita y mínima con coordenadas tipadas:

- `originLabel`
- `originLat`
- `originLng`
- `destinationLabel`
- `destinationLat`
- `destinationLng`

Esto evita JSON innecesario y deja mejor base para filtros y búsqueda futura.

### Fecha exacta o rango

Se dejó preparado el soporte con:

- `departureDate`
- `departureWindowStart`
- `departureWindowEnd`

La validación de dominio de “fecha exacta o rango válido” se deja para la siguiente issue de aplicación.

### Precio

`pricePerSlot` se modeló como `Int` para persistir monto entero y evitar problemas de redondeo.

### Desvío máximo

`maxDetourKm` quedó nullable.

Esto está alineado con el dominio actual porque ya existe `TransporterProfile.maxDetourKmDefault` como valor por defecto opcional, y el glosario indica que el desvío por oferta puede sobrescribirse.

### Retornos

Se agregó `isReturn` y no se agregó `parentOfferId` en esta issue para mantener el alcance mínimo pedido.

## Cambios realizados

### Schema

Se agregó el enum:

- `TripOfferStatus`
  - `DRAFT`
  - `PUBLISHED`
  - `FULL`
  - `CLOSED`
  - `CANCELLED`

Se agregó el modelo `TripOffer` con estos campos:

- `id`
- `transporterProfileId`
- `originLabel`
- `originLat`
- `originLng`
- `destinationLabel`
- `destinationLat`
- `destinationLng`
- `departureDate`
- `departureWindowStart`
- `departureWindowEnd`
- `capacityTotal`
- `availableCapacity`
- `pricePerSlot`
- `maxDetourKm`
- `notes`
- `cancellationPolicy`
- `cargoType`
- `isReturn`
- `status`
- `createdAt`
- `updatedAt`

También se agregó la relación inversa:

- `TransporterProfile.tripOffers`

### Índices

Se agregaron solo los mínimos definidos para esta issue:

- `trip_offers_transporterProfileId_idx`
- `trip_offers_transporterProfileId_status_idx`
- `trip_offers_status_idx`
- `trip_offers_cargoType_status_idx`

### Constraints

La migración incluye `CHECK` reales para reforzar reglas base de capacidad:

- `capacityTotal > 0`
- `availableCapacity >= 0`
- `availableCapacity <= capacityTotal`

## Archivos modificados

- `packages/database/prisma/schema.prisma`
- `packages/database/prisma/migrations/20260421173000_add_trip_offer_model/migration.sql`
- `packages/database/src/index.ts`

## Verificación realizada

Se ejecutó correctamente:

- `pnpm --filter @logistica/database db:generate`
- `pnpm --filter @logistica/database build`

## Limitaciones / notas operativas

No se pudo ejecutar `prisma migrate dev` contra la base local porque `localhost:5432` no estaba disponible durante la implementación (`P1001: Can't reach database server`).

Por eso:

- la migración quedó versionada manualmente en SQL
- el schema y el client sí fueron regenerados y compilados

## Riesgos / impacto para la siguiente issue

- La próxima issue ya puede apoyarse en `TripOffer` para crear/editar borradores.
- Si más adelante se necesita enlazar retornos con su viaje original, habrá que agregar `parentOfferId` en una migración posterior.
- La validación estricta entre `departureDate` y `departureWindowStart/End` todavía queda a nivel aplicación en la próxima etapa.

## Cómo probar / revisar

1. Revisar el nuevo enum `TripOfferStatus`.
2. Revisar el modelo `TripOffer` y su relación con `TransporterProfile`.
3. Confirmar que la migración SQL contiene los `CHECK` de capacidad.
4. Confirmar que `@logistica/database` expone `CargoType`, `TripOfferStatus` y `TripOffer`.
5. Si hay una DB local activa, correr:
   - `pnpm --filter @logistica/database db:migrate`
   - `pnpm --filter @logistica/database db:generate`
   - `pnpm --filter @logistica/database build`
