### PR TITLE
feat(trip-offer): add public search filters

### DIFF
--- a/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
+++ b/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
@@ -103,6 +103,39 @@ describe('TripOfferService', () => {
     );
   });
 
+  it('forwards optional public search filters to the repository', async () => {
+    tripOfferRepository.searchPublic.mockResolvedValue({
+      items: [],
+      total: 0,
+    });
+
+    await tripOfferService.searchPublicTripOffers({
+      origin: ' Buenos Aires ',
+      destination: ' Rosario ',
+      date: new Date('2026-05-01T00:00:00.000Z'),
+      requiredCapacity: 2,
+      minPrice: 100000,
+      maxPrice: 150000,
+      verifiedOnly: true,
+      maxDetourKm: 80,
+      page: 1,
+      limit: 10,
+    });
+
+    expect(tripOfferRepository.searchPublic).toHaveBeenCalledWith({
+      origin: 'Buenos Aires',
+      destination: 'Rosario',
+      date: new Date('2026-05-01T00:00:00.000Z'),
+      requiredCapacity: 2,
+      minPrice: 100000,
+      maxPrice: 150000,
+      verifiedOnly: true,
+      maxDetourKm: 80,
+      page: 1,
+      limit: 10,
+    });
+  });
+
   it('returns totalPages as 0 when the public search has no results', async () => {
     tripOfferRepository.searchPublic.mockResolvedValue({
       items: [],

--- a/apps/api/src/trip-offer/repositories/trip-offer.repository.spec.ts
+++ b/apps/api/src/trip-offer/repositories/trip-offer.repository.spec.ts
@@ -1,4 +1,7 @@
-import { TripOfferStatus } from '@logistica/database';
+import {
+  TripOfferStatus,
+  TransporterVerificationStatus,
+} from '@logistica/database';
 import { TripOfferRepository } from './trip-offer.repository';
 
 describe('TripOfferRepository', () => {
@@ -31,30 +34,31 @@ describe('TripOfferRepository', () => {
       limit: 5,
     });
 
-    expect(prisma.tripOffer.findMany).toHaveBeenCalledWith({
-      where: {
-        status: TripOfferStatus.PUBLISHED,
-        originLabel: {
-          contains: 'Buenos Aires',
-          mode: 'insensitive',
+    expect(prisma.tripOffer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          status: TripOfferStatus.PUBLISHED,
+          originLabel: {
+            contains: 'Buenos Aires',
+            mode: 'insensitive',
+          },
+          destinationLabel: {
+            contains: 'Rosario',
+            mode: 'insensitive',
+          },
+          availableCapacity: {
+            gte: 2,
+          },
+          departureDate: {
+            gte: new Date('2026-05-01T00:00:00.000Z'),
+            lt: new Date('2026-05-02T00:00:00.000Z'),
+          },
         },
-        destinationLabel: {
-          contains: 'Rosario',
-          mode: 'insensitive',
-        },
-        availableCapacity: {
-          gte: 2,
-        },
-        departureDate: {
-          gte: new Date('2026-05-01T00:00:00.000Z'),
-          lt: new Date('2026-05-02T00:00:00.000Z'),
-        },
-      },
-      orderBy: [{ departureDate: 'asc' }, { createdAt: 'desc' }],
-      skip: 5,
-      take: 5,
-      select: expect.any(Object),
-    });
+        orderBy: [{ departureDate: 'asc' }, { createdAt: 'desc' }],
+        skip: 5,
+        take: 5,
+      }),
+    );
     expect(prisma.tripOffer.count).toHaveBeenCalledWith({
       where: {
         status: TripOfferStatus.PUBLISHED,
@@ -79,5 +83,90 @@ describe('TripOfferRepository', () => {
       'findMany-operation',
       'count-operation',
     ]);
+  });
+
+  it('applies price, verification, and detour filters before pagination', async () => {
+    prisma.tripOffer.findMany.mockReturnValue('findMany-operation');
+    prisma.tripOffer.count.mockReturnValue('count-operation');
+    prisma.$transaction.mockResolvedValue([[], 0]);
+
+    await tripOfferRepository.searchPublic({
+      origin: 'Buenos Aires',
+      destination: 'Rosario',
+      date: new Date('2026-05-01T15:24:00.000Z'),
+      requiredCapacity: 2,
+      minPrice: 100000,
+      maxPrice: 150000,
+      verifiedOnly: true,
+      maxDetourKm: 80,
+      page: 1,
+      limit: 10,
+    });
+
+    expect(prisma.tripOffer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          status: TripOfferStatus.PUBLISHED,
+          originLabel: {
+            contains: 'Buenos Aires',
+            mode: 'insensitive',
+          },
+          destinationLabel: {
+            contains: 'Rosario',
+            mode: 'insensitive',
+          },
+          availableCapacity: {
+            gte: 2,
+          },
+          pricePerSlot: {
+            gte: 100000,
+            lte: 150000,
+          },
+          transporterProfile: {
+            verificationStatus: TransporterVerificationStatus.VERIFIED,
+          },
+          maxDetourKm: {
+            lte: 80,
+          },
+          departureDate: {
+            gte: new Date('2026-05-01T00:00:00.000Z'),
+            lt: new Date('2026-05-02T00:00:00.000Z'),
+          },
+        },
+        orderBy: [{ departureDate: 'asc' }, { createdAt: 'desc' }],
+        skip: 0,
+        take: 10,
+      }),
+    );
+    expect(prisma.tripOffer.count).toHaveBeenCalledWith({
+      where: {
+        status: TripOfferStatus.PUBLISHED,
+        originLabel: {
+          contains: 'Buenos Aires',
+          mode: 'insensitive',
+        },
+        destinationLabel: {
+          contains: 'Rosario',
+          mode: 'insensitive',
+        },
+        availableCapacity: {
+          gte: 2,
+        },
+        pricePerSlot: {
+          gte: 100000,
+          lte: 150000,
+        },
+        transporterProfile: {
+          verificationStatus: TransporterVerificationStatus.VERIFIED,
+        },
+        maxDetourKm: {
+          lte: 80,
+        },
+        departureDate: {
+          gte: new Date('2026-05-01T00:00:00.000Z'),
+          lt: new Date('2026-05-02T00:00:00.000Z'),
+        },
+      },
+    });
   });
 });

--- a/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
+++ b/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
@@ -1,5 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { Prisma, PrismaService, TripOfferStatus } from '@logistica/database';
+import {
+  Prisma,
+  PrismaService,
+  TripOfferStatus,
+  TransporterVerificationStatus,
+} from '@logistica/database';
 import type {
   CreateTripOfferInput,
   SearchTripOffersQuery,
@@ -148,6 +153,35 @@ export class TripOfferRepository {
       availableCapacity: {
         gte: query.requiredCapacity,
       },
+      ...(query.minPrice !== undefined
+        ? {
+            pricePerSlot: {
+              gte: query.minPrice,
+            },
+          }
+        : {}),
+      ...(query.maxPrice !== undefined
+        ? {
+            pricePerSlot: {
+              ...(query.minPrice !== undefined ? { gte: query.minPrice } : {}),
+              lte: query.maxPrice,
+            },
+          }
+        : {}),
+      ...(query.verifiedOnly === true
+        ? {
+            transporterProfile: {
+              verificationStatus: TransporterVerificationStatus.VERIFIED,
+            },
+          }
+        : {}),
+      ...(query.maxDetourKm !== undefined
+        ? {
+            maxDetourKm: {
+              lte: query.maxDetourKm,
+            },
+          }
+        : {}),
       departureDate: {
         gte: dayStart,
         lt: nextDayStart,

--- a/apps/api/src/trip-offer/trip-offer.controller.spec.ts
+++ b/apps/api/src/trip-offer/trip-offer.controller.spec.ts
@@ -156,6 +156,10 @@ describe('TripOfferController', () => {
         destination: 'Rosario',
         date: '2026-05-01',
         requiredCapacity: '2',
+        minPrice: '100000',
+        maxPrice: '150000',
+        verifiedOnly: 'true',
+        maxDetourKm: '80',
         page: '2',
         limit: '5',
       })
@@ -184,6 +188,10 @@ describe('TripOfferController', () => {
       destination: 'Rosario',
       date: new Date('2026-05-01T00:00:00.000Z'),
       requiredCapacity: 2,
+      minPrice: 100000,
+      maxPrice: 150000,
+      verifiedOnly: true,
+      maxDetourKm: 80,
       page: 2,
       limit: 5,
     });
@@ -692,6 +700,107 @@ describe('TripOfferController', () => {
         date: '2026-05-01',
         requiredCapacity: '1',
         limit: '21',
+      })
+      .expect(400);
+
+    expect(tripOfferService.searchPublicTripOffers).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when minPrice is invalid in search', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: '2026-05-01',
+        requiredCapacity: '1',
+        minPrice: '-1',
+      })
+      .expect(400);
+
+    expect(tripOfferService.searchPublicTripOffers).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when maxPrice is invalid in search', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: '2026-05-01',
+        requiredCapacity: '1',
+        maxPrice: '-1',
+      })
+      .expect(400);
+
+    expect(tripOfferService.searchPublicTripOffers).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when maxDetourKm is invalid in search', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: '2026-05-01',
+        requiredCapacity: '1',
+        maxDetourKm: '-1',
+      })
+      .expect(400);
+
+    expect(tripOfferService.searchPublicTripOffers).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when minPrice is greater than maxPrice in search', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: '2026-05-01',
+        requiredCapacity: '1',
+        minPrice: '200000',
+        maxPrice: '100000',
+      })
+      .expect(400);
+
+    expect(tripOfferService.searchPublicTripOffers).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when verifiedOnly is not a strict boolean in search', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: '2026-05-01',
+        requiredCapacity: '1',
+        verifiedOnly: '1',
       })
       .expect(400);
 

--- a/packages/shared/src/schemas/trip-offer.schema.ts
+++ b/packages/shared/src/schemas/trip-offer.schema.ts
@@ -51,10 +51,31 @@ const positiveIntegerQuerySchema = z.coerce
   .int('El valor debe ser un numero entero.')
   .positive('El valor debe ser mayor a cero.');
 
+const nonNegativeIntegerQuerySchema = z.coerce
+  .number()
+  .int('El valor debe ser un numero entero.')
+  .min(0, 'El valor no puede ser negativo.');
+
 const nonNegativeIntegerSchema = z
   .number()
   .int('El valor debe ser un numero entero.')
   .min(0, 'El valor no puede ser negativo.');
+
+const optionalStrictBooleanQuerySchema = z.preprocess((value) => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === 'true') {
+    return true;
+  }
+
+  if (value === 'false') {
+    return false;
+  }
+
+  return value;
+}, z.boolean().optional());
 
 type TemporalFields = {
   departureDate?: Date | null;
@@ -193,10 +214,7 @@ export const TripOfferParamsSchema = z.object({
 
 export const TripOfferSearchQuerySchema = z
   .object({
-    origin: requiredTrimmedTextSchema(
-      160,
-      'Ingresa el origen de la busqueda.',
-    ),
+    origin: requiredTrimmedTextSchema(160, 'Ingresa el origen de la busqueda.'),
     destination: requiredTrimmedTextSchema(
       160,
       'Ingresa el destino de la busqueda.',
@@ -206,6 +224,10 @@ export const TripOfferSearchQuerySchema = z
       invalid_type_error: 'Ingresa una fecha valida.',
     }),
     requiredCapacity: positiveIntegerQuerySchema,
+    minPrice: nonNegativeIntegerQuerySchema.optional(),
+    maxPrice: nonNegativeIntegerQuerySchema.optional(),
+    verifiedOnly: optionalStrictBooleanQuerySchema,
+    maxDetourKm: nonNegativeIntegerQuerySchema.optional(),
     page: positiveIntegerQuerySchema.default(1),
     limit: positiveIntegerQuerySchema.default(10),
   })
@@ -216,6 +238,18 @@ export const TripOfferSearchQuerySchema = z
         code: z.ZodIssueCode.custom,
         message: 'El limite no puede ser mayor a 20.',
         path: ['limit'],
+      });
+    }
+
+    if (
+      value.minPrice !== undefined &&
+      value.maxPrice !== undefined &&
+      value.minPrice > value.maxPrice
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'minPrice no puede ser mayor que maxPrice.',
+        path: ['minPrice'],
       });
     }
   });
@@ -266,7 +300,9 @@ export const PublicTripOfferSearchResponseSchema = z.object({
 export type CreateTripOfferDto = z.infer<typeof CreateTripOfferSchema>;
 export type UpdateTripOfferDto = z.infer<typeof UpdateTripOfferSchema>;
 export type TripOfferParamsDto = z.infer<typeof TripOfferParamsSchema>;
-export type TripOfferSearchQueryDto = z.infer<typeof TripOfferSearchQuerySchema>;
+export type TripOfferSearchQueryDto = z.infer<
+  typeof TripOfferSearchQuerySchema
+>;
 export type TripOfferView = z.infer<typeof TripOfferViewSchema>;
 export type PublicTripOfferSearchItem = z.infer<
   typeof PublicTripOfferSearchItemSchema


### PR DESCRIPTION
## Summary

- Extiende GET /trip-offers/search con filtros opcionales minPrice, maxPrice, erifiedOnly y maxDetourKm
- Mantiene el contrato actual de respuesta y la paginacion existente
- Aplica los filtros en backend junto con la elegibilidad base ya implementada

## Why

La busqueda publica ya resolvia elegibilidad basica por estado, capacidad, origen, destino y fecha, pero faltaban criterios de refinamiento clave para el MVP. Esta PR agrega filtros de precio, verificacion del transportista y desvio maximo sin romper el endpoint actual y dejando la consulta preparada para sumar ordenamiento en una siguiente issue.

## Acceptance Criteria

- [x] El filtro de precio funciona correctamente
- [x] El filtro de verificacion funciona correctamente
- [x] El filtro de desvio funciona correctamente
- [x] Los filtros pueden combinarse sin romper la busqueda
- [x] La busqueda sigue devolviendo solo ofertas viables segun las reglas base ya implementadas
- [x] La paginacion sigue funcionando correctamente al aplicar filtros
- [x] Los nuevos query params quedan validados server-side
- [x] No se rompe compatibilidad con el contrato actual del endpoint
- [x] Los filtros se aplican en backend y no en frontend
- [x] No se duplica logica entre service y repository
- [x] La implementacion queda preparada para sumar ordenamiento en la siguiente issue

## Validation

- [x] pnpm --filter @logistica/api lint
- [x] pnpm --filter @logistica/api typecheck
- [x] Jest directo sobre:
  - pps/api/src/trip-offer/repositories/trip-offer.repository.spec.ts
  - pps/api/src/trip-offer/application/trip-offer.service.spec.ts
  - pps/api/src/trip-offer/trip-offer.controller.spec.ts
- [x] 56 tests OK en esas 3 suites

## Risks

- La semantica elegida para maxDetourKm excluye ofertas con TripOffer.maxDetourKm = null cuando el cliente informa ese filtro
- erifiedOnly=false se interpreta como no aplicar filtro de verificacion
- No agrega todavia ordenamiento por precio o cercania; solo deja la base de filtrado lista

## Screenshots / Evidence

- No aplica; cambio backend-only

## Handoff Notes

- Next ready issue: ordenamiento de resultados sobre la busqueda publica
- Contract changes: se agregan query params opcionales minPrice, maxPrice, erifiedOnly y maxDetourKm sin cambiar la respuesta
- Protected zones touched: none
- Scope: schema compartido + controller/service/repository/specs de 	rip-offer; sin cambios en frontend ni detalle publico de oferta