### PR TITLE
feat(api): add TripOffer draft create and update endpoints for E4-BE-02

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,6 +6,7 @@ import { AccountsModule } from './identity/accounts/accounts.module';
 import { AuthenticationModule } from './identity/authentication/authentication.module';
 import { TransporterProfileModule } from './identity/transporter-profile/transporter-profile.module';
 import { TrailerModule } from './trailer/trailer.module';
+import { TripOfferModule } from './trip-offer/trip-offer.module';
 import { VehicleModule } from './vehicle/vehicle.module';
 
 @Module({
@@ -38,6 +39,7 @@ import { VehicleModule } from './vehicle/vehicle.module';
     AuthenticationModule,
     TransporterProfileModule,
     TrailerModule,
+    TripOfferModule,
     VehicleModule,
   ],
   controllers: [],

--- a/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
+++ b/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
@@ -1,0 +1,365 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@logistica/database';
+import { TripOfferService } from './trip-offer.service';
+
+describe('TripOfferService', () => {
+  const tripOfferRepository = {
+    findTransporterProfileByAccountId: jest.fn(),
+    findById: jest.fn(),
+    create: jest.fn(),
+    updateById: jest.fn(),
+  };
+
+  let tripOfferService: TripOfferService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tripOfferService = new TripOfferService(tripOfferRepository as never);
+  });
+
+  it('creates a draft trip offer for the authenticated transporter', async () => {
+    const createdAt = new Date('2026-04-21T10:00:00.000Z');
+    const updatedAt = new Date('2026-04-21T10:00:00.000Z');
+    const departureDate = new Date('2026-05-01T00:00:00.000Z');
+
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+    tripOfferRepository.create.mockResolvedValue({
+      id: 'trip-offer-id',
+      transporterProfileId: 'transporter-profile-id',
+      originLabel: 'Buenos Aires',
+      originLat: new Prisma.Decimal('-34.603722'),
+      originLng: new Prisma.Decimal('-58.381592'),
+      destinationLabel: 'Rosario',
+      destinationLat: new Prisma.Decimal('-32.944243'),
+      destinationLng: new Prisma.Decimal('-60.650539'),
+      departureDate,
+      departureWindowStart: null,
+      departureWindowEnd: null,
+      capacityTotal: 6,
+      availableCapacity: 6,
+      pricePerSlot: 120000,
+      maxDetourKm: 50,
+      notes: 'Salida temprana',
+      cancellationPolicy: 'Flexible',
+      cargoType: 'EQUINE',
+      isReturn: false,
+      status: 'DRAFT',
+      createdAt,
+      updatedAt,
+    });
+
+    await expect(
+      tripOfferService.createOwnTripOffer('account-id', {
+        originLabel: ' Buenos Aires ',
+        originLat: -34.603722,
+        originLng: -58.381592,
+        destinationLabel: ' Rosario ',
+        destinationLat: -32.944243,
+        destinationLng: -60.650539,
+        departureDate,
+        departureWindowStart: null,
+        departureWindowEnd: null,
+        capacityTotal: 6,
+        availableCapacity: 2,
+        pricePerSlot: 120000,
+        maxDetourKm: 50,
+        notes: ' Salida temprana ',
+        cancellationPolicy: ' Flexible ',
+        cargoType: 'EQUINE',
+        isReturn: false,
+      }),
+    ).resolves.toEqual({
+      id: 'trip-offer-id',
+      originLabel: 'Buenos Aires',
+      originLat: -34.603722,
+      originLng: -58.381592,
+      destinationLabel: 'Rosario',
+      destinationLat: -32.944243,
+      destinationLng: -60.650539,
+      departureDate,
+      departureWindowStart: null,
+      departureWindowEnd: null,
+      capacityTotal: 6,
+      availableCapacity: 6,
+      pricePerSlot: 120000,
+      maxDetourKm: 50,
+      notes: 'Salida temprana',
+      cancellationPolicy: 'Flexible',
+      cargoType: 'EQUINE',
+      isReturn: false,
+      status: 'DRAFT',
+      createdAt,
+      updatedAt,
+    });
+
+    expect(
+      tripOfferRepository.findTransporterProfileByAccountId,
+    ).toHaveBeenCalledWith('account-id');
+    expect(tripOfferRepository.create).toHaveBeenCalledWith(
+      'transporter-profile-id',
+      expect.objectContaining({
+        originLabel: 'Buenos Aires',
+        destinationLabel: 'Rosario',
+        capacityTotal: 6,
+        availableCapacity: 6,
+        notes: 'Salida temprana',
+        cancellationPolicy: 'Flexible',
+      }),
+    );
+  });
+
+  it('throws when the authenticated account has no transporter profile', async () => {
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue(
+      null,
+    );
+
+    await expect(
+      tripOfferService.createOwnTripOffer('missing-account', {
+        originLabel: 'Buenos Aires',
+        originLat: -34.603722,
+        originLng: -58.381592,
+        destinationLabel: 'Rosario',
+        destinationLat: -32.944243,
+        destinationLng: -60.650539,
+        departureDate: new Date('2026-05-01T00:00:00.000Z'),
+        departureWindowStart: null,
+        departureWindowEnd: null,
+        capacityTotal: 6,
+        availableCapacity: 6,
+        pricePerSlot: 120000,
+        maxDetourKm: 50,
+        notes: null,
+        cancellationPolicy: null,
+        cargoType: 'EQUINE',
+        isReturn: false,
+      }),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws when creating a trip offer with an invalid temporal modality', async () => {
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+
+    await expect(
+      tripOfferService.createOwnTripOffer('account-id', {
+        originLabel: 'Buenos Aires',
+        originLat: -34.603722,
+        originLng: -58.381592,
+        destinationLabel: 'Rosario',
+        destinationLat: -32.944243,
+        destinationLng: -60.650539,
+        departureDate: new Date('2026-05-01T00:00:00.000Z'),
+        departureWindowStart: new Date('2026-05-01T08:00:00.000Z'),
+        departureWindowEnd: new Date('2026-05-01T12:00:00.000Z'),
+        capacityTotal: 6,
+        availableCapacity: 6,
+        pricePerSlot: 120000,
+        maxDetourKm: 50,
+        notes: null,
+        cancellationPolicy: null,
+        cargoType: 'EQUINE',
+        isReturn: false,
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(tripOfferRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('updates an owned draft trip offer and resyncs available capacity', async () => {
+    const updatedAt = new Date('2026-04-21T12:00:00.000Z');
+
+    tripOfferRepository.findById.mockResolvedValue({
+      id: 'trip-offer-id',
+      transporterProfileId: 'transporter-profile-id',
+      originLabel: 'Buenos Aires',
+      originLat: new Prisma.Decimal('-34.603722'),
+      originLng: new Prisma.Decimal('-58.381592'),
+      destinationLabel: 'Rosario',
+      destinationLat: new Prisma.Decimal('-32.944243'),
+      destinationLng: new Prisma.Decimal('-60.650539'),
+      departureDate: new Date('2026-05-01T00:00:00.000Z'),
+      departureWindowStart: null,
+      departureWindowEnd: null,
+      capacityTotal: 6,
+      availableCapacity: 4,
+      pricePerSlot: 120000,
+      maxDetourKm: 50,
+      notes: 'Salida temprana',
+      cancellationPolicy: 'Flexible',
+      cargoType: 'EQUINE',
+      isReturn: false,
+      status: 'DRAFT',
+      createdAt: new Date('2026-04-21T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-21T10:00:00.000Z'),
+    });
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+    tripOfferRepository.updateById.mockResolvedValue({
+      id: 'trip-offer-id',
+      transporterProfileId: 'transporter-profile-id',
+      originLabel: 'Buenos Aires',
+      originLat: new Prisma.Decimal('-34.603722'),
+      originLng: new Prisma.Decimal('-58.381592'),
+      destinationLabel: 'Cordoba',
+      destinationLat: new Prisma.Decimal('-31.420083'),
+      destinationLng: new Prisma.Decimal('-64.188776'),
+      departureDate: null,
+      departureWindowStart: new Date('2026-05-02T08:00:00.000Z'),
+      departureWindowEnd: new Date('2026-05-02T12:00:00.000Z'),
+      capacityTotal: 10,
+      availableCapacity: 10,
+      pricePerSlot: 140000,
+      maxDetourKm: 70,
+      notes: null,
+      cancellationPolicy: 'Moderada',
+      cargoType: 'GENERAL_CARGO',
+      isReturn: true,
+      status: 'DRAFT',
+      createdAt: new Date('2026-04-21T10:00:00.000Z'),
+      updatedAt,
+    });
+
+    await expect(
+      tripOfferService.updateOwnTripOffer('account-id', 'trip-offer-id', {
+        destinationLabel: ' Cordoba ',
+        destinationLat: -31.420083,
+        destinationLng: -64.188776,
+        departureDate: null,
+        departureWindowStart: new Date('2026-05-02T08:00:00.000Z'),
+        departureWindowEnd: new Date('2026-05-02T12:00:00.000Z'),
+        capacityTotal: 10,
+        availableCapacity: 1,
+        pricePerSlot: 140000,
+        maxDetourKm: 70,
+        notes: '   ',
+        cancellationPolicy: ' Moderada ',
+        cargoType: 'GENERAL_CARGO',
+        isReturn: true,
+      }),
+    ).resolves.toEqual({
+      id: 'trip-offer-id',
+      originLabel: 'Buenos Aires',
+      originLat: -34.603722,
+      originLng: -58.381592,
+      destinationLabel: 'Cordoba',
+      destinationLat: -31.420083,
+      destinationLng: -64.188776,
+      departureDate: null,
+      departureWindowStart: new Date('2026-05-02T08:00:00.000Z'),
+      departureWindowEnd: new Date('2026-05-02T12:00:00.000Z'),
+      capacityTotal: 10,
+      availableCapacity: 10,
+      pricePerSlot: 140000,
+      maxDetourKm: 70,
+      notes: null,
+      cancellationPolicy: 'Moderada',
+      cargoType: 'GENERAL_CARGO',
+      isReturn: true,
+      status: 'DRAFT',
+      createdAt: new Date('2026-04-21T10:00:00.000Z'),
+      updatedAt,
+    });
+
+    expect(tripOfferRepository.updateById).toHaveBeenCalledWith(
+      'trip-offer-id',
+      expect.objectContaining({
+        destinationLabel: 'Cordoba',
+        capacityTotal: 10,
+        availableCapacity: 10,
+        notes: null,
+        cancellationPolicy: 'Moderada',
+      }),
+    );
+  });
+
+  it('throws when updating a trip offer that does not exist', async () => {
+    tripOfferRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      tripOfferService.updateOwnTripOffer('account-id', 'missing-id', {
+        pricePerSlot: 140000,
+      }),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws when updating a trip offer owned by another transporter', async () => {
+    tripOfferRepository.findById.mockResolvedValue({
+      id: 'trip-offer-id',
+      transporterProfileId: 'other-transporter-profile-id',
+      originLabel: 'Buenos Aires',
+      originLat: new Prisma.Decimal('-34.603722'),
+      originLng: new Prisma.Decimal('-58.381592'),
+      destinationLabel: 'Rosario',
+      destinationLat: new Prisma.Decimal('-32.944243'),
+      destinationLng: new Prisma.Decimal('-60.650539'),
+      departureDate: new Date('2026-05-01T00:00:00.000Z'),
+      departureWindowStart: null,
+      departureWindowEnd: null,
+      capacityTotal: 6,
+      availableCapacity: 6,
+      pricePerSlot: 120000,
+      maxDetourKm: 50,
+      notes: null,
+      cancellationPolicy: null,
+      cargoType: 'EQUINE',
+      isReturn: false,
+      status: 'DRAFT',
+      createdAt: new Date('2026-04-21T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-21T10:00:00.000Z'),
+    });
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+
+    await expect(
+      tripOfferService.updateOwnTripOffer('account-id', 'trip-offer-id', {
+        pricePerSlot: 140000,
+      }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('throws when updating a trip offer that is no longer in draft', async () => {
+    tripOfferRepository.findById.mockResolvedValue({
+      id: 'trip-offer-id',
+      transporterProfileId: 'transporter-profile-id',
+      originLabel: 'Buenos Aires',
+      originLat: new Prisma.Decimal('-34.603722'),
+      originLng: new Prisma.Decimal('-58.381592'),
+      destinationLabel: 'Rosario',
+      destinationLat: new Prisma.Decimal('-32.944243'),
+      destinationLng: new Prisma.Decimal('-60.650539'),
+      departureDate: new Date('2026-05-01T00:00:00.000Z'),
+      departureWindowStart: null,
+      departureWindowEnd: null,
+      capacityTotal: 6,
+      availableCapacity: 6,
+      pricePerSlot: 120000,
+      maxDetourKm: 50,
+      notes: null,
+      cancellationPolicy: null,
+      cargoType: 'EQUINE',
+      isReturn: false,
+      status: 'PUBLISHED',
+      createdAt: new Date('2026-04-21T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-21T10:00:00.000Z'),
+    });
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+
+    await expect(
+      tripOfferService.updateOwnTripOffer('account-id', 'trip-offer-id', {
+        pricePerSlot: 140000,
+      }),
+    ).rejects.toThrow(ConflictException);
+  });
+});

--- a/apps/api/src/trip-offer/application/trip-offer.service.ts
+++ b/apps/api/src/trip-offer/application/trip-offer.service.ts
@@ -1,0 +1,392 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import type { TripOfferResponseDto } from '../dto/trip-offer.response.dto';
+import { TripOfferRepository } from '../repositories/trip-offer.repository';
+import type {
+  CreateTripOfferInput,
+  TripOfferRecord,
+  UpdateTripOfferInput,
+} from '../types/trip-offer.types';
+
+type NullableTemporalInput = {
+  departureDate?: Date | null;
+  departureWindowStart?: Date | null;
+  departureWindowEnd?: Date | null;
+};
+
+type TripOfferDraftState = Pick<
+  TripOfferRecord,
+  | 'originLabel'
+  | 'destinationLabel'
+  | 'departureDate'
+  | 'departureWindowStart'
+  | 'departureWindowEnd'
+  | 'capacityTotal'
+  | 'pricePerSlot'
+  | 'maxDetourKm'
+  | 'notes'
+  | 'cancellationPolicy'
+  | 'cargoType'
+  | 'isReturn'
+> & {
+  originLat: number;
+  originLng: number;
+  destinationLat: number;
+  destinationLng: number;
+};
+
+@Injectable()
+export class TripOfferService {
+  constructor(private readonly tripOfferRepository: TripOfferRepository) {}
+
+  async createOwnTripOffer(
+    accountId: string,
+    input: CreateTripOfferInput,
+  ): Promise<TripOfferResponseDto> {
+    const transporterProfile =
+      await this.tripOfferRepository.findTransporterProfileByAccountId(
+        accountId,
+      );
+
+    if (!transporterProfile) {
+      throw new NotFoundException(
+        'Transporter profile not found for the authenticated account.',
+      );
+    }
+
+    const normalizedInput = this.normalizeCreateInput(input);
+    this.validateDraftState(normalizedInput);
+
+    const createdTripOffer = await this.tripOfferRepository.create(
+      transporterProfile.id,
+      normalizedInput,
+    );
+
+    return this.toTripOfferResponse(createdTripOffer);
+  }
+
+  async updateOwnTripOffer(
+    accountId: string,
+    tripOfferId: string,
+    input: UpdateTripOfferInput,
+  ): Promise<TripOfferResponseDto> {
+    const existingTripOffer =
+      await this.tripOfferRepository.findById(tripOfferId);
+
+    if (!existingTripOffer) {
+      throw new NotFoundException('Trip offer not found.');
+    }
+
+    const transporterProfile =
+      await this.tripOfferRepository.findTransporterProfileByAccountId(
+        accountId,
+      );
+
+    if (!transporterProfile) {
+      throw new NotFoundException(
+        'Transporter profile not found for the authenticated account.',
+      );
+    }
+
+    if (existingTripOffer.transporterProfileId !== transporterProfile.id) {
+      throw new ForbiddenException(
+        'You cannot edit a trip offer that belongs to another transporter.',
+      );
+    }
+
+    if (existingTripOffer.status !== 'DRAFT') {
+      throw new ConflictException(
+        'Only trip offers in DRAFT status can be edited.',
+      );
+    }
+
+    const normalizedInput = this.normalizeUpdateInput(input);
+    const finalDraftState = this.mergeDraftState(
+      existingTripOffer,
+      normalizedInput,
+    );
+
+    this.validateDraftState(finalDraftState);
+
+    const updatedTripOffer = await this.tripOfferRepository.updateById(
+      tripOfferId,
+      {
+        ...this.toUpdateData(normalizedInput),
+        availableCapacity: finalDraftState.capacityTotal,
+      },
+    );
+
+    return this.toTripOfferResponse(updatedTripOffer);
+  }
+
+  private validateDraftState(input: {
+    departureDate?: Date | null;
+    departureWindowStart?: Date | null;
+    departureWindowEnd?: Date | null;
+    capacityTotal: number;
+    pricePerSlot: number;
+    maxDetourKm?: number | null;
+  }): void {
+    this.validateTemporalState(input);
+
+    if (!Number.isInteger(input.capacityTotal) || input.capacityTotal <= 0) {
+      throw new BadRequestException(
+        'Trip offer total capacity must be a positive integer.',
+      );
+    }
+
+    if (!Number.isInteger(input.pricePerSlot) || input.pricePerSlot < 0) {
+      throw new BadRequestException(
+        'Trip offer slot price must be a non-negative integer.',
+      );
+    }
+
+    if (
+      input.maxDetourKm !== null &&
+      input.maxDetourKm !== undefined &&
+      (!Number.isInteger(input.maxDetourKm) || input.maxDetourKm < 0)
+    ) {
+      throw new BadRequestException(
+        'Trip offer max detour must be a non-negative integer.',
+      );
+    }
+  }
+
+  private validateTemporalState(input: NullableTemporalInput): void {
+    const hasDepartureDate = input.departureDate instanceof Date;
+    const hasWindowStart = input.departureWindowStart instanceof Date;
+    const hasWindowEnd = input.departureWindowEnd instanceof Date;
+    const hasWindow = hasWindowStart || hasWindowEnd;
+
+    if (hasDepartureDate === hasWindow) {
+      throw new BadRequestException(
+        'Trip offer must define either a departure date or a complete departure window.',
+      );
+    }
+
+    if (hasWindowStart !== hasWindowEnd) {
+      throw new BadRequestException(
+        'Trip offer departure window requires both start and end values.',
+      );
+    }
+
+    if (
+      hasWindowStart &&
+      hasWindowEnd &&
+      input.departureWindowStart!.getTime() >=
+        input.departureWindowEnd!.getTime()
+    ) {
+      throw new BadRequestException(
+        'Trip offer departure window start must be before the end.',
+      );
+    }
+  }
+
+  private normalizeCreateInput(
+    input: CreateTripOfferInput,
+  ): CreateTripOfferInput {
+    return {
+      originLabel: input.originLabel.trim(),
+      originLat: input.originLat,
+      originLng: input.originLng,
+      destinationLabel: input.destinationLabel.trim(),
+      destinationLat: input.destinationLat,
+      destinationLng: input.destinationLng,
+      departureDate: input.departureDate ?? null,
+      departureWindowStart: input.departureWindowStart ?? null,
+      departureWindowEnd: input.departureWindowEnd ?? null,
+      capacityTotal: input.capacityTotal,
+      availableCapacity: input.capacityTotal,
+      pricePerSlot: input.pricePerSlot,
+      maxDetourKm: input.maxDetourKm ?? null,
+      notes: this.normalizeNullableText(input.notes),
+      cancellationPolicy: this.normalizeNullableText(input.cancellationPolicy),
+      cargoType: input.cargoType,
+      isReturn: input.isReturn,
+    };
+  }
+
+  private normalizeUpdateInput(
+    input: UpdateTripOfferInput,
+  ): UpdateTripOfferInput {
+    return {
+      ...(input.originLabel !== undefined
+        ? { originLabel: input.originLabel.trim() }
+        : {}),
+      ...(input.originLat !== undefined ? { originLat: input.originLat } : {}),
+      ...(input.originLng !== undefined ? { originLng: input.originLng } : {}),
+      ...(input.destinationLabel !== undefined
+        ? { destinationLabel: input.destinationLabel.trim() }
+        : {}),
+      ...(input.destinationLat !== undefined
+        ? { destinationLat: input.destinationLat }
+        : {}),
+      ...(input.destinationLng !== undefined
+        ? { destinationLng: input.destinationLng }
+        : {}),
+      ...(input.departureDate !== undefined
+        ? { departureDate: input.departureDate }
+        : {}),
+      ...(input.departureWindowStart !== undefined
+        ? { departureWindowStart: input.departureWindowStart }
+        : {}),
+      ...(input.departureWindowEnd !== undefined
+        ? { departureWindowEnd: input.departureWindowEnd }
+        : {}),
+      ...(input.capacityTotal !== undefined
+        ? { capacityTotal: input.capacityTotal }
+        : {}),
+      ...(input.availableCapacity !== undefined
+        ? { availableCapacity: input.availableCapacity }
+        : {}),
+      ...(input.pricePerSlot !== undefined
+        ? { pricePerSlot: input.pricePerSlot }
+        : {}),
+      ...(input.maxDetourKm !== undefined
+        ? { maxDetourKm: input.maxDetourKm }
+        : {}),
+      ...(input.notes !== undefined
+        ? { notes: this.normalizeNullableText(input.notes) }
+        : {}),
+      ...(input.cancellationPolicy !== undefined
+        ? {
+            cancellationPolicy: this.normalizeNullableText(
+              input.cancellationPolicy,
+            ),
+          }
+        : {}),
+      ...(input.cargoType !== undefined ? { cargoType: input.cargoType } : {}),
+      ...(input.isReturn !== undefined ? { isReturn: input.isReturn } : {}),
+    };
+  }
+
+  private mergeDraftState(
+    existingTripOffer: TripOfferRecord,
+    input: UpdateTripOfferInput,
+  ): TripOfferDraftState {
+    return {
+      originLabel: input.originLabel ?? existingTripOffer.originLabel,
+      originLat: input.originLat ?? Number(existingTripOffer.originLat),
+      originLng: input.originLng ?? Number(existingTripOffer.originLng),
+      destinationLabel:
+        input.destinationLabel ?? existingTripOffer.destinationLabel,
+      destinationLat:
+        input.destinationLat ?? Number(existingTripOffer.destinationLat),
+      destinationLng:
+        input.destinationLng ?? Number(existingTripOffer.destinationLng),
+      departureDate:
+        input.departureDate !== undefined
+          ? input.departureDate
+          : existingTripOffer.departureDate,
+      departureWindowStart:
+        input.departureWindowStart !== undefined
+          ? input.departureWindowStart
+          : existingTripOffer.departureWindowStart,
+      departureWindowEnd:
+        input.departureWindowEnd !== undefined
+          ? input.departureWindowEnd
+          : existingTripOffer.departureWindowEnd,
+      capacityTotal: input.capacityTotal ?? existingTripOffer.capacityTotal,
+      pricePerSlot: input.pricePerSlot ?? existingTripOffer.pricePerSlot,
+      maxDetourKm:
+        input.maxDetourKm !== undefined
+          ? input.maxDetourKm
+          : existingTripOffer.maxDetourKm,
+      notes: input.notes !== undefined ? input.notes : existingTripOffer.notes,
+      cancellationPolicy:
+        input.cancellationPolicy !== undefined
+          ? input.cancellationPolicy
+          : existingTripOffer.cancellationPolicy,
+      cargoType: input.cargoType ?? existingTripOffer.cargoType,
+      isReturn: input.isReturn ?? existingTripOffer.isReturn,
+    };
+  }
+
+  private toUpdateData(input: UpdateTripOfferInput) {
+    return {
+      ...(input.originLabel !== undefined
+        ? { originLabel: input.originLabel }
+        : {}),
+      ...(input.originLat !== undefined ? { originLat: input.originLat } : {}),
+      ...(input.originLng !== undefined ? { originLng: input.originLng } : {}),
+      ...(input.destinationLabel !== undefined
+        ? { destinationLabel: input.destinationLabel }
+        : {}),
+      ...(input.destinationLat !== undefined
+        ? { destinationLat: input.destinationLat }
+        : {}),
+      ...(input.destinationLng !== undefined
+        ? { destinationLng: input.destinationLng }
+        : {}),
+      ...(input.departureDate !== undefined
+        ? { departureDate: input.departureDate }
+        : {}),
+      ...(input.departureWindowStart !== undefined
+        ? { departureWindowStart: input.departureWindowStart }
+        : {}),
+      ...(input.departureWindowEnd !== undefined
+        ? { departureWindowEnd: input.departureWindowEnd }
+        : {}),
+      ...(input.capacityTotal !== undefined
+        ? { capacityTotal: input.capacityTotal }
+        : {}),
+      ...(input.pricePerSlot !== undefined
+        ? { pricePerSlot: input.pricePerSlot }
+        : {}),
+      ...(input.maxDetourKm !== undefined
+        ? { maxDetourKm: input.maxDetourKm }
+        : {}),
+      ...(input.notes !== undefined ? { notes: input.notes } : {}),
+      ...(input.cancellationPolicy !== undefined
+        ? { cancellationPolicy: input.cancellationPolicy }
+        : {}),
+      ...(input.cargoType !== undefined ? { cargoType: input.cargoType } : {}),
+      ...(input.isReturn !== undefined ? { isReturn: input.isReturn } : {}),
+    };
+  }
+
+  private normalizeNullableText(
+    value: string | null | undefined,
+  ): string | null {
+    if (value === undefined || value === null) {
+      return value ?? null;
+    }
+
+    const normalizedValue = value.trim();
+
+    return normalizedValue.length > 0 ? normalizedValue : null;
+  }
+
+  private toTripOfferResponse(
+    tripOffer: TripOfferRecord,
+  ): TripOfferResponseDto {
+    return {
+      id: tripOffer.id,
+      originLabel: tripOffer.originLabel,
+      originLat: Number(tripOffer.originLat),
+      originLng: Number(tripOffer.originLng),
+      destinationLabel: tripOffer.destinationLabel,
+      destinationLat: Number(tripOffer.destinationLat),
+      destinationLng: Number(tripOffer.destinationLng),
+      departureDate: tripOffer.departureDate,
+      departureWindowStart: tripOffer.departureWindowStart,
+      departureWindowEnd: tripOffer.departureWindowEnd,
+      capacityTotal: tripOffer.capacityTotal,
+      availableCapacity: tripOffer.availableCapacity,
+      pricePerSlot: tripOffer.pricePerSlot,
+      maxDetourKm: tripOffer.maxDetourKm,
+      notes: tripOffer.notes,
+      cancellationPolicy: tripOffer.cancellationPolicy,
+      cargoType: tripOffer.cargoType,
+      isReturn: tripOffer.isReturn,
+      status: tripOffer.status,
+      createdAt: tripOffer.createdAt,
+      updatedAt: tripOffer.updatedAt,
+    };
+  }
+}

--- a/apps/api/src/trip-offer/dto/create-trip-offer.dto.ts
+++ b/apps/api/src/trip-offer/dto/create-trip-offer.dto.ts
@@ -1,0 +1,3 @@
+import type { ICreateTripOfferDto } from '@logistica/shared';
+
+export type CreateTripOfferDto = ICreateTripOfferDto;

--- a/apps/api/src/trip-offer/dto/trip-offer.response.dto.ts
+++ b/apps/api/src/trip-offer/dto/trip-offer.response.dto.ts
@@ -1,0 +1,3 @@
+import type { ITripOfferView } from '@logistica/shared';
+
+export type TripOfferResponseDto = ITripOfferView;

--- a/apps/api/src/trip-offer/dto/update-trip-offer.dto.ts
+++ b/apps/api/src/trip-offer/dto/update-trip-offer.dto.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+import type {
+  ITripOfferParamsDto,
+  IUpdateTripOfferDto,
+} from '@logistica/shared';
+
+export const TripOfferParamsSchema = z.object({
+  id: z.string().cuid(),
+});
+
+export type TripOfferParamsDto = ITripOfferParamsDto;
+export type UpdateTripOfferDto = IUpdateTripOfferDto;

--- a/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
+++ b/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma, PrismaService, TripOfferStatus } from '@logistica/database';
+import type {
+  CreateTripOfferInput,
+  TransporterProfileOwnerRecord,
+  TripOfferRecord,
+  TripOfferUpdateData,
+} from '../types/trip-offer.types';
+import {
+  transporterProfileOwnerSelect,
+  tripOfferSelect,
+} from '../types/trip-offer.types';
+
+@Injectable()
+export class TripOfferRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findTransporterProfileByAccountId(
+    accountId: string,
+  ): Promise<TransporterProfileOwnerRecord | null> {
+    return this.prisma.transporterProfile.findUnique({
+      where: { accountId },
+      select: transporterProfileOwnerSelect,
+    });
+  }
+
+  async findById(tripOfferId: string): Promise<TripOfferRecord | null> {
+    return this.prisma.tripOffer.findUnique({
+      where: { id: tripOfferId },
+      select: tripOfferSelect,
+    });
+  }
+
+  async create(
+    transporterProfileId: string,
+    input: CreateTripOfferInput,
+  ): Promise<TripOfferRecord> {
+    return this.prisma.tripOffer.create({
+      data: {
+        transporterProfile: {
+          connect: {
+            id: transporterProfileId,
+          },
+        },
+        originLabel: input.originLabel,
+        originLat: new Prisma.Decimal(input.originLat),
+        originLng: new Prisma.Decimal(input.originLng),
+        destinationLabel: input.destinationLabel,
+        destinationLat: new Prisma.Decimal(input.destinationLat),
+        destinationLng: new Prisma.Decimal(input.destinationLng),
+        departureDate: input.departureDate ?? null,
+        departureWindowStart: input.departureWindowStart ?? null,
+        departureWindowEnd: input.departureWindowEnd ?? null,
+        capacityTotal: input.capacityTotal,
+        availableCapacity: input.capacityTotal,
+        pricePerSlot: input.pricePerSlot,
+        maxDetourKm: input.maxDetourKm ?? null,
+        notes: input.notes ?? null,
+        cancellationPolicy: input.cancellationPolicy ?? null,
+        cargoType: input.cargoType,
+        isReturn: input.isReturn,
+        status: TripOfferStatus.DRAFT,
+      },
+      select: tripOfferSelect,
+    });
+  }
+
+  async updateById(
+    tripOfferId: string,
+    data: TripOfferUpdateData,
+  ): Promise<TripOfferRecord> {
+    return this.prisma.tripOffer.update({
+      where: { id: tripOfferId },
+      data,
+      select: tripOfferSelect,
+    });
+  }
+}

--- a/apps/api/src/trip-offer/trip-offer.controller.spec.ts
+++ b/apps/api/src/trip-offer/trip-offer.controller.spec.ts
@@ -1,0 +1,445 @@
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  type ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
+import { RolesGuard } from '../identity/authentication/guards/roles.guard';
+import { TripOfferService } from './application/trip-offer.service';
+import { TripOfferController } from './trip-offer.controller';
+
+@Injectable()
+class TestJwtAuthGuard {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{
+      headers: Record<string, string | string[] | undefined>;
+      user?: { accountId: string; role: 'CLIENT' | 'TRANSPORTER' | 'ADMIN' };
+    }>();
+    const authorizationHeader = request.headers.authorization;
+
+    if (typeof authorizationHeader !== 'string') {
+      throw new UnauthorizedException();
+    }
+
+    const [, role] = authorizationHeader.split(' ');
+
+    if (role !== 'CLIENT' && role !== 'TRANSPORTER' && role !== 'ADMIN') {
+      throw new UnauthorizedException();
+    }
+
+    request.user = {
+      accountId: 'transporter-account-id',
+      role,
+    };
+
+    return true;
+  }
+}
+
+describe('TripOfferController', () => {
+  const tripOfferService = {
+    createOwnTripOffer: jest.fn(),
+    updateOwnTripOffer: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  async function createApp() {
+    const moduleBuilder = Test.createTestingModule({
+      controllers: [TripOfferController],
+      providers: [
+        RolesGuard,
+        {
+          provide: TripOfferService,
+          useValue: tripOfferService,
+        },
+      ],
+    });
+
+    moduleBuilder.overrideGuard(JwtAuthGuard).useClass(TestJwtAuthGuard);
+
+    const moduleRef = await moduleBuilder.compile();
+    const app = moduleRef.createNestApplication();
+    await app.init();
+
+    return app;
+  }
+
+  it('creates a trip offer draft for the authenticated transporter', async () => {
+    const createdAt = '2026-04-21T10:00:00.000Z';
+    const updatedAt = '2026-04-21T10:00:00.000Z';
+
+    tripOfferService.createOwnTripOffer.mockResolvedValue({
+      id: 'trip-offer-id',
+      originLabel: 'Buenos Aires',
+      originLat: -34.603722,
+      originLng: -58.381592,
+      destinationLabel: 'Rosario',
+      destinationLat: -32.944243,
+      destinationLng: -60.650539,
+      departureDate: new Date('2026-05-01T00:00:00.000Z'),
+      departureWindowStart: null,
+      departureWindowEnd: null,
+      capacityTotal: 6,
+      availableCapacity: 6,
+      pricePerSlot: 120000,
+      maxDetourKm: 50,
+      notes: 'Salida temprana',
+      cancellationPolicy: 'Flexible',
+      cargoType: 'EQUINE',
+      isReturn: false,
+      status: 'DRAFT',
+      createdAt: new Date(createdAt),
+      updatedAt: new Date(updatedAt),
+    });
+
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trip-offers')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        originLabel: 'Buenos Aires',
+        originLat: -34.603722,
+        originLng: -58.381592,
+        destinationLabel: 'Rosario',
+        destinationLat: -32.944243,
+        destinationLng: -60.650539,
+        departureDate: '2026-05-01T00:00:00.000Z',
+        capacityTotal: 6,
+        availableCapacity: 3,
+        pricePerSlot: 120000,
+        maxDetourKm: 50,
+        notes: 'Salida temprana',
+        cancellationPolicy: 'Flexible',
+        cargoType: 'EQUINE',
+        isReturn: false,
+      })
+      .expect(201)
+      .expect({
+        id: 'trip-offer-id',
+        originLabel: 'Buenos Aires',
+        originLat: -34.603722,
+        originLng: -58.381592,
+        destinationLabel: 'Rosario',
+        destinationLat: -32.944243,
+        destinationLng: -60.650539,
+        departureDate: '2026-05-01T00:00:00.000Z',
+        departureWindowStart: null,
+        departureWindowEnd: null,
+        capacityTotal: 6,
+        availableCapacity: 6,
+        pricePerSlot: 120000,
+        maxDetourKm: 50,
+        notes: 'Salida temprana',
+        cancellationPolicy: 'Flexible',
+        cargoType: 'EQUINE',
+        isReturn: false,
+        status: 'DRAFT',
+        createdAt,
+        updatedAt,
+      });
+
+    expect(tripOfferService.createOwnTripOffer).toHaveBeenCalledWith(
+      'transporter-account-id',
+      expect.objectContaining({
+        originLabel: 'Buenos Aires',
+        capacityTotal: 6,
+        availableCapacity: 3,
+        departureDate: new Date('2026-05-01T00:00:00.000Z'),
+      }),
+    );
+
+    await app.close();
+  });
+
+  it('returns 400 when the payload is invalid', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trip-offers')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        originLabel: '',
+        originLat: -120,
+        originLng: -58.381592,
+        destinationLabel: 'Rosario',
+        destinationLat: -32.944243,
+        destinationLng: -60.650539,
+        departureDate: '2026-05-01T00:00:00.000Z',
+        capacityTotal: 0,
+        pricePerSlot: -1,
+        cargoType: 'EQUINE',
+        isReturn: false,
+      })
+      .expect(400);
+
+    expect(tripOfferService.createOwnTripOffer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when trying to send forbidden ownership fields', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trip-offers')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        originLabel: 'Buenos Aires',
+        originLat: -34.603722,
+        originLng: -58.381592,
+        destinationLabel: 'Rosario',
+        destinationLat: -32.944243,
+        destinationLng: -60.650539,
+        departureDate: '2026-05-01T00:00:00.000Z',
+        capacityTotal: 6,
+        pricePerSlot: 120000,
+        cargoType: 'EQUINE',
+        isReturn: false,
+        transporterProfileId: 'other-profile-id',
+      })
+      .expect(400);
+
+    expect(tripOfferService.createOwnTripOffer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 401 when the access token is missing', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trip-offers')
+      .send({
+        originLabel: 'Buenos Aires',
+        originLat: -34.603722,
+        originLng: -58.381592,
+        destinationLabel: 'Rosario',
+        destinationLat: -32.944243,
+        destinationLng: -60.650539,
+        departureDate: '2026-05-01T00:00:00.000Z',
+        capacityTotal: 6,
+        pricePerSlot: 120000,
+        cargoType: 'EQUINE',
+        isReturn: false,
+      })
+      .expect(401);
+
+    await app.close();
+  });
+
+  it('returns 403 when the authenticated role is not TRANSPORTER', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trip-offers')
+      .set('Authorization', 'Bearer CLIENT')
+      .send({
+        originLabel: 'Buenos Aires',
+        originLat: -34.603722,
+        originLng: -58.381592,
+        destinationLabel: 'Rosario',
+        destinationLat: -32.944243,
+        destinationLng: -60.650539,
+        departureDate: '2026-05-01T00:00:00.000Z',
+        capacityTotal: 6,
+        pricePerSlot: 120000,
+        cargoType: 'EQUINE',
+        isReturn: false,
+      })
+      .expect(403);
+
+    await app.close();
+  });
+
+  it('updates a draft trip offer when the id is valid', async () => {
+    const updatedAt = '2026-04-21T12:00:00.000Z';
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const tripOfferId = 'cm9tripoffer0000wqz5oy7k8ph1';
+
+    tripOfferService.updateOwnTripOffer.mockResolvedValue({
+      id: tripOfferId,
+      originLabel: 'Buenos Aires',
+      originLat: -34.603722,
+      originLng: -58.381592,
+      destinationLabel: 'Cordoba',
+      destinationLat: -31.420083,
+      destinationLng: -64.188776,
+      departureDate: null,
+      departureWindowStart: new Date('2026-05-02T08:00:00.000Z'),
+      departureWindowEnd: new Date('2026-05-02T12:00:00.000Z'),
+      capacityTotal: 10,
+      availableCapacity: 10,
+      pricePerSlot: 140000,
+      maxDetourKm: 70,
+      notes: null,
+      cancellationPolicy: 'Moderada',
+      cargoType: 'GENERAL_CARGO',
+      isReturn: true,
+      status: 'DRAFT',
+      createdAt: new Date('2026-04-21T10:00:00.000Z'),
+      updatedAt: new Date(updatedAt),
+    });
+
+    await request(server)
+      .patch(`/trip-offers/${tripOfferId}`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        destinationLabel: 'Cordoba',
+        destinationLat: -31.420083,
+        destinationLng: -64.188776,
+        departureDate: null,
+        departureWindowStart: '2026-05-02T08:00:00.000Z',
+        departureWindowEnd: '2026-05-02T12:00:00.000Z',
+        capacityTotal: 10,
+        availableCapacity: 2,
+        pricePerSlot: 140000,
+        maxDetourKm: 70,
+        notes: null,
+        cancellationPolicy: 'Moderada',
+        cargoType: 'GENERAL_CARGO',
+        isReturn: true,
+      })
+      .expect(200)
+      .expect({
+        id: tripOfferId,
+        originLabel: 'Buenos Aires',
+        originLat: -34.603722,
+        originLng: -58.381592,
+        destinationLabel: 'Cordoba',
+        destinationLat: -31.420083,
+        destinationLng: -64.188776,
+        departureDate: null,
+        departureWindowStart: '2026-05-02T08:00:00.000Z',
+        departureWindowEnd: '2026-05-02T12:00:00.000Z',
+        capacityTotal: 10,
+        availableCapacity: 10,
+        pricePerSlot: 140000,
+        maxDetourKm: 70,
+        notes: null,
+        cancellationPolicy: 'Moderada',
+        cargoType: 'GENERAL_CARGO',
+        isReturn: true,
+        status: 'DRAFT',
+        createdAt: '2026-04-21T10:00:00.000Z',
+        updatedAt,
+      });
+
+    expect(tripOfferService.updateOwnTripOffer).toHaveBeenCalledWith(
+      'transporter-account-id',
+      tripOfferId,
+      expect.objectContaining({
+        destinationLabel: 'Cordoba',
+        capacityTotal: 10,
+        availableCapacity: 2,
+      }),
+    );
+
+    await app.close();
+  });
+
+  it('returns 404 when updating a trip offer that does not exist', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const tripOfferId = 'cm9tripoffer0000wqz5oy7k8ph1';
+
+    tripOfferService.updateOwnTripOffer.mockRejectedValue(
+      new NotFoundException('Trip offer not found.'),
+    );
+
+    await request(server)
+      .patch(`/trip-offers/${tripOfferId}`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        pricePerSlot: 140000,
+      })
+      .expect(404);
+
+    await app.close();
+  });
+
+  it('returns 403 when updating a trip offer owned by another transporter', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const tripOfferId = 'cm9tripoffer0000wqz5oy7k8ph1';
+
+    tripOfferService.updateOwnTripOffer.mockRejectedValue(
+      new ForbiddenException(
+        'You cannot edit a trip offer that belongs to another transporter.',
+      ),
+    );
+
+    await request(server)
+      .patch(`/trip-offers/${tripOfferId}`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        pricePerSlot: 140000,
+      })
+      .expect(403);
+
+    await app.close();
+  });
+
+  it('returns 409 when updating a trip offer outside draft status', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const tripOfferId = 'cm9tripoffer0000wqz5oy7k8ph1';
+
+    tripOfferService.updateOwnTripOffer.mockRejectedValue(
+      new ConflictException('Only trip offers in DRAFT status can be edited.'),
+    );
+
+    await request(server)
+      .patch(`/trip-offers/${tripOfferId}`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        pricePerSlot: 140000,
+      })
+      .expect(409);
+
+    await app.close();
+  });
+
+  it('returns 400 when the temporal rule is invalid', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trip-offers')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        originLabel: 'Buenos Aires',
+        originLat: -34.603722,
+        originLng: -58.381592,
+        destinationLabel: 'Rosario',
+        destinationLat: -32.944243,
+        destinationLng: -60.650539,
+        departureDate: '2026-05-01T00:00:00.000Z',
+        departureWindowStart: '2026-05-01T08:00:00.000Z',
+        departureWindowEnd: '2026-05-01T12:00:00.000Z',
+        capacityTotal: 6,
+        pricePerSlot: 120000,
+        cargoType: 'EQUINE',
+        isReturn: false,
+      })
+      .expect(400);
+
+    expect(tripOfferService.createOwnTripOffer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+});

--- a/apps/api/src/trip-offer/trip-offer.controller.ts
+++ b/apps/api/src/trip-offer/trip-offer.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Body,
+  Controller,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  CreateTripOfferSchema,
+  UpdateTripOfferSchema,
+} from '@logistica/shared';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { Roles } from '../identity/authentication/decorators/roles.decorator';
+import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
+import { RolesGuard } from '../identity/authentication/guards/roles.guard';
+import type { AuthenticatedAccount } from '../identity/authentication/types/authentication.types';
+import { TripOfferService } from './application/trip-offer.service';
+import type { CreateTripOfferDto } from './dto/create-trip-offer.dto';
+import type {
+  TripOfferParamsDto,
+  UpdateTripOfferDto,
+} from './dto/update-trip-offer.dto';
+import { TripOfferParamsSchema } from './dto/update-trip-offer.dto';
+import type { TripOfferResponseDto } from './dto/trip-offer.response.dto';
+
+interface AuthenticatedHttpRequest {
+  user: AuthenticatedAccount;
+}
+
+@Controller('trip-offers')
+export class TripOfferController {
+  constructor(private readonly tripOfferService: TripOfferService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async createOwnTripOffer(
+    @Req() request: AuthenticatedHttpRequest,
+    @Body(new ZodValidationPipe(CreateTripOfferSchema))
+    createTripOfferDto: CreateTripOfferDto,
+  ): Promise<TripOfferResponseDto> {
+    return this.tripOfferService.createOwnTripOffer(
+      request.user.accountId,
+      createTripOfferDto,
+    );
+  }
+
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async updateOwnTripOffer(
+    @Req() request: AuthenticatedHttpRequest,
+    @Param(new ZodValidationPipe(TripOfferParamsSchema))
+    params: TripOfferParamsDto,
+    @Body(new ZodValidationPipe(UpdateTripOfferSchema))
+    updateTripOfferDto: UpdateTripOfferDto,
+  ): Promise<TripOfferResponseDto> {
+    return this.tripOfferService.updateOwnTripOffer(
+      request.user.accountId,
+      params.id,
+      updateTripOfferDto,
+    );
+  }
+}

--- a/apps/api/src/trip-offer/trip-offer.module.ts
+++ b/apps/api/src/trip-offer/trip-offer.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '@logistica/database';
+import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
+import { RolesGuard } from '../identity/authentication/guards/roles.guard';
+import { TripOfferService } from './application/trip-offer.service';
+import { TripOfferController } from './trip-offer.controller';
+import { TripOfferRepository } from './repositories/trip-offer.repository';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [TripOfferController],
+  providers: [TripOfferService, TripOfferRepository, JwtAuthGuard, RolesGuard],
+})
+export class TripOfferModule {}

--- a/apps/api/src/trip-offer/types/trip-offer.types.ts
+++ b/apps/api/src/trip-offer/types/trip-offer.types.ts
@@ -1,0 +1,46 @@
+import type { Prisma } from '@logistica/database';
+import type {
+  ICreateTripOfferDto,
+  IUpdateTripOfferDto,
+} from '@logistica/shared';
+
+export const tripOfferSelect = {
+  id: true,
+  transporterProfileId: true,
+  originLabel: true,
+  originLat: true,
+  originLng: true,
+  destinationLabel: true,
+  destinationLat: true,
+  destinationLng: true,
+  departureDate: true,
+  departureWindowStart: true,
+  departureWindowEnd: true,
+  capacityTotal: true,
+  availableCapacity: true,
+  pricePerSlot: true,
+  maxDetourKm: true,
+  notes: true,
+  cancellationPolicy: true,
+  cargoType: true,
+  isReturn: true,
+  status: true,
+  createdAt: true,
+  updatedAt: true,
+} satisfies Prisma.TripOfferSelect;
+
+export const transporterProfileOwnerSelect = {
+  id: true,
+} satisfies Prisma.TransporterProfileSelect;
+
+export type CreateTripOfferInput = ICreateTripOfferDto;
+export type UpdateTripOfferInput = IUpdateTripOfferDto;
+export type TripOfferRecord = Prisma.TripOfferGetPayload<{
+  select: typeof tripOfferSelect;
+}>;
+export type TransporterProfileOwnerRecord =
+  Prisma.TransporterProfileGetPayload<{
+    select: typeof transporterProfileOwnerSelect;
+  }>;
+export type TripOfferCreateData = Prisma.TripOfferCreateInput;
+export type TripOfferUpdateData = Prisma.TripOfferUpdateInput;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from './schemas/auth.schema';
 export * from './schemas/trailer.schema';
+export * from './schemas/trip-offer.schema';
 export * from './schemas/transporter-profile.schema';
 export * from './schemas/vehicle.schema';
 export * from './interfaces/interfaces';

--- a/packages/shared/src/interfaces/interfaces.ts
+++ b/packages/shared/src/interfaces/interfaces.ts
@@ -15,6 +15,12 @@ import {
   CreateTrailerSchema,
   UpdateTrailerSchema,
 } from '../schemas/trailer.schema';
+import {
+  CreateTripOfferSchema,
+  TripOfferParamsSchema,
+  TripOfferViewSchema,
+  UpdateTripOfferSchema,
+} from '../schemas/trip-offer.schema';
 
 const emailSchema = z.string().trim().email().max(320);
 const cuidSchema = z.string().cuid();
@@ -92,6 +98,15 @@ export const TrailerViewSchema = z.object({
 });
 export type ITrailerView = z.infer<typeof TrailerViewSchema>;
 
+export const TripOfferStatusSchema = z.enum([
+  'DRAFT',
+  'PUBLISHED',
+  'FULL',
+  'CLOSED',
+  'CANCELLED',
+]);
+export type ITripOfferStatus = z.infer<typeof TripOfferStatusSchema>;
+
 export type IUpdateTransporterProfileDto = {
   displayName?: string;
   businessName?: string | null;
@@ -111,6 +126,18 @@ export type ICreateTrailerDto = z.infer<typeof CreateTrailerDtoSchema>;
 
 export const UpdateTrailerDtoSchema = UpdateTrailerSchema;
 export type IUpdateTrailerDto = z.infer<typeof UpdateTrailerDtoSchema>;
+
+export const CreateTripOfferDtoSchema = CreateTripOfferSchema;
+export type ICreateTripOfferDto = z.infer<typeof CreateTripOfferDtoSchema>;
+
+export const UpdateTripOfferDtoSchema = UpdateTripOfferSchema;
+export type IUpdateTripOfferDto = z.infer<typeof UpdateTripOfferDtoSchema>;
+
+export const TripOfferParamsDtoSchema = TripOfferParamsSchema;
+export type ITripOfferParamsDto = z.infer<typeof TripOfferParamsDtoSchema>;
+
+export const TripOfferViewDtoSchema = TripOfferViewSchema;
+export type ITripOfferView = z.infer<typeof TripOfferViewDtoSchema>;
 
 export const AuthProfileViewSchema = z
   .union([UserProfileViewSchema, TransporterProfileViewSchema])

--- a/packages/shared/src/schemas/trip-offer.schema.ts
+++ b/packages/shared/src/schemas/trip-offer.schema.ts
@@ -1,0 +1,216 @@
+import { z } from 'zod';
+import { CargoTypeSchema } from './trailer.schema';
+
+const cuidSchema = z.string().cuid();
+const tripOfferStatusSchema = z.enum([
+  'DRAFT',
+  'PUBLISHED',
+  'FULL',
+  'CLOSED',
+  'CANCELLED',
+]);
+
+const requiredTrimmedTextSchema = (
+  maxLength: number,
+  requiredMessage: string,
+) =>
+  z
+    .string()
+    .trim()
+    .min(1, requiredMessage)
+    .max(maxLength, `El valor no puede superar los ${maxLength} caracteres.`);
+
+const nullableTrimmedTextSchema = (maxLength: number, message: string) =>
+  z.preprocess((value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    const trimmedValue = value.trim();
+
+    return trimmedValue.length === 0 ? null : trimmedValue;
+  }, z.string().max(maxLength, message).nullable());
+
+const latitudeSchema = z
+  .number()
+  .min(-90, 'La latitud debe estar entre -90 y 90.')
+  .max(90, 'La latitud debe estar entre -90 y 90.');
+
+const longitudeSchema = z
+  .number()
+  .min(-180, 'La longitud debe estar entre -180 y 180.')
+  .max(180, 'La longitud debe estar entre -180 y 180.');
+
+const positiveIntegerSchema = z
+  .number()
+  .int('El valor debe ser un numero entero.')
+  .positive('El valor debe ser mayor a cero.');
+
+const nonNegativeIntegerSchema = z
+  .number()
+  .int('El valor debe ser un numero entero.')
+  .min(0, 'El valor no puede ser negativo.');
+
+type TemporalFields = {
+  departureDate?: Date | null;
+  departureWindowStart?: Date | null;
+  departureWindowEnd?: Date | null;
+};
+
+const validateTemporalFields = (
+  value: TemporalFields,
+  context: z.RefinementCtx,
+): void => {
+  const hasDepartureDate = value.departureDate instanceof Date;
+  const hasWindowStart = value.departureWindowStart instanceof Date;
+  const hasWindowEnd = value.departureWindowEnd instanceof Date;
+  const hasWindow = hasWindowStart || hasWindowEnd;
+
+  if (hasDepartureDate === hasWindow) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        'Debes informar una fecha exacta o un rango horario valido, pero no ambos.',
+      path: ['departureDate'],
+    });
+  }
+
+  if (hasWindowStart !== hasWindowEnd) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        'Debes informar departureWindowStart y departureWindowEnd juntos.',
+      path: ['departureWindowStart'],
+    });
+  }
+
+  if (
+    hasWindowStart &&
+    hasWindowEnd &&
+    value.departureWindowStart!.getTime() >= value.departureWindowEnd!.getTime()
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'departureWindowStart debe ser menor que departureWindowEnd.',
+      path: ['departureWindowStart'],
+    });
+  }
+};
+
+export const CreateTripOfferSchema = z
+  .object({
+    originLabel: requiredTrimmedTextSchema(
+      160,
+      'Ingresa el origen de la oferta.',
+    ),
+    originLat: latitudeSchema,
+    originLng: longitudeSchema,
+    destinationLabel: requiredTrimmedTextSchema(
+      160,
+      'Ingresa el destino de la oferta.',
+    ),
+    destinationLat: latitudeSchema,
+    destinationLng: longitudeSchema,
+    departureDate: z.coerce.date().optional().nullable(),
+    departureWindowStart: z.coerce.date().optional().nullable(),
+    departureWindowEnd: z.coerce.date().optional().nullable(),
+    capacityTotal: positiveIntegerSchema,
+    availableCapacity: nonNegativeIntegerSchema.optional(),
+    pricePerSlot: nonNegativeIntegerSchema,
+    maxDetourKm: nonNegativeIntegerSchema.optional().nullable(),
+    notes: nullableTrimmedTextSchema(
+      2000,
+      'Las notas no pueden superar los 2000 caracteres.',
+    ).optional(),
+    cancellationPolicy: nullableTrimmedTextSchema(
+      1000,
+      'La politica de cancelacion no puede superar los 1000 caracteres.',
+    ).optional(),
+    cargoType: CargoTypeSchema,
+    isReturn: z.boolean(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    validateTemporalFields(value, context);
+
+    if (
+      value.availableCapacity !== undefined &&
+      value.availableCapacity > value.capacityTotal
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'availableCapacity no puede ser mayor que capacityTotal.',
+        path: ['availableCapacity'],
+      });
+    }
+  });
+
+export const UpdateTripOfferSchema = z
+  .object({
+    originLabel: requiredTrimmedTextSchema(
+      160,
+      'Ingresa el origen de la oferta.',
+    ).optional(),
+    originLat: latitudeSchema.optional(),
+    originLng: longitudeSchema.optional(),
+    destinationLabel: requiredTrimmedTextSchema(
+      160,
+      'Ingresa el destino de la oferta.',
+    ).optional(),
+    destinationLat: latitudeSchema.optional(),
+    destinationLng: longitudeSchema.optional(),
+    departureDate: z.coerce.date().optional().nullable(),
+    departureWindowStart: z.coerce.date().optional().nullable(),
+    departureWindowEnd: z.coerce.date().optional().nullable(),
+    capacityTotal: positiveIntegerSchema.optional(),
+    availableCapacity: nonNegativeIntegerSchema.optional(),
+    pricePerSlot: nonNegativeIntegerSchema.optional(),
+    maxDetourKm: nonNegativeIntegerSchema.optional().nullable(),
+    notes: nullableTrimmedTextSchema(
+      2000,
+      'Las notas no pueden superar los 2000 caracteres.',
+    ).optional(),
+    cancellationPolicy: nullableTrimmedTextSchema(
+      1000,
+      'La politica de cancelacion no puede superar los 1000 caracteres.',
+    ).optional(),
+    cargoType: CargoTypeSchema.optional(),
+    isReturn: z.boolean().optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'Debes enviar al menos un campo para actualizar la oferta.',
+  });
+
+export const TripOfferParamsSchema = z.object({
+  id: cuidSchema,
+});
+
+export const TripOfferViewSchema = z.object({
+  id: cuidSchema,
+  originLabel: z.string().trim().min(1).max(160),
+  originLat: z.number(),
+  originLng: z.number(),
+  destinationLabel: z.string().trim().min(1).max(160),
+  destinationLat: z.number(),
+  destinationLng: z.number(),
+  departureDate: z.date().nullable(),
+  departureWindowStart: z.date().nullable(),
+  departureWindowEnd: z.date().nullable(),
+  capacityTotal: z.number().int().positive(),
+  availableCapacity: z.number().int().min(0),
+  pricePerSlot: z.number().int().min(0),
+  maxDetourKm: z.number().int().min(0).nullable(),
+  notes: z.string().max(2000).nullable(),
+  cancellationPolicy: z.string().max(1000).nullable(),
+  cargoType: CargoTypeSchema,
+  isReturn: z.boolean(),
+  status: tripOfferStatusSchema,
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type CreateTripOfferDto = z.infer<typeof CreateTripOfferSchema>;
+export type UpdateTripOfferDto = z.infer<typeof UpdateTripOfferSchema>;
+export type TripOfferParamsDto = z.infer<typeof TripOfferParamsSchema>;
+export type TripOfferView = z.infer<typeof TripOfferViewSchema>;


### PR DESCRIPTION
## Contexto

Resuelve la issue `E4-BE-02` de la ?pica `E4-BE - Publicaci?n de ofertas backend`.

El objetivo de esta PR es permitir que un transportista autenticado cree una `TripOffer` en estado `DRAFT` y pueda editarla de forma segura antes de publicarla, reutilizando auth, roles, validaci?n Zod y el patr?n repository/service ya existente en el proyecto.

## Alcance

Incluye ?nicamente:

- endpoint `POST /trip-offers`
- endpoint `PATCH /trip-offers/:id`
- m?dulo backend `trip-offer` completo
- ownership resuelto desde la cuenta autenticada y su `TransporterProfile`
- validaciones de entrada y de coherencia temporal
- edici?n permitida solo sobre ofertas propias en `DRAFT`
- contratos compartidos en `@logistica/shared` para create/update/view de `TripOffer`
- tests unitarios e integration specs del controller

No incluye:

- publicaci?n de ofertas
- listados propios o p?blicos
- b?squeda p?blica
- bookings
- pagos
- transiciones a `PUBLISHED`, `FULL`, `CLOSED` o `CANCELLED`
- cambios de schema Prisma o migraciones

## An?lisis previo aplicado

Antes del cambio se revis? el estado real del repo para no abrir una arquitectura paralela:

- auth usa `JwtAuthGuard`, `RolesGuard` y `request.user.accountId`
- los m?dulos `vehicle` y `trailer` marcan el patr?n actual de controller/service/repository
- la validaci?n HTTP actual usa `ZodValidationPipe` con schemas exportados desde `@logistica/shared`
- `TripOffer` ya exist?a en Prisma por la issue anterior
- `TransporterProfile` es la entidad due?a real de los recursos del transportista

## Decisiones de implementaci?n

### Ownership

El owner de la oferta se resuelve siempre desde el usuario autenticado y su `TransporterProfile`.

No se acepta `transporterProfileId` en el body porque los schemas son `.strict()` y el service nunca lo toma del cliente.

### Estado inicial

La creaci?n persiste siempre `status = DRAFT`.

No se acepta `status` desde el cliente y no se implementa ninguna l?gica de publish en esta PR.

### Available capacity

Se prioriz? la convenci?n segura pedida por la issue:

- al crear: `availableCapacity = capacityTotal`
- al editar un `DRAFT`: `availableCapacity` se vuelve a sincronizar con `capacityTotal`

Esto evita inconsistencias mientras todav?a no existen reservas asociadas.

### Reglas temporales

La oferta debe definir una sola modalidad v?lida:

- o `departureDate`
- o `departureWindowStart` + `departureWindowEnd`

Si el rango est? presente, el inicio debe ser menor que el fin.

### Ownership error expl?cito

A diferencia de `vehicle` y `trailer`, esta PR distingue:

- `404` si la oferta no existe
- `403` si existe pero pertenece a otro transportista

Esto se implement? as? porque la issue lo pide de forma expl?cita.

## Cambios realizados

### Shared contracts

Se agreg? `packages/shared/src/schemas/trip-offer.schema.ts` con:

- `CreateTripOfferSchema`
- `UpdateTripOfferSchema`
- `TripOfferParamsSchema`
- `TripOfferViewSchema`

Y se exportaron los tipos/contratos correspondientes desde `@logistica/shared`.

### Backend module

Se cre? `apps/api/src/trip-offer/` con la estructura est?ndar del repo:

- `trip-offer.module.ts`
- `trip-offer.controller.ts`
- `application/trip-offer.service.ts`
- `repositories/trip-offer.repository.ts`
- `dto/*`
- `types/trip-offer.types.ts`
- tests de service y controller junto a cada archivo

### L?gica de negocio

El service implementa:

- resoluci?n del `TransporterProfile` por `accountId`
- normalizaci?n de strings opcionales
- validaci?n de ownership
- validaci?n de edici?n solo en `DRAFT`
- validaci?n temporal y de capacidad
- mapeo de `Decimal` de Prisma a `number` para la respuesta HTTP

### Wiring del API

Se registr? `TripOfferModule` en `apps/api/src/app.module.ts`.

## Archivos modificados

- `packages/shared/src/schemas/trip-offer.schema.ts`
- `packages/shared/src/interfaces/interfaces.ts`
- `packages/shared/src/index.ts`
- `apps/api/src/app.module.ts`
- `apps/api/src/trip-offer/*`

## Verificaci?n realizada

Se ejecut? correctamente:

- `pnpm --filter @logistica/api typecheck`
- `pnpm --filter @logistica/api test`

## Limitaciones / notas operativas

`pnpm --filter @logistica/api lint` no qued? en verde por un problema preexistente fuera del alcance de esta issue:

- `apps/api/src/identity/authentication/application/auth-token.service.ts`

Ese archivo pertenece a `auth`, que adem?s est? marcado como zona protegida en `AGENTS.md`, por lo que no se modific? en esta PR.

## Riesgos / impacto para la siguiente issue

- La base ya qued? lista para la issue de publicaci?n/listado de ofertas.
- La siguiente etapa puede apoyarse en este m?dulo sin volver a resolver ownership ni validaci?n b?sica del borrador.
- Si se decide alinear `vehicle`/`trailer` con el mismo contrato de ownership expl?cito, eso deber?a tratarse como ajuste aparte.

## C?mo probar / revisar

1. Crear una oferta con `POST /trip-offers` usando token `TRANSPORTER`.
2. Confirmar que la respuesta queda en `DRAFT` y que `availableCapacity` coincide con `capacityTotal`.
3. Editar la oferta con `PATCH /trip-offers/:id` y verificar que sigue en `DRAFT`.
4. Verificar que una oferta ajena responde `403`.
5. Verificar que una oferta inexistente responde `404`.
6. Verificar que una oferta no `DRAFT` responde `409`.
7. Ejecutar:
   - `pnpm --filter @logistica/api typecheck`
   - `pnpm --filter @logistica/api test`
