### PR TITLE
feat(trip-offer): add public trip offer search endpoint

### DIFF
--- a/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
+++ b/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
@@ -37,6 +37,7 @@ const createTripOfferRecord = (
 
 describe('TripOfferService', () => {
   const tripOfferRepository = {
+    searchPublic: jest.fn(),
     findTransporterProfileByAccountId: jest.fn(),
     findById: jest.fn(),
     findOwnedByAccountId: jest.fn(),
@@ -50,6 +51,80 @@ describe('TripOfferService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     tripOfferService = new TripOfferService(tripOfferRepository as never);
+  });
+
+  it('searches public trip offers with pagination metadata', async () => {
+    tripOfferRepository.searchPublic.mockResolvedValue({
+      items: [
+        createTripOfferRecord({
+          id: 'trip-offer-search-id',
+          status: TripOfferStatus.PUBLISHED,
+        }),
+      ],
+      total: 11,
+    });
+
+    await expect(
+      tripOfferService.searchPublicTripOffers({
+        origin: ' Buenos Aires ',
+        destination: ' Rosario ',
+        date: new Date('2026-05-01T00:00:00.000Z'),
+        requiredCapacity: 2,
+        page: 2,
+        limit: 5,
+      }),
+    ).resolves.toEqual({
+      items: [
+        {
+          id: 'trip-offer-search-id',
+          originLabel: 'Buenos Aires',
+          destinationLabel: 'Rosario',
+          departureDate: new Date('2026-05-01T00:00:00.000Z'),
+          availableCapacity: 6,
+          pricePerSlot: 120000,
+          cargoType: 'EQUINE',
+          status: 'PUBLISHED',
+        },
+      ],
+      page: 2,
+      limit: 5,
+      total: 11,
+      totalPages: 3,
+    });
+
+    expect(tripOfferRepository.searchPublic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        requiredCapacity: 2,
+        page: 2,
+        limit: 5,
+      }),
+    );
+  });
+
+  it('returns totalPages as 0 when the public search has no results', async () => {
+    tripOfferRepository.searchPublic.mockResolvedValue({
+      items: [],
+      total: 0,
+    });
+
+    await expect(
+      tripOfferService.searchPublicTripOffers({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: new Date('2026-05-01T00:00:00.000Z'),
+        requiredCapacity: 1,
+        page: 1,
+        limit: 10,
+      }),
+    ).resolves.toEqual({
+      items: [],
+      page: 1,
+      limit: 10,
+      total: 0,
+      totalPages: 0,
+    });
   });
 
   it('creates a draft trip offer for the authenticated transporter', async () => {

--- a/apps/api/src/trip-offer/application/trip-offer.service.ts
+++ b/apps/api/src/trip-offer/application/trip-offer.service.ts
@@ -6,10 +6,12 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { TripOfferStatus } from '@logistica/database';
+import type { SearchTripOffersResponseDto } from '../dto/search-trip-offers.response.dto';
 import type { TripOfferResponseDto } from '../dto/trip-offer.response.dto';
 import { TripOfferRepository } from '../repositories/trip-offer.repository';
 import type {
   CreateTripOfferInput,
+  SearchTripOffersQuery,
   TripOfferRecord,
   UpdateTripOfferInput,
 } from '../types/trip-offer.types';
@@ -44,6 +46,26 @@ type TripOfferDraftState = Pick<
 @Injectable()
 export class TripOfferService {
   constructor(private readonly tripOfferRepository: TripOfferRepository) {}
+
+  async searchPublicTripOffers(
+    query: SearchTripOffersQuery,
+  ): Promise<SearchTripOffersResponseDto> {
+    const normalizedQuery = {
+      ...query,
+      origin: query.origin.trim(),
+      destination: query.destination.trim(),
+    };
+    const { items, total } =
+      await this.tripOfferRepository.searchPublic(normalizedQuery);
+
+    return {
+      items: items.map((tripOffer) => this.toPublicSearchItem(tripOffer)),
+      page: normalizedQuery.page,
+      limit: normalizedQuery.limit,
+      total,
+      totalPages: total === 0 ? 0 : Math.ceil(total / normalizedQuery.limit),
+    };
+  }
 
   async listOwnTripOffers(accountId: string): Promise<TripOfferResponseDto[]> {
     await this.getTransporterProfileOrThrow(accountId);
@@ -563,6 +585,19 @@ export class TripOfferService {
       status: this.getEffectiveStatus(tripOffer),
       createdAt: tripOffer.createdAt,
       updatedAt: tripOffer.updatedAt,
+    };
+  }
+
+  private toPublicSearchItem(tripOffer: TripOfferRecord) {
+    return {
+      id: tripOffer.id,
+      originLabel: tripOffer.originLabel,
+      destinationLabel: tripOffer.destinationLabel,
+      departureDate: tripOffer.departureDate,
+      availableCapacity: tripOffer.availableCapacity,
+      pricePerSlot: tripOffer.pricePerSlot,
+      cargoType: tripOffer.cargoType,
+      status: this.getEffectiveStatus(tripOffer),
     };
   }
 }

--- a/apps/api/src/trip-offer/dto/search-trip-offers.dto.ts
+++ b/apps/api/src/trip-offer/dto/search-trip-offers.dto.ts
@@ -1,0 +1,8 @@
+import {
+  TripOfferSearchQuerySchema,
+  type ITripOfferSearchQueryDto,
+} from '@logistica/shared';
+
+export const SearchTripOffersQuerySchema = TripOfferSearchQuerySchema;
+
+export type SearchTripOffersQueryDto = ITripOfferSearchQueryDto;

--- a/apps/api/src/trip-offer/dto/search-trip-offers.response.dto.ts
+++ b/apps/api/src/trip-offer/dto/search-trip-offers.response.dto.ts
@@ -1,0 +1,3 @@
+import type { IPublicTripOfferSearchResponse } from '@logistica/shared';
+
+export type SearchTripOffersResponseDto = IPublicTripOfferSearchResponse;

--- a/apps/api/src/trip-offer/repositories/trip-offer.repository.spec.ts
+++ b/apps/api/src/trip-offer/repositories/trip-offer.repository.spec.ts
@@ -1,0 +1,87 @@
+import { TripOfferStatus } from '@logistica/database';
+import { TripOfferRepository } from './trip-offer.repository';
+
+describe('TripOfferRepository', () => {
+  const prisma = {
+    $transaction: jest.fn(),
+    tripOffer: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+  };
+
+  let tripOfferRepository: TripOfferRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tripOfferRepository = new TripOfferRepository(prisma as never);
+  });
+
+  it('searches only public offers matching capacity and date filters', async () => {
+    prisma.tripOffer.findMany.mockReturnValue('findMany-operation');
+    prisma.tripOffer.count.mockReturnValue('count-operation');
+    prisma.$transaction.mockResolvedValue([[], 0]);
+
+    await tripOfferRepository.searchPublic({
+      origin: 'Buenos Aires',
+      destination: 'Rosario',
+      date: new Date('2026-05-01T15:24:00.000Z'),
+      requiredCapacity: 2,
+      page: 2,
+      limit: 5,
+    });
+
+    expect(prisma.tripOffer.findMany).toHaveBeenCalledWith({
+      where: {
+        status: {
+          in: [TripOfferStatus.PUBLISHED, TripOfferStatus.FULL],
+        },
+        originLabel: {
+          contains: 'Buenos Aires',
+          mode: 'insensitive',
+        },
+        destinationLabel: {
+          contains: 'Rosario',
+          mode: 'insensitive',
+        },
+        availableCapacity: {
+          gte: 2,
+        },
+        departureDate: {
+          gte: new Date('2026-05-01T00:00:00.000Z'),
+          lt: new Date('2026-05-02T00:00:00.000Z'),
+        },
+      },
+      orderBy: [{ departureDate: 'asc' }, { createdAt: 'desc' }],
+      skip: 5,
+      take: 5,
+      select: expect.any(Object),
+    });
+    expect(prisma.tripOffer.count).toHaveBeenCalledWith({
+      where: {
+        status: {
+          in: [TripOfferStatus.PUBLISHED, TripOfferStatus.FULL],
+        },
+        originLabel: {
+          contains: 'Buenos Aires',
+          mode: 'insensitive',
+        },
+        destinationLabel: {
+          contains: 'Rosario',
+          mode: 'insensitive',
+        },
+        availableCapacity: {
+          gte: 2,
+        },
+        departureDate: {
+          gte: new Date('2026-05-01T00:00:00.000Z'),
+          lt: new Date('2026-05-02T00:00:00.000Z'),
+        },
+      },
+    });
+    expect(prisma.$transaction).toHaveBeenCalledWith([
+      'findMany-operation',
+      'count-operation',
+    ]);
+  });
+});

--- a/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
+++ b/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
@@ -2,8 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { Prisma, PrismaService, TripOfferStatus } from '@logistica/database';
 import type {
   CreateTripOfferInput,
+  SearchTripOffersQuery,
   TransporterProfileOwnerRecord,
   TripOfferRecord,
+  TripOfferSearchWhereInput,
   TripOfferUpdateData,
 } from '../types/trip-offer.types';
 import {
@@ -14,6 +16,25 @@ import {
 @Injectable()
 export class TripOfferRepository {
   constructor(private readonly prisma: PrismaService) {}
+
+  async searchPublic(
+    query: SearchTripOffersQuery,
+  ): Promise<{ items: TripOfferRecord[]; total: number }> {
+    const where = this.buildSearchWhere(query);
+
+    const [items, total] = await this.prisma.$transaction([
+      this.prisma.tripOffer.findMany({
+        where,
+        orderBy: [{ departureDate: 'asc' }, { createdAt: 'desc' }],
+        skip: (query.page - 1) * query.limit,
+        take: query.limit,
+        select: tripOfferSelect,
+      }),
+      this.prisma.tripOffer.count({ where }),
+    ]);
+
+    return { items, total };
+  }
 
   async findTransporterProfileByAccountId(
     accountId: string,
@@ -99,5 +120,40 @@ export class TripOfferRepository {
       data: { status },
       select: tripOfferSelect,
     });
+  }
+
+  private buildSearchWhere(
+    query: SearchTripOffersQuery,
+  ): TripOfferSearchWhereInput {
+    const dayStart = new Date(
+      Date.UTC(
+        query.date.getUTCFullYear(),
+        query.date.getUTCMonth(),
+        query.date.getUTCDate(),
+      ),
+    );
+    const nextDayStart = new Date(dayStart);
+    nextDayStart.setUTCDate(nextDayStart.getUTCDate() + 1);
+
+    return {
+      status: {
+        in: [TripOfferStatus.PUBLISHED, TripOfferStatus.FULL],
+      },
+      originLabel: {
+        contains: query.origin,
+        mode: 'insensitive',
+      },
+      destinationLabel: {
+        contains: query.destination,
+        mode: 'insensitive',
+      },
+      availableCapacity: {
+        gte: query.requiredCapacity,
+      },
+      departureDate: {
+        gte: dayStart,
+        lt: nextDayStart,
+      },
+    };
   }
 }

--- a/apps/api/src/trip-offer/trip-offer.controller.spec.ts
+++ b/apps/api/src/trip-offer/trip-offer.controller.spec.ts
@@ -43,6 +43,7 @@ class TestJwtAuthGuard {
 
 describe('TripOfferController', () => {
   const tripOfferService = {
+    searchPublicTripOffers: jest.fn(),
     listOwnTripOffers: jest.fn(),
     createOwnTripOffer: jest.fn(),
     publishOwnTripOffer: jest.fn(),
@@ -121,6 +122,113 @@ describe('TripOfferController', () => {
     expect(tripOfferService.listOwnTripOffers).toHaveBeenCalledWith(
       'transporter-account-id',
     );
+
+    await app.close();
+  });
+
+  it('searches public trip offers with all query params', async () => {
+    tripOfferService.searchPublicTripOffers.mockResolvedValue({
+      items: [
+        {
+          id: 'cm9tripoffer0000wqz5oy7k8ph1',
+          originLabel: 'Buenos Aires',
+          destinationLabel: 'Rosario',
+          departureDate: new Date('2026-05-01T00:00:00.000Z'),
+          availableCapacity: 6,
+          pricePerSlot: 120000,
+          cargoType: 'EQUINE',
+          status: 'PUBLISHED',
+        },
+      ],
+      page: 2,
+      limit: 5,
+      total: 11,
+      totalPages: 3,
+    });
+
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: '2026-05-01',
+        requiredCapacity: '2',
+        page: '2',
+        limit: '5',
+      })
+      .expect(200)
+      .expect({
+        items: [
+          {
+            id: 'cm9tripoffer0000wqz5oy7k8ph1',
+            originLabel: 'Buenos Aires',
+            destinationLabel: 'Rosario',
+            departureDate: '2026-05-01T00:00:00.000Z',
+            availableCapacity: 6,
+            pricePerSlot: 120000,
+            cargoType: 'EQUINE',
+            status: 'PUBLISHED',
+          },
+        ],
+        page: 2,
+        limit: 5,
+        total: 11,
+        totalPages: 3,
+      });
+
+    expect(tripOfferService.searchPublicTripOffers).toHaveBeenCalledWith({
+      origin: 'Buenos Aires',
+      destination: 'Rosario',
+      date: new Date('2026-05-01T00:00:00.000Z'),
+      requiredCapacity: 2,
+      page: 2,
+      limit: 5,
+    });
+
+    await app.close();
+  });
+
+  it('searches public trip offers using pagination defaults', async () => {
+    tripOfferService.searchPublicTripOffers.mockResolvedValue({
+      items: [],
+      page: 1,
+      limit: 10,
+      total: 0,
+      totalPages: 0,
+    });
+
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    const response = await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: '2026-05-01',
+        requiredCapacity: '1',
+      })
+      .expect(200);
+
+    expect(response.body).toEqual({
+      items: [],
+      page: 1,
+      limit: 10,
+      total: 0,
+      totalPages: 0,
+    });
+
+    expect(tripOfferService.searchPublicTripOffers).toHaveBeenCalledWith({
+      origin: 'Buenos Aires',
+      destination: 'Rosario',
+      date: new Date('2026-05-01T00:00:00.000Z'),
+      requiredCapacity: 1,
+      page: 1,
+      limit: 10,
+    });
 
     await app.close();
   });
@@ -474,6 +582,120 @@ describe('TripOfferController', () => {
       .expect(400);
 
     expect(tripOfferService.createOwnTripOffer).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when origin is missing in search', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        destination: 'Rosario',
+        date: '2026-05-01',
+        requiredCapacity: '1',
+      })
+      .expect(400);
+
+    expect(tripOfferService.searchPublicTripOffers).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when destination is missing in search', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        date: '2026-05-01',
+        requiredCapacity: '1',
+      })
+      .expect(400);
+
+    expect(tripOfferService.searchPublicTripOffers).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when the search date is invalid', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: 'not-a-date',
+        requiredCapacity: '1',
+      })
+      .expect(400);
+
+    expect(tripOfferService.searchPublicTripOffers).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when requiredCapacity is not greater than zero', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: '2026-05-01',
+        requiredCapacity: '0',
+      })
+      .expect(400);
+
+    expect(tripOfferService.searchPublicTripOffers).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when page is less than 1 in search', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: '2026-05-01',
+        requiredCapacity: '1',
+        page: '0',
+      })
+      .expect(400);
+
+    expect(tripOfferService.searchPublicTripOffers).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when limit is greater than 20 in search', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: '2026-05-01',
+        requiredCapacity: '1',
+        limit: '21',
+      })
+      .expect(400);
+
+    expect(tripOfferService.searchPublicTripOffers).not.toHaveBeenCalled();
 
     await app.close();
   });

--- a/apps/api/src/trip-offer/trip-offer.controller.ts
+++ b/apps/api/src/trip-offer/trip-offer.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Req,
   UseGuards,
 } from '@nestjs/common';
@@ -20,6 +21,9 @@ import { RolesGuard } from '../identity/authentication/guards/roles.guard';
 import type { AuthenticatedAccount } from '../identity/authentication/types/authentication.types';
 import { TripOfferService } from './application/trip-offer.service';
 import type { CreateTripOfferDto } from './dto/create-trip-offer.dto';
+import type { SearchTripOffersQueryDto } from './dto/search-trip-offers.dto';
+import { SearchTripOffersQuerySchema } from './dto/search-trip-offers.dto';
+import type { SearchTripOffersResponseDto } from './dto/search-trip-offers.response.dto';
 import type {
   TripOfferParamsDto,
   UpdateTripOfferDto,
@@ -34,6 +38,14 @@ interface AuthenticatedHttpRequest {
 @Controller('trip-offers')
 export class TripOfferController {
   constructor(private readonly tripOfferService: TripOfferService) {}
+
+  @Get('search')
+  async searchTripOffers(
+    @Query(new ZodValidationPipe(SearchTripOffersQuerySchema))
+    query: SearchTripOffersQueryDto,
+  ): Promise<SearchTripOffersResponseDto> {
+    return this.tripOfferService.searchPublicTripOffers(query);
+  }
 
   @Get('my')
   @UseGuards(JwtAuthGuard, RolesGuard)

--- a/apps/api/src/trip-offer/types/trip-offer.types.ts
+++ b/apps/api/src/trip-offer/types/trip-offer.types.ts
@@ -1,6 +1,8 @@
 import type { Prisma } from '@logistica/database';
 import type {
   ICreateTripOfferDto,
+  ITripOfferSearchQueryDto,
+  IPublicTripOfferSearchItem,
   IUpdateTripOfferDto,
 } from '@logistica/shared';
 
@@ -35,6 +37,8 @@ export const transporterProfileOwnerSelect = {
 
 export type CreateTripOfferInput = ICreateTripOfferDto;
 export type UpdateTripOfferInput = IUpdateTripOfferDto;
+export type SearchTripOffersQuery = ITripOfferSearchQueryDto;
+export type PublicTripOfferSearchItem = IPublicTripOfferSearchItem;
 export type TripOfferRecord = Prisma.TripOfferGetPayload<{
   select: typeof tripOfferSelect;
 }>;
@@ -44,3 +48,4 @@ export type TransporterProfileOwnerRecord =
   }>;
 export type TripOfferCreateData = Prisma.TripOfferCreateInput;
 export type TripOfferUpdateData = Prisma.TripOfferUpdateInput;
+export type TripOfferSearchWhereInput = Prisma.TripOfferWhereInput;

--- a/packages/shared/src/interfaces/interfaces.ts
+++ b/packages/shared/src/interfaces/interfaces.ts
@@ -17,6 +17,9 @@ import {
 } from '../schemas/trailer.schema';
 import {
   CreateTripOfferSchema,
+  PublicTripOfferSearchItemSchema,
+  PublicTripOfferSearchResponseSchema,
+  TripOfferSearchQuerySchema,
   TripOfferParamsSchema,
   TripOfferViewSchema,
   UpdateTripOfferSchema,
@@ -136,8 +139,24 @@ export type IUpdateTripOfferDto = z.infer<typeof UpdateTripOfferDtoSchema>;
 export const TripOfferParamsDtoSchema = TripOfferParamsSchema;
 export type ITripOfferParamsDto = z.infer<typeof TripOfferParamsDtoSchema>;
 
+export const TripOfferSearchQueryDtoSchema = TripOfferSearchQuerySchema;
+export type ITripOfferSearchQueryDto = z.infer<
+  typeof TripOfferSearchQueryDtoSchema
+>;
+
 export const TripOfferViewDtoSchema = TripOfferViewSchema;
 export type ITripOfferView = z.infer<typeof TripOfferViewDtoSchema>;
+
+export const PublicTripOfferSearchItemDtoSchema = PublicTripOfferSearchItemSchema;
+export type IPublicTripOfferSearchItem = z.infer<
+  typeof PublicTripOfferSearchItemDtoSchema
+>;
+
+export const PublicTripOfferSearchResponseDtoSchema =
+  PublicTripOfferSearchResponseSchema;
+export type IPublicTripOfferSearchResponse = z.infer<
+  typeof PublicTripOfferSearchResponseDtoSchema
+>;
 
 export const AuthProfileViewSchema = z
   .union([UserProfileViewSchema, TransporterProfileViewSchema])

--- a/packages/shared/src/schemas/trip-offer.schema.ts
+++ b/packages/shared/src/schemas/trip-offer.schema.ts
@@ -46,6 +46,11 @@ const positiveIntegerSchema = z
   .int('El valor debe ser un numero entero.')
   .positive('El valor debe ser mayor a cero.');
 
+const positiveIntegerQuerySchema = z.coerce
+  .number()
+  .int('El valor debe ser un numero entero.')
+  .positive('El valor debe ser mayor a cero.');
+
 const nonNegativeIntegerSchema = z
   .number()
   .int('El valor debe ser un numero entero.')
@@ -186,6 +191,35 @@ export const TripOfferParamsSchema = z.object({
   id: cuidSchema,
 });
 
+export const TripOfferSearchQuerySchema = z
+  .object({
+    origin: requiredTrimmedTextSchema(
+      160,
+      'Ingresa el origen de la busqueda.',
+    ),
+    destination: requiredTrimmedTextSchema(
+      160,
+      'Ingresa el destino de la busqueda.',
+    ),
+    date: z.coerce.date({
+      required_error: 'Ingresa la fecha de la busqueda.',
+      invalid_type_error: 'Ingresa una fecha valida.',
+    }),
+    requiredCapacity: positiveIntegerQuerySchema,
+    page: positiveIntegerQuerySchema.default(1),
+    limit: positiveIntegerQuerySchema.default(10),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.limit > 20) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'El limite no puede ser mayor a 20.',
+        path: ['limit'],
+      });
+    }
+  });
+
 export const TripOfferViewSchema = z.object({
   id: cuidSchema,
   originLabel: z.string().trim().min(1).max(160),
@@ -210,7 +244,33 @@ export const TripOfferViewSchema = z.object({
   updatedAt: z.date(),
 });
 
+export const PublicTripOfferSearchItemSchema = z.object({
+  id: cuidSchema,
+  originLabel: z.string().trim().min(1).max(160),
+  destinationLabel: z.string().trim().min(1).max(160),
+  departureDate: z.date().nullable(),
+  availableCapacity: z.number().int().min(0),
+  pricePerSlot: z.number().int().min(0),
+  cargoType: CargoTypeSchema,
+  status: tripOfferStatusSchema,
+});
+
+export const PublicTripOfferSearchResponseSchema = z.object({
+  items: z.array(PublicTripOfferSearchItemSchema),
+  page: z.number().int().positive(),
+  limit: z.number().int().positive().max(20),
+  total: z.number().int().min(0),
+  totalPages: z.number().int().min(0),
+});
+
 export type CreateTripOfferDto = z.infer<typeof CreateTripOfferSchema>;
 export type UpdateTripOfferDto = z.infer<typeof UpdateTripOfferSchema>;
 export type TripOfferParamsDto = z.infer<typeof TripOfferParamsSchema>;
+export type TripOfferSearchQueryDto = z.infer<typeof TripOfferSearchQuerySchema>;
 export type TripOfferView = z.infer<typeof TripOfferViewSchema>;
+export type PublicTripOfferSearchItem = z.infer<
+  typeof PublicTripOfferSearchItemSchema
+>;
+export type PublicTripOfferSearchResponse = z.infer<
+  typeof PublicTripOfferSearchResponseSchema
+>;


### PR DESCRIPTION
## Summary

- Lane: `backend-e5` | `shared-support`
- Scope: agrega el endpoint publico `GET /trip-offers/search` para buscar ofertas por origen, destino, fecha y capacidad requerida
- Scope: incorpora contratos shared para query/response y cobertura de tests en controller, service y repository

## Why

Este cambio habilita el flujo de exploracion de ofertas desde cliente sobre una API real. La busqueda queda validada con Zod, responde con metadata de paginacion y restringe los resultados a ofertas publicas con capacidad suficiente.

## Acceptance Criteria

- [x] Existe el endpoint publico de busqueda de ofertas
- [x] La query valida `origin`, `destination`, `date`, `requiredCapacity`, `page` y `limit`
- [x] La respuesta devuelve `items`, `page`, `limit`, `total` y `totalPages`
- [x] La busqueda filtra solo ofertas publicas con capacidad disponible suficiente

## Validation

- [x] `pnpm --filter @logistica/api test`
- [x] `pnpm --filter @logistica/api build`
- [ ] Validacion manual realizada

## Risks

- None

## Screenshots / Evidence

- Endpoint agregado: `GET /trip-offers/search`
- Contratos nuevos: `TripOfferSearchQuerySchema` y `PublicTripOfferSearchResponseSchema`

## Handoff Notes

- Next ready issue: UI de busqueda y resultados para cliente
- Contract changes: nuevo contrato shared para query y response de busqueda publica de ofertas
- Protected zones touched: None

## Checklist

- [x] Un solo proposito claro
- [x] No toca zonas protegidas sin aprobacion explicita
- [x] Incluye manejo razonable de errores si aplica
- [x] `.env.example` actualizado si se agregaron variables
- [x] Documentacion actualizada si cambia comportamiento importante
- [x] PR chico y revisable
