### PR TITLE
E4-BE-03 - Publicar, listar y gestionar estados basicos de TripOffer

### DIFF
--- a/apps/api/src/identity/authentication/application/auth-token.service.ts
+++ b/apps/api/src/identity/authentication/application/auth-token.service.ts
@@ -55,9 +55,7 @@ export class AuthTokenService {
     return timingSafeEqual(storedHashBuffer, presentedHashBuffer);
   }
 
-  async signAccessToken(
-    account: SignableAccessTokenAccount,
-  ): Promise<string> {
+  async signAccessToken(account: SignableAccessTokenAccount): Promise<string> {
     const payload: AccessTokenPayload = {
       sub: account.id,
       role: resolveEffectiveAccountRole(account),

--- a/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
+++ b/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
@@ -4,15 +4,45 @@ import {
   ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
-import { Prisma } from '@logistica/database';
+import { Prisma, TripOfferStatus } from '@logistica/database';
 import { TripOfferService } from './trip-offer.service';
+
+const createTripOfferRecord = (
+  overrides: Partial<Record<string, unknown>> = {},
+) => ({
+  id: 'trip-offer-id',
+  transporterProfileId: 'transporter-profile-id',
+  originLabel: 'Buenos Aires',
+  originLat: new Prisma.Decimal('-34.603722'),
+  originLng: new Prisma.Decimal('-58.381592'),
+  destinationLabel: 'Rosario',
+  destinationLat: new Prisma.Decimal('-32.944243'),
+  destinationLng: new Prisma.Decimal('-60.650539'),
+  departureDate: new Date('2026-05-01T00:00:00.000Z'),
+  departureWindowStart: null,
+  departureWindowEnd: null,
+  capacityTotal: 6,
+  availableCapacity: 6,
+  pricePerSlot: 120000,
+  maxDetourKm: 50,
+  notes: 'Salida temprana',
+  cancellationPolicy: 'Flexible',
+  cargoType: 'EQUINE',
+  isReturn: false,
+  status: TripOfferStatus.DRAFT,
+  createdAt: new Date('2026-04-21T10:00:00.000Z'),
+  updatedAt: new Date('2026-04-21T10:00:00.000Z'),
+  ...overrides,
+});
 
 describe('TripOfferService', () => {
   const tripOfferRepository = {
     findTransporterProfileByAccountId: jest.fn(),
     findById: jest.fn(),
+    findOwnedByAccountId: jest.fn(),
     create: jest.fn(),
     updateById: jest.fn(),
+    updateStatusById: jest.fn(),
   };
 
   let tripOfferService: TripOfferService;
@@ -30,30 +60,13 @@ describe('TripOfferService', () => {
     tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
       id: 'transporter-profile-id',
     });
-    tripOfferRepository.create.mockResolvedValue({
-      id: 'trip-offer-id',
-      transporterProfileId: 'transporter-profile-id',
-      originLabel: 'Buenos Aires',
-      originLat: new Prisma.Decimal('-34.603722'),
-      originLng: new Prisma.Decimal('-58.381592'),
-      destinationLabel: 'Rosario',
-      destinationLat: new Prisma.Decimal('-32.944243'),
-      destinationLng: new Prisma.Decimal('-60.650539'),
-      departureDate,
-      departureWindowStart: null,
-      departureWindowEnd: null,
-      capacityTotal: 6,
-      availableCapacity: 6,
-      pricePerSlot: 120000,
-      maxDetourKm: 50,
-      notes: 'Salida temprana',
-      cancellationPolicy: 'Flexible',
-      cargoType: 'EQUINE',
-      isReturn: false,
-      status: 'DRAFT',
-      createdAt,
-      updatedAt,
-    });
+    tripOfferRepository.create.mockResolvedValue(
+      createTripOfferRecord({
+        departureDate,
+        createdAt,
+        updatedAt,
+      }),
+    );
 
     await expect(
       tripOfferService.createOwnTripOffer('account-id', {
@@ -173,60 +186,157 @@ describe('TripOfferService', () => {
     expect(tripOfferRepository.create).not.toHaveBeenCalled();
   });
 
-  it('updates an owned draft trip offer and resyncs available capacity', async () => {
-    const updatedAt = new Date('2026-04-21T12:00:00.000Z');
-
-    tripOfferRepository.findById.mockResolvedValue({
-      id: 'trip-offer-id',
-      transporterProfileId: 'transporter-profile-id',
-      originLabel: 'Buenos Aires',
-      originLat: new Prisma.Decimal('-34.603722'),
-      originLng: new Prisma.Decimal('-58.381592'),
-      destinationLabel: 'Rosario',
-      destinationLat: new Prisma.Decimal('-32.944243'),
-      destinationLng: new Prisma.Decimal('-60.650539'),
-      departureDate: new Date('2026-05-01T00:00:00.000Z'),
-      departureWindowStart: null,
-      departureWindowEnd: null,
-      capacityTotal: 6,
-      availableCapacity: 4,
-      pricePerSlot: 120000,
-      maxDetourKm: 50,
-      notes: 'Salida temprana',
-      cancellationPolicy: 'Flexible',
-      cargoType: 'EQUINE',
-      isReturn: false,
-      status: 'DRAFT',
-      createdAt: new Date('2026-04-21T10:00:00.000Z'),
-      updatedAt: new Date('2026-04-21T10:00:00.000Z'),
-    });
+  it('lists only the authenticated transporter trip offers', async () => {
     tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
       id: 'transporter-profile-id',
     });
-    tripOfferRepository.updateById.mockResolvedValue({
-      id: 'trip-offer-id',
-      transporterProfileId: 'transporter-profile-id',
-      originLabel: 'Buenos Aires',
-      originLat: new Prisma.Decimal('-34.603722'),
-      originLng: new Prisma.Decimal('-58.381592'),
-      destinationLabel: 'Cordoba',
-      destinationLat: new Prisma.Decimal('-31.420083'),
-      destinationLng: new Prisma.Decimal('-64.188776'),
-      departureDate: null,
-      departureWindowStart: new Date('2026-05-02T08:00:00.000Z'),
-      departureWindowEnd: new Date('2026-05-02T12:00:00.000Z'),
-      capacityTotal: 10,
-      availableCapacity: 10,
-      pricePerSlot: 140000,
-      maxDetourKm: 70,
-      notes: null,
-      cancellationPolicy: 'Moderada',
-      cargoType: 'GENERAL_CARGO',
-      isReturn: true,
-      status: 'DRAFT',
-      createdAt: new Date('2026-04-21T10:00:00.000Z'),
-      updatedAt,
+    tripOfferRepository.findOwnedByAccountId.mockResolvedValue([
+      createTripOfferRecord(),
+      createTripOfferRecord({
+        id: 'trip-offer-full-id',
+        availableCapacity: 0,
+        status: TripOfferStatus.PUBLISHED,
+      }),
+    ]);
+
+    await expect(
+      tripOfferService.listOwnTripOffers('account-id'),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'trip-offer-id',
+        status: 'DRAFT',
+      }),
+      expect.objectContaining({
+        id: 'trip-offer-full-id',
+        status: 'FULL',
+      }),
+    ]);
+
+    expect(tripOfferRepository.findOwnedByAccountId).toHaveBeenCalledWith(
+      'account-id',
+    );
+  });
+
+  it('publishes an owned draft trip offer as PUBLISHED when capacity remains', async () => {
+    tripOfferRepository.findById.mockResolvedValue(createTripOfferRecord());
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
     });
+    tripOfferRepository.updateStatusById.mockResolvedValue(
+      createTripOfferRecord({
+        status: TripOfferStatus.PUBLISHED,
+      }),
+    );
+
+    await expect(
+      tripOfferService.publishOwnTripOffer('account-id', 'trip-offer-id'),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        id: 'trip-offer-id',
+        status: 'PUBLISHED',
+      }),
+    );
+
+    expect(tripOfferRepository.updateStatusById).toHaveBeenCalledWith(
+      'trip-offer-id',
+      TripOfferStatus.PUBLISHED,
+    );
+  });
+
+  it('publishes an owned draft trip offer as FULL when availableCapacity is zero', async () => {
+    tripOfferRepository.findById.mockResolvedValue(
+      createTripOfferRecord({
+        availableCapacity: 0,
+      }),
+    );
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+    tripOfferRepository.updateStatusById.mockResolvedValue(
+      createTripOfferRecord({
+        availableCapacity: 0,
+        status: TripOfferStatus.FULL,
+      }),
+    );
+
+    await expect(
+      tripOfferService.publishOwnTripOffer('account-id', 'trip-offer-id'),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        status: 'FULL',
+      }),
+    );
+
+    expect(tripOfferRepository.updateStatusById).toHaveBeenCalledWith(
+      'trip-offer-id',
+      TripOfferStatus.FULL,
+    );
+  });
+
+  it('throws when publishing a trip offer that does not exist', async () => {
+    tripOfferRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      tripOfferService.publishOwnTripOffer('account-id', 'missing-id'),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws when publishing a trip offer owned by another transporter', async () => {
+    tripOfferRepository.findById.mockResolvedValue(
+      createTripOfferRecord({
+        transporterProfileId: 'other-transporter-profile-id',
+      }),
+    );
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+
+    await expect(
+      tripOfferService.publishOwnTripOffer('account-id', 'trip-offer-id'),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('throws when publishing a trip offer outside draft status', async () => {
+    tripOfferRepository.findById.mockResolvedValue(
+      createTripOfferRecord({
+        status: TripOfferStatus.CANCELLED,
+      }),
+    );
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+
+    await expect(
+      tripOfferService.publishOwnTripOffer('account-id', 'trip-offer-id'),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('updates an owned draft trip offer and resyncs available capacity', async () => {
+    const updatedAt = new Date('2026-04-21T12:00:00.000Z');
+
+    tripOfferRepository.findById.mockResolvedValue(createTripOfferRecord());
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+    tripOfferRepository.updateById.mockResolvedValue(
+      createTripOfferRecord({
+        destinationLabel: 'Cordoba',
+        destinationLat: new Prisma.Decimal('-31.420083'),
+        destinationLng: new Prisma.Decimal('-64.188776'),
+        departureDate: null,
+        departureWindowStart: new Date('2026-05-02T08:00:00.000Z'),
+        departureWindowEnd: new Date('2026-05-02T12:00:00.000Z'),
+        capacityTotal: 10,
+        availableCapacity: 10,
+        pricePerSlot: 140000,
+        maxDetourKm: 70,
+        notes: null,
+        cancellationPolicy: 'Moderada',
+        cargoType: 'GENERAL_CARGO',
+        isReturn: true,
+        updatedAt,
+      }),
+    );
 
     await expect(
       tripOfferService.updateOwnTripOffer('account-id', 'trip-offer-id', {
@@ -292,30 +402,11 @@ describe('TripOfferService', () => {
   });
 
   it('throws when updating a trip offer owned by another transporter', async () => {
-    tripOfferRepository.findById.mockResolvedValue({
-      id: 'trip-offer-id',
-      transporterProfileId: 'other-transporter-profile-id',
-      originLabel: 'Buenos Aires',
-      originLat: new Prisma.Decimal('-34.603722'),
-      originLng: new Prisma.Decimal('-58.381592'),
-      destinationLabel: 'Rosario',
-      destinationLat: new Prisma.Decimal('-32.944243'),
-      destinationLng: new Prisma.Decimal('-60.650539'),
-      departureDate: new Date('2026-05-01T00:00:00.000Z'),
-      departureWindowStart: null,
-      departureWindowEnd: null,
-      capacityTotal: 6,
-      availableCapacity: 6,
-      pricePerSlot: 120000,
-      maxDetourKm: 50,
-      notes: null,
-      cancellationPolicy: null,
-      cargoType: 'EQUINE',
-      isReturn: false,
-      status: 'DRAFT',
-      createdAt: new Date('2026-04-21T10:00:00.000Z'),
-      updatedAt: new Date('2026-04-21T10:00:00.000Z'),
-    });
+    tripOfferRepository.findById.mockResolvedValue(
+      createTripOfferRecord({
+        transporterProfileId: 'other-transporter-profile-id',
+      }),
+    );
     tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
       id: 'transporter-profile-id',
     });
@@ -328,30 +419,11 @@ describe('TripOfferService', () => {
   });
 
   it('throws when updating a trip offer that is no longer in draft', async () => {
-    tripOfferRepository.findById.mockResolvedValue({
-      id: 'trip-offer-id',
-      transporterProfileId: 'transporter-profile-id',
-      originLabel: 'Buenos Aires',
-      originLat: new Prisma.Decimal('-34.603722'),
-      originLng: new Prisma.Decimal('-58.381592'),
-      destinationLabel: 'Rosario',
-      destinationLat: new Prisma.Decimal('-32.944243'),
-      destinationLng: new Prisma.Decimal('-60.650539'),
-      departureDate: new Date('2026-05-01T00:00:00.000Z'),
-      departureWindowStart: null,
-      departureWindowEnd: null,
-      capacityTotal: 6,
-      availableCapacity: 6,
-      pricePerSlot: 120000,
-      maxDetourKm: 50,
-      notes: null,
-      cancellationPolicy: null,
-      cargoType: 'EQUINE',
-      isReturn: false,
-      status: 'PUBLISHED',
-      createdAt: new Date('2026-04-21T10:00:00.000Z'),
-      updatedAt: new Date('2026-04-21T10:00:00.000Z'),
-    });
+    tripOfferRepository.findById.mockResolvedValue(
+      createTripOfferRecord({
+        status: TripOfferStatus.PUBLISHED,
+      }),
+    );
     tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
       id: 'transporter-profile-id',
     });
@@ -360,6 +432,86 @@ describe('TripOfferService', () => {
       tripOfferService.updateOwnTripOffer('account-id', 'trip-offer-id', {
         pricePerSlot: 140000,
       }),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('closes an owned trip offer from a permitted status', async () => {
+    tripOfferRepository.findById.mockResolvedValue(
+      createTripOfferRecord({
+        status: TripOfferStatus.FULL,
+        availableCapacity: 0,
+      }),
+    );
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+    tripOfferRepository.updateStatusById.mockResolvedValue(
+      createTripOfferRecord({
+        status: TripOfferStatus.CLOSED,
+        availableCapacity: 0,
+      }),
+    );
+
+    await expect(
+      tripOfferService.closeOwnTripOffer('account-id', 'trip-offer-id'),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        status: 'CLOSED',
+      }),
+    );
+  });
+
+  it('throws when closing a trip offer in a non-operable status', async () => {
+    tripOfferRepository.findById.mockResolvedValue(
+      createTripOfferRecord({
+        status: TripOfferStatus.CANCELLED,
+      }),
+    );
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+
+    await expect(
+      tripOfferService.closeOwnTripOffer('account-id', 'trip-offer-id'),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('cancels an owned trip offer from a permitted status', async () => {
+    tripOfferRepository.findById.mockResolvedValue(
+      createTripOfferRecord({
+        status: TripOfferStatus.PUBLISHED,
+      }),
+    );
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+    tripOfferRepository.updateStatusById.mockResolvedValue(
+      createTripOfferRecord({
+        status: TripOfferStatus.CANCELLED,
+      }),
+    );
+
+    await expect(
+      tripOfferService.cancelOwnTripOffer('account-id', 'trip-offer-id'),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        status: 'CANCELLED',
+      }),
+    );
+  });
+
+  it('throws when cancelling a trip offer in a non-operable status', async () => {
+    tripOfferRepository.findById.mockResolvedValue(
+      createTripOfferRecord({
+        status: TripOfferStatus.CLOSED,
+      }),
+    );
+    tripOfferRepository.findTransporterProfileByAccountId.mockResolvedValue({
+      id: 'transporter-profile-id',
+    });
+
+    await expect(
+      tripOfferService.cancelOwnTripOffer('account-id', 'trip-offer-id'),
     ).rejects.toThrow(ConflictException);
   });
 });

--- a/apps/api/src/trip-offer/application/trip-offer.service.ts
+++ b/apps/api/src/trip-offer/application/trip-offer.service.ts
@@ -5,6 +5,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import { TripOfferStatus } from '@logistica/database';
 import type { TripOfferResponseDto } from '../dto/trip-offer.response.dto';
 import { TripOfferRepository } from '../repositories/trip-offer.repository';
 import type {
@@ -44,20 +45,21 @@ type TripOfferDraftState = Pick<
 export class TripOfferService {
   constructor(private readonly tripOfferRepository: TripOfferRepository) {}
 
+  async listOwnTripOffers(accountId: string): Promise<TripOfferResponseDto[]> {
+    await this.getTransporterProfileOrThrow(accountId);
+
+    const tripOffers =
+      await this.tripOfferRepository.findOwnedByAccountId(accountId);
+
+    return tripOffers.map((tripOffer) => this.toTripOfferResponse(tripOffer));
+  }
+
   async createOwnTripOffer(
     accountId: string,
     input: CreateTripOfferInput,
   ): Promise<TripOfferResponseDto> {
     const transporterProfile =
-      await this.tripOfferRepository.findTransporterProfileByAccountId(
-        accountId,
-      );
-
-    if (!transporterProfile) {
-      throw new NotFoundException(
-        'Transporter profile not found for the authenticated account.',
-      );
-    }
+      await this.getTransporterProfileOrThrow(accountId);
 
     const normalizedInput = this.normalizeCreateInput(input);
     this.validateDraftState(normalizedInput);
@@ -68,6 +70,38 @@ export class TripOfferService {
     );
 
     return this.toTripOfferResponse(createdTripOffer);
+  }
+
+  async publishOwnTripOffer(
+    accountId: string,
+    tripOfferId: string,
+  ): Promise<TripOfferResponseDto> {
+    const existingTripOffer =
+      await this.tripOfferRepository.findById(tripOfferId);
+
+    if (!existingTripOffer) {
+      throw new NotFoundException('Trip offer not found.');
+    }
+
+    const transporterProfile =
+      await this.getTransporterProfileOrThrow(accountId);
+
+    this.assertOwnership(existingTripOffer, transporterProfile.id, 'publish');
+
+    if (existingTripOffer.status !== TripOfferStatus.DRAFT) {
+      throw new ConflictException(
+        'Only trip offers in DRAFT status can be published.',
+      );
+    }
+
+    this.validateDraftState(this.toDraftState(existingTripOffer));
+
+    const publishedTripOffer = await this.tripOfferRepository.updateStatusById(
+      tripOfferId,
+      this.resolvePublishedStatus(existingTripOffer.availableCapacity),
+    );
+
+    return this.toTripOfferResponse(publishedTripOffer);
   }
 
   async updateOwnTripOffer(
@@ -83,21 +117,9 @@ export class TripOfferService {
     }
 
     const transporterProfile =
-      await this.tripOfferRepository.findTransporterProfileByAccountId(
-        accountId,
-      );
+      await this.getTransporterProfileOrThrow(accountId);
 
-    if (!transporterProfile) {
-      throw new NotFoundException(
-        'Transporter profile not found for the authenticated account.',
-      );
-    }
-
-    if (existingTripOffer.transporterProfileId !== transporterProfile.id) {
-      throw new ForbiddenException(
-        'You cannot edit a trip offer that belongs to another transporter.',
-      );
-    }
+    this.assertOwnership(existingTripOffer, transporterProfile.id, 'edit');
 
     if (existingTripOffer.status !== 'DRAFT') {
       throw new ConflictException(
@@ -122,6 +144,64 @@ export class TripOfferService {
     );
 
     return this.toTripOfferResponse(updatedTripOffer);
+  }
+
+  async closeOwnTripOffer(
+    accountId: string,
+    tripOfferId: string,
+  ): Promise<TripOfferResponseDto> {
+    const existingTripOffer =
+      await this.tripOfferRepository.findById(tripOfferId);
+
+    if (!existingTripOffer) {
+      throw new NotFoundException('Trip offer not found.');
+    }
+
+    const transporterProfile =
+      await this.getTransporterProfileOrThrow(accountId);
+
+    this.assertOwnership(existingTripOffer, transporterProfile.id, 'close');
+    this.assertStatusTransitionAllowed(
+      existingTripOffer,
+      [TripOfferStatus.DRAFT, TripOfferStatus.PUBLISHED, TripOfferStatus.FULL],
+      'close',
+    );
+
+    const closedTripOffer = await this.tripOfferRepository.updateStatusById(
+      tripOfferId,
+      TripOfferStatus.CLOSED,
+    );
+
+    return this.toTripOfferResponse(closedTripOffer);
+  }
+
+  async cancelOwnTripOffer(
+    accountId: string,
+    tripOfferId: string,
+  ): Promise<TripOfferResponseDto> {
+    const existingTripOffer =
+      await this.tripOfferRepository.findById(tripOfferId);
+
+    if (!existingTripOffer) {
+      throw new NotFoundException('Trip offer not found.');
+    }
+
+    const transporterProfile =
+      await this.getTransporterProfileOrThrow(accountId);
+
+    this.assertOwnership(existingTripOffer, transporterProfile.id, 'cancel');
+    this.assertStatusTransitionAllowed(
+      existingTripOffer,
+      [TripOfferStatus.DRAFT, TripOfferStatus.PUBLISHED, TripOfferStatus.FULL],
+      'cancel',
+    );
+
+    const cancelledTripOffer = await this.tripOfferRepository.updateStatusById(
+      tripOfferId,
+      TripOfferStatus.CANCELLED,
+    );
+
+    return this.toTripOfferResponse(cancelledTripOffer);
   }
 
   private validateDraftState(input: {
@@ -362,6 +442,102 @@ export class TripOfferService {
     return normalizedValue.length > 0 ? normalizedValue : null;
   }
 
+  private async getTransporterProfileOrThrow(accountId: string) {
+    const transporterProfile =
+      await this.tripOfferRepository.findTransporterProfileByAccountId(
+        accountId,
+      );
+
+    if (!transporterProfile) {
+      throw new NotFoundException(
+        'Transporter profile not found for the authenticated account.',
+      );
+    }
+
+    return transporterProfile;
+  }
+
+  private assertOwnership(
+    tripOffer: TripOfferRecord,
+    transporterProfileId: string,
+    action: 'edit' | 'publish' | 'close' | 'cancel',
+  ): void {
+    if (tripOffer.transporterProfileId === transporterProfileId) {
+      return;
+    }
+
+    const messages = {
+      edit: 'You cannot edit a trip offer that belongs to another transporter.',
+      publish:
+        'You cannot publish a trip offer that belongs to another transporter.',
+      close:
+        'You cannot close a trip offer that belongs to another transporter.',
+      cancel:
+        'You cannot cancel a trip offer that belongs to another transporter.',
+    } as const;
+
+    throw new ForbiddenException(messages[action]);
+  }
+
+  private assertStatusTransitionAllowed(
+    tripOffer: TripOfferRecord,
+    allowedStatuses: TripOfferStatus[],
+    action: 'close' | 'cancel',
+  ): void {
+    const effectiveStatus = this.getEffectiveStatus(tripOffer);
+
+    if (allowedStatuses.includes(effectiveStatus)) {
+      return;
+    }
+
+    const messages = {
+      close:
+        'Only trip offers in DRAFT, PUBLISHED, or FULL status can be closed.',
+      cancel:
+        'Only trip offers in DRAFT, PUBLISHED, or FULL status can be cancelled.',
+    } as const;
+
+    throw new ConflictException(messages[action]);
+  }
+
+  private toDraftState(tripOffer: TripOfferRecord): TripOfferDraftState {
+    return {
+      originLabel: tripOffer.originLabel,
+      originLat: Number(tripOffer.originLat),
+      originLng: Number(tripOffer.originLng),
+      destinationLabel: tripOffer.destinationLabel,
+      destinationLat: Number(tripOffer.destinationLat),
+      destinationLng: Number(tripOffer.destinationLng),
+      departureDate: tripOffer.departureDate,
+      departureWindowStart: tripOffer.departureWindowStart,
+      departureWindowEnd: tripOffer.departureWindowEnd,
+      capacityTotal: tripOffer.capacityTotal,
+      pricePerSlot: tripOffer.pricePerSlot,
+      maxDetourKm: tripOffer.maxDetourKm,
+      notes: tripOffer.notes,
+      cancellationPolicy: tripOffer.cancellationPolicy,
+      cargoType: tripOffer.cargoType,
+      isReturn: tripOffer.isReturn,
+    };
+  }
+
+  private resolvePublishedStatus(availableCapacity: number): TripOfferStatus {
+    return availableCapacity === 0
+      ? TripOfferStatus.FULL
+      : TripOfferStatus.PUBLISHED;
+  }
+
+  private getEffectiveStatus(tripOffer: TripOfferRecord): TripOfferStatus {
+    if (
+      tripOffer.status === TripOfferStatus.PUBLISHED &&
+      tripOffer.availableCapacity === 0
+    ) {
+      return TripOfferStatus.FULL;
+    }
+
+    return tripOffer.status;
+  }
+
   private toTripOfferResponse(
     tripOffer: TripOfferRecord,
   ): TripOfferResponseDto {
@@ -384,7 +560,7 @@ export class TripOfferService {
       cancellationPolicy: tripOffer.cancellationPolicy,
       cargoType: tripOffer.cargoType,
       isReturn: tripOffer.isReturn,
-      status: tripOffer.status,
+      status: this.getEffectiveStatus(tripOffer),
       createdAt: tripOffer.createdAt,
       updatedAt: tripOffer.updatedAt,
     };

--- a/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
+++ b/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
@@ -31,6 +31,20 @@ export class TripOfferRepository {
     });
   }
 
+  async findOwnedByAccountId(accountId: string): Promise<TripOfferRecord[]> {
+    return this.prisma.tripOffer.findMany({
+      where: {
+        transporterProfile: {
+          accountId,
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      select: tripOfferSelect,
+    });
+  }
+
   async create(
     transporterProfileId: string,
     input: CreateTripOfferInput,
@@ -72,6 +86,17 @@ export class TripOfferRepository {
     return this.prisma.tripOffer.update({
       where: { id: tripOfferId },
       data,
+      select: tripOfferSelect,
+    });
+  }
+
+  async updateStatusById(
+    tripOfferId: string,
+    status: TripOfferStatus,
+  ): Promise<TripOfferRecord> {
+    return this.prisma.tripOffer.update({
+      where: { id: tripOfferId },
+      data: { status },
       select: tripOfferSelect,
     });
   }

--- a/apps/api/src/trip-offer/trip-offer.controller.spec.ts
+++ b/apps/api/src/trip-offer/trip-offer.controller.spec.ts
@@ -43,8 +43,12 @@ class TestJwtAuthGuard {
 
 describe('TripOfferController', () => {
   const tripOfferService = {
+    listOwnTripOffers: jest.fn(),
     createOwnTripOffer: jest.fn(),
+    publishOwnTripOffer: jest.fn(),
     updateOwnTripOffer: jest.fn(),
+    closeOwnTripOffer: jest.fn(),
+    cancelOwnTripOffer: jest.fn(),
   };
 
   beforeEach(() => {
@@ -71,6 +75,55 @@ describe('TripOfferController', () => {
 
     return app;
   }
+
+  it('lists the authenticated transporter trip offers', async () => {
+    tripOfferService.listOwnTripOffers.mockResolvedValue([
+      {
+        id: 'trip-offer-id',
+        originLabel: 'Buenos Aires',
+        originLat: -34.603722,
+        originLng: -58.381592,
+        destinationLabel: 'Rosario',
+        destinationLat: -32.944243,
+        destinationLng: -60.650539,
+        departureDate: '2026-05-01T00:00:00.000Z',
+        departureWindowStart: null,
+        departureWindowEnd: null,
+        capacityTotal: 6,
+        availableCapacity: 0,
+        pricePerSlot: 120000,
+        maxDetourKm: 50,
+        notes: 'Salida temprana',
+        cancellationPolicy: 'Flexible',
+        cargoType: 'EQUINE',
+        isReturn: false,
+        status: 'FULL',
+        createdAt: '2026-04-21T10:00:00.000Z',
+        updatedAt: '2026-04-21T10:00:00.000Z',
+      },
+    ]);
+
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    const response = await request(server)
+      .get('/trip-offers/my')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .expect(200);
+
+    expect(response.body).toEqual([
+      expect.objectContaining({
+        id: 'trip-offer-id',
+        status: 'FULL',
+      }),
+    ]);
+
+    expect(tripOfferService.listOwnTripOffers).toHaveBeenCalledWith(
+      'transporter-account-id',
+    );
+
+    await app.close();
+  });
 
   it('creates a trip offer draft for the authenticated transporter', async () => {
     const createdAt = '2026-04-21T10:00:00.000Z';
@@ -161,106 +214,52 @@ describe('TripOfferController', () => {
     await app.close();
   });
 
-  it('returns 400 when the payload is invalid', async () => {
+  it('publishes a trip offer when the id is valid', async () => {
+    const tripOfferId = 'cm9tripoffer0000wqz5oy7k8ph1';
+
+    tripOfferService.publishOwnTripOffer.mockResolvedValue({
+      id: tripOfferId,
+      originLabel: 'Buenos Aires',
+      originLat: -34.603722,
+      originLng: -58.381592,
+      destinationLabel: 'Rosario',
+      destinationLat: -32.944243,
+      destinationLng: -60.650539,
+      departureDate: new Date('2026-05-01T00:00:00.000Z'),
+      departureWindowStart: null,
+      departureWindowEnd: null,
+      capacityTotal: 6,
+      availableCapacity: 6,
+      pricePerSlot: 120000,
+      maxDetourKm: 50,
+      notes: 'Salida temprana',
+      cancellationPolicy: 'Flexible',
+      cargoType: 'EQUINE',
+      isReturn: false,
+      status: 'PUBLISHED',
+      createdAt: new Date('2026-04-21T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-21T12:00:00.000Z'),
+    });
+
     const app = await createApp();
     const server = app.getHttpServer() as Parameters<typeof request>[0];
 
-    await request(server)
-      .post('/trip-offers')
+    const response = await request(server)
+      .post(`/trip-offers/${tripOfferId}/publish`)
       .set('Authorization', 'Bearer TRANSPORTER')
-      .send({
-        originLabel: '',
-        originLat: -120,
-        originLng: -58.381592,
-        destinationLabel: 'Rosario',
-        destinationLat: -32.944243,
-        destinationLng: -60.650539,
-        departureDate: '2026-05-01T00:00:00.000Z',
-        capacityTotal: 0,
-        pricePerSlot: -1,
-        cargoType: 'EQUINE',
-        isReturn: false,
-      })
-      .expect(400);
+      .expect(200);
 
-    expect(tripOfferService.createOwnTripOffer).not.toHaveBeenCalled();
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        id: tripOfferId,
+        status: 'PUBLISHED',
+      }),
+    );
 
-    await app.close();
-  });
-
-  it('returns 400 when trying to send forbidden ownership fields', async () => {
-    const app = await createApp();
-    const server = app.getHttpServer() as Parameters<typeof request>[0];
-
-    await request(server)
-      .post('/trip-offers')
-      .set('Authorization', 'Bearer TRANSPORTER')
-      .send({
-        originLabel: 'Buenos Aires',
-        originLat: -34.603722,
-        originLng: -58.381592,
-        destinationLabel: 'Rosario',
-        destinationLat: -32.944243,
-        destinationLng: -60.650539,
-        departureDate: '2026-05-01T00:00:00.000Z',
-        capacityTotal: 6,
-        pricePerSlot: 120000,
-        cargoType: 'EQUINE',
-        isReturn: false,
-        transporterProfileId: 'other-profile-id',
-      })
-      .expect(400);
-
-    expect(tripOfferService.createOwnTripOffer).not.toHaveBeenCalled();
-
-    await app.close();
-  });
-
-  it('returns 401 when the access token is missing', async () => {
-    const app = await createApp();
-    const server = app.getHttpServer() as Parameters<typeof request>[0];
-
-    await request(server)
-      .post('/trip-offers')
-      .send({
-        originLabel: 'Buenos Aires',
-        originLat: -34.603722,
-        originLng: -58.381592,
-        destinationLabel: 'Rosario',
-        destinationLat: -32.944243,
-        destinationLng: -60.650539,
-        departureDate: '2026-05-01T00:00:00.000Z',
-        capacityTotal: 6,
-        pricePerSlot: 120000,
-        cargoType: 'EQUINE',
-        isReturn: false,
-      })
-      .expect(401);
-
-    await app.close();
-  });
-
-  it('returns 403 when the authenticated role is not TRANSPORTER', async () => {
-    const app = await createApp();
-    const server = app.getHttpServer() as Parameters<typeof request>[0];
-
-    await request(server)
-      .post('/trip-offers')
-      .set('Authorization', 'Bearer CLIENT')
-      .send({
-        originLabel: 'Buenos Aires',
-        originLat: -34.603722,
-        originLng: -58.381592,
-        destinationLabel: 'Rosario',
-        destinationLat: -32.944243,
-        destinationLng: -60.650539,
-        departureDate: '2026-05-01T00:00:00.000Z',
-        capacityTotal: 6,
-        pricePerSlot: 120000,
-        cargoType: 'EQUINE',
-        isReturn: false,
-      })
-      .expect(403);
+    expect(tripOfferService.publishOwnTripOffer).toHaveBeenCalledWith(
+      'transporter-account-id',
+      tripOfferId,
+    );
 
     await app.close();
   });
@@ -352,6 +351,211 @@ describe('TripOfferController', () => {
     await app.close();
   });
 
+  it('closes a trip offer when the id is valid', async () => {
+    const tripOfferId = 'cm9tripoffer0000wqz5oy7k8ph1';
+
+    tripOfferService.closeOwnTripOffer.mockResolvedValue({
+      id: tripOfferId,
+      originLabel: 'Buenos Aires',
+      originLat: -34.603722,
+      originLng: -58.381592,
+      destinationLabel: 'Rosario',
+      destinationLat: -32.944243,
+      destinationLng: -60.650539,
+      departureDate: new Date('2026-05-01T00:00:00.000Z'),
+      departureWindowStart: null,
+      departureWindowEnd: null,
+      capacityTotal: 6,
+      availableCapacity: 0,
+      pricePerSlot: 120000,
+      maxDetourKm: 50,
+      notes: 'Salida temprana',
+      cancellationPolicy: 'Flexible',
+      cargoType: 'EQUINE',
+      isReturn: false,
+      status: 'CLOSED',
+      createdAt: new Date('2026-04-21T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-21T12:00:00.000Z'),
+    });
+
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    const response = await request(server)
+      .post(`/trip-offers/${tripOfferId}/close`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .expect(200);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        id: tripOfferId,
+        status: 'CLOSED',
+      }),
+    );
+
+    expect(tripOfferService.closeOwnTripOffer).toHaveBeenCalledWith(
+      'transporter-account-id',
+      tripOfferId,
+    );
+
+    await app.close();
+  });
+
+  it('cancels a trip offer when the id is valid', async () => {
+    const tripOfferId = 'cm9tripoffer0000wqz5oy7k8ph1';
+
+    tripOfferService.cancelOwnTripOffer.mockResolvedValue({
+      id: tripOfferId,
+      originLabel: 'Buenos Aires',
+      originLat: -34.603722,
+      originLng: -58.381592,
+      destinationLabel: 'Rosario',
+      destinationLat: -32.944243,
+      destinationLng: -60.650539,
+      departureDate: new Date('2026-05-01T00:00:00.000Z'),
+      departureWindowStart: null,
+      departureWindowEnd: null,
+      capacityTotal: 6,
+      availableCapacity: 0,
+      pricePerSlot: 120000,
+      maxDetourKm: 50,
+      notes: 'Salida temprana',
+      cancellationPolicy: 'Flexible',
+      cargoType: 'EQUINE',
+      isReturn: false,
+      status: 'CANCELLED',
+      createdAt: new Date('2026-04-21T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-21T12:00:00.000Z'),
+    });
+
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    const response = await request(server)
+      .post(`/trip-offers/${tripOfferId}/cancel`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .expect(200);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        id: tripOfferId,
+        status: 'CANCELLED',
+      }),
+    );
+
+    expect(tripOfferService.cancelOwnTripOffer).toHaveBeenCalledWith(
+      'transporter-account-id',
+      tripOfferId,
+    );
+
+    await app.close();
+  });
+
+  it('returns 400 when the payload is invalid', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trip-offers')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        originLabel: '',
+        originLat: -120,
+        originLng: -58.381592,
+        destinationLabel: 'Rosario',
+        destinationLat: -32.944243,
+        destinationLng: -60.650539,
+        departureDate: '2026-05-01T00:00:00.000Z',
+        capacityTotal: 0,
+        pricePerSlot: -1,
+        cargoType: 'EQUINE',
+        isReturn: false,
+      })
+      .expect(400);
+
+    expect(tripOfferService.createOwnTripOffer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when trying to send forbidden ownership fields', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trip-offers')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .send({
+        originLabel: 'Buenos Aires',
+        originLat: -34.603722,
+        originLng: -58.381592,
+        destinationLabel: 'Rosario',
+        destinationLat: -32.944243,
+        destinationLng: -60.650539,
+        departureDate: '2026-05-01T00:00:00.000Z',
+        capacityTotal: 6,
+        pricePerSlot: 120000,
+        cargoType: 'EQUINE',
+        isReturn: false,
+        transporterProfileId: 'other-profile-id',
+      })
+      .expect(400);
+
+    expect(tripOfferService.createOwnTripOffer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when the path id is invalid for state actions', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trip-offers/not-a-cuid/publish')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .expect(400);
+
+    expect(tripOfferService.publishOwnTripOffer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 401 when the access token is missing', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/trip-offers')
+      .send({
+        originLabel: 'Buenos Aires',
+        originLat: -34.603722,
+        originLng: -58.381592,
+        destinationLabel: 'Rosario',
+        destinationLat: -32.944243,
+        destinationLng: -60.650539,
+        departureDate: '2026-05-01T00:00:00.000Z',
+        capacityTotal: 6,
+        pricePerSlot: 120000,
+        cargoType: 'EQUINE',
+        isReturn: false,
+      })
+      .expect(401);
+
+    await app.close();
+  });
+
+  it('returns 403 when the authenticated role is not TRANSPORTER', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/my')
+      .set('Authorization', 'Bearer CLIENT')
+      .expect(403);
+
+    await app.close();
+  });
+
   it('returns 404 when updating a trip offer that does not exist', async () => {
     const app = await createApp();
     const server = app.getHttpServer() as Parameters<typeof request>[0];
@@ -368,6 +572,44 @@ describe('TripOfferController', () => {
         pricePerSlot: 140000,
       })
       .expect(404);
+
+    await app.close();
+  });
+
+  it('returns 403 when publishing a trip offer owned by another transporter', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const tripOfferId = 'cm9tripoffer0000wqz5oy7k8ph1';
+
+    tripOfferService.publishOwnTripOffer.mockRejectedValue(
+      new ForbiddenException(
+        'You cannot publish a trip offer that belongs to another transporter.',
+      ),
+    );
+
+    await request(server)
+      .post(`/trip-offers/${tripOfferId}/publish`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .expect(403);
+
+    await app.close();
+  });
+
+  it('returns 409 when publishing a trip offer outside draft status', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const tripOfferId = 'cm9tripoffer0000wqz5oy7k8ph1';
+
+    tripOfferService.publishOwnTripOffer.mockRejectedValue(
+      new ConflictException(
+        'Only trip offers in DRAFT status can be published.',
+      ),
+    );
+
+    await request(server)
+      .post(`/trip-offers/${tripOfferId}/publish`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .expect(409);
 
     await app.close();
   });
@@ -409,6 +651,44 @@ describe('TripOfferController', () => {
       .send({
         pricePerSlot: 140000,
       })
+      .expect(409);
+
+    await app.close();
+  });
+
+  it('returns 409 when closing a trip offer in a non-operable status', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const tripOfferId = 'cm9tripoffer0000wqz5oy7k8ph1';
+
+    tripOfferService.closeOwnTripOffer.mockRejectedValue(
+      new ConflictException(
+        'Only trip offers in DRAFT, PUBLISHED, or FULL status can be closed.',
+      ),
+    );
+
+    await request(server)
+      .post(`/trip-offers/${tripOfferId}/close`)
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .expect(409);
+
+    await app.close();
+  });
+
+  it('returns 409 when cancelling a trip offer in a non-operable status', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const tripOfferId = 'cm9tripoffer0000wqz5oy7k8ph1';
+
+    tripOfferService.cancelOwnTripOffer.mockRejectedValue(
+      new ConflictException(
+        'Only trip offers in DRAFT, PUBLISHED, or FULL status can be cancelled.',
+      ),
+    );
+
+    await request(server)
+      .post(`/trip-offers/${tripOfferId}/cancel`)
+      .set('Authorization', 'Bearer TRANSPORTER')
       .expect(409);
 
     await app.close();

--- a/apps/api/src/trip-offer/trip-offer.controller.ts
+++ b/apps/api/src/trip-offer/trip-offer.controller.ts
@@ -1,6 +1,8 @@
 import {
   Body,
   Controller,
+  Get,
+  HttpCode,
   Param,
   Patch,
   Post,
@@ -33,6 +35,15 @@ interface AuthenticatedHttpRequest {
 export class TripOfferController {
   constructor(private readonly tripOfferService: TripOfferService) {}
 
+  @Get('my')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async listOwnTripOffers(
+    @Req() request: AuthenticatedHttpRequest,
+  ): Promise<TripOfferResponseDto[]> {
+    return this.tripOfferService.listOwnTripOffers(request.user.accountId);
+  }
+
   @Post()
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('TRANSPORTER')
@@ -44,6 +55,21 @@ export class TripOfferController {
     return this.tripOfferService.createOwnTripOffer(
       request.user.accountId,
       createTripOfferDto,
+    );
+  }
+
+  @Post(':id/publish')
+  @HttpCode(200)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async publishOwnTripOffer(
+    @Req() request: AuthenticatedHttpRequest,
+    @Param(new ZodValidationPipe(TripOfferParamsSchema))
+    params: TripOfferParamsDto,
+  ): Promise<TripOfferResponseDto> {
+    return this.tripOfferService.publishOwnTripOffer(
+      request.user.accountId,
+      params.id,
     );
   }
 
@@ -61,6 +87,36 @@ export class TripOfferController {
       request.user.accountId,
       params.id,
       updateTripOfferDto,
+    );
+  }
+
+  @Post(':id/close')
+  @HttpCode(200)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async closeOwnTripOffer(
+    @Req() request: AuthenticatedHttpRequest,
+    @Param(new ZodValidationPipe(TripOfferParamsSchema))
+    params: TripOfferParamsDto,
+  ): Promise<TripOfferResponseDto> {
+    return this.tripOfferService.closeOwnTripOffer(
+      request.user.accountId,
+      params.id,
+    );
+  }
+
+  @Post(':id/cancel')
+  @HttpCode(200)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('TRANSPORTER')
+  async cancelOwnTripOffer(
+    @Req() request: AuthenticatedHttpRequest,
+    @Param(new ZodValidationPipe(TripOfferParamsSchema))
+    params: TripOfferParamsDto,
+  ): Promise<TripOfferResponseDto> {
+    return this.tripOfferService.cancelOwnTripOffer(
+      request.user.accountId,
+      params.id,
     );
   }
 }


### PR DESCRIPTION
## Contexto
Implementa E4-BE-03 en backend para publicar ofertas, listar las ofertas propias del transportista y gestionar estados basicos de TripOffer.

## Alcance
- agregar GET /trip-offers/my
- agregar POST /trip-offers/:id/publish
- agregar POST /trip-offers/:id/close
- agregar POST /trip-offers/:id/cancel
- validar ownership y transiciones permitidas
- aplicar regla FULL cuando availableCapacity es cero
- extender tests de service y controller

## Verificacion
- pnpm --filter @logistica/api test
- pnpm --filter @logistica/api typecheck
- pnpm --filter @logistica/api lint