### PR TITLE
feat: aplicar criterios base de elegibilidad en busqueda publica de ofertas

### DIFF
--- a/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
+++ b/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
@@ -127,6 +127,89 @@ describe('TripOfferService', () => {
     });
   });
 
+  it('keeps public search results limited to published offers with enough capacity', async () => {
+    tripOfferRepository.searchPublic.mockResolvedValue({
+      items: [
+        createTripOfferRecord({
+          id: 'published-eligible-offer',
+          status: TripOfferStatus.PUBLISHED,
+          availableCapacity: 4,
+        }),
+      ],
+      total: 1,
+    });
+
+    await expect(
+      tripOfferService.searchPublicTripOffers({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: new Date('2026-05-01T00:00:00.000Z'),
+        requiredCapacity: 4,
+        page: 1,
+        limit: 10,
+      }),
+    ).resolves.toEqual({
+      items: [
+        {
+          id: 'published-eligible-offer',
+          originLabel: 'Buenos Aires',
+          destinationLabel: 'Rosario',
+          departureDate: new Date('2026-05-01T00:00:00.000Z'),
+          availableCapacity: 4,
+          pricePerSlot: 120000,
+          cargoType: 'EQUINE',
+          status: 'PUBLISHED',
+        },
+      ],
+      page: 1,
+      limit: 10,
+      total: 1,
+      totalPages: 1,
+    });
+
+    expect(tripOfferRepository.searchPublic).toHaveBeenCalledWith({
+      origin: 'Buenos Aires',
+      destination: 'Rosario',
+      date: new Date('2026-05-01T00:00:00.000Z'),
+      requiredCapacity: 4,
+      page: 1,
+      limit: 10,
+    });
+  });
+
+  it('returns no public search results when no offer matches origin, destination, date, and required capacity together', async () => {
+    tripOfferRepository.searchPublic.mockResolvedValue({
+      items: [],
+      total: 0,
+    });
+
+    await expect(
+      tripOfferService.searchPublicTripOffers({
+        origin: 'Mendoza',
+        destination: 'Rosario',
+        date: new Date('2026-05-01T00:00:00.000Z'),
+        requiredCapacity: 3,
+        page: 3,
+        limit: 2,
+      }),
+    ).resolves.toEqual({
+      items: [],
+      page: 3,
+      limit: 2,
+      total: 0,
+      totalPages: 0,
+    });
+
+    expect(tripOfferRepository.searchPublic).toHaveBeenCalledWith({
+      origin: 'Mendoza',
+      destination: 'Rosario',
+      date: new Date('2026-05-01T00:00:00.000Z'),
+      requiredCapacity: 3,
+      page: 3,
+      limit: 2,
+    });
+  });
+
   it('creates a draft trip offer for the authenticated transporter', async () => {
     const createdAt = new Date('2026-04-21T10:00:00.000Z');
     const updatedAt = new Date('2026-04-21T10:00:00.000Z');

--- a/apps/api/src/trip-offer/repositories/trip-offer.repository.spec.ts
+++ b/apps/api/src/trip-offer/repositories/trip-offer.repository.spec.ts
@@ -17,7 +17,7 @@ describe('TripOfferRepository', () => {
     tripOfferRepository = new TripOfferRepository(prisma as never);
   });
 
-  it('searches only public offers matching capacity and date filters', async () => {
+  it('searches only published offers matching origin, destination, capacity, and date filters', async () => {
     prisma.tripOffer.findMany.mockReturnValue('findMany-operation');
     prisma.tripOffer.count.mockReturnValue('count-operation');
     prisma.$transaction.mockResolvedValue([[], 0]);
@@ -33,9 +33,7 @@ describe('TripOfferRepository', () => {
 
     expect(prisma.tripOffer.findMany).toHaveBeenCalledWith({
       where: {
-        status: {
-          in: [TripOfferStatus.PUBLISHED, TripOfferStatus.FULL],
-        },
+        status: TripOfferStatus.PUBLISHED,
         originLabel: {
           contains: 'Buenos Aires',
           mode: 'insensitive',
@@ -59,9 +57,7 @@ describe('TripOfferRepository', () => {
     });
     expect(prisma.tripOffer.count).toHaveBeenCalledWith({
       where: {
-        status: {
-          in: [TripOfferStatus.PUBLISHED, TripOfferStatus.FULL],
-        },
+        status: TripOfferStatus.PUBLISHED,
         originLabel: {
           contains: 'Buenos Aires',
           mode: 'insensitive',

--- a/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
+++ b/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
@@ -136,9 +136,7 @@ export class TripOfferRepository {
     nextDayStart.setUTCDate(nextDayStart.getUTCDate() + 1);
 
     return {
-      status: {
-        in: [TripOfferStatus.PUBLISHED, TripOfferStatus.FULL],
-      },
+      status: TripOfferStatus.PUBLISHED,
       originLabel: {
         contains: query.origin,
         mode: 'insensitive',


### PR DESCRIPTION
## Contexto
Aplica la elegibilidad base del MVP sobre GET /trip-offers/search para que la busqueda publica devuelva solo ofertas viables.

## Cambios
- limita la busqueda publica a ofertas en estado PUBLISHED
- mantiene el filtro backend por vailableCapacity >= requiredCapacity
- conserva el matching por origin, destination y date dentro de la query de Prisma
- preserva el contrato de respuesta y la paginacion existente
- amplia tests de repository y service para cubrir elegibilidad y metadatos de paginacion

## Validacion
- pnpm --filter @logistica/api test -- trip-offer

## Riesgos revisados
- no se filtra en memoria; la elegibilidad queda en la query
- no se cambia el contrato del endpoint
- la comparacion de fecha sigue alineada con Prisma