### PR TITLE
feat(trip-offer): add public search sorting

### DIFF
--- a/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
+++ b/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
@@ -136,6 +136,52 @@ describe('TripOfferService', () => {
     });
   });
 
+  it('forwards public search sorting to the repository', async () => {
+    tripOfferRepository.searchPublic.mockResolvedValue({
+      items: [],
+      total: 0,
+    });
+
+    await tripOfferService.searchPublicTripOffers({
+      origin: ' Buenos Aires ',
+      destination: ' Rosario ',
+      date: new Date('2026-05-01T00:00:00.000Z'),
+      requiredCapacity: 2,
+      sortBy: 'price',
+      sortOrder: 'asc',
+      page: 1,
+      limit: 10,
+    });
+
+    expect(tripOfferRepository.searchPublic).toHaveBeenCalledWith({
+      origin: 'Buenos Aires',
+      destination: 'Rosario',
+      date: new Date('2026-05-01T00:00:00.000Z'),
+      requiredCapacity: 2,
+      sortBy: 'price',
+      sortOrder: 'asc',
+      page: 1,
+      limit: 10,
+    });
+  });
+
+  it('throws when sortOrder is sent for a non-price sort', async () => {
+    await expect(
+      tripOfferService.searchPublicTripOffers({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: new Date('2026-05-01T00:00:00.000Z'),
+        requiredCapacity: 2,
+        sortBy: 'rating',
+        sortOrder: 'desc',
+        page: 1,
+        limit: 10,
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(tripOfferRepository.searchPublic).not.toHaveBeenCalled();
+  });
+
   it('returns totalPages as 0 when the public search has no results', async () => {
     tripOfferRepository.searchPublic.mockResolvedValue({
       items: [],

--- a/apps/api/src/trip-offer/application/trip-offer.service.ts
+++ b/apps/api/src/trip-offer/application/trip-offer.service.ts
@@ -50,6 +50,8 @@ export class TripOfferService {
   async searchPublicTripOffers(
     query: SearchTripOffersQuery,
   ): Promise<SearchTripOffersResponseDto> {
+    this.validateSearchSort(query);
+
     const normalizedQuery = {
       ...query,
       origin: query.origin.trim(),
@@ -65,6 +67,14 @@ export class TripOfferService {
       total,
       totalPages: total === 0 ? 0 : Math.ceil(total / normalizedQuery.limit),
     };
+  }
+
+  private validateSearchSort(query: SearchTripOffersQuery): void {
+    if (query.sortOrder !== undefined && query.sortBy !== 'price') {
+      throw new BadRequestException(
+        'sortOrder is only supported when sortBy=price.',
+      );
+    }
   }
 
   async listOwnTripOffers(accountId: string): Promise<TripOfferResponseDto[]> {

--- a/apps/api/src/trip-offer/repositories/trip-offer.repository.spec.ts
+++ b/apps/api/src/trip-offer/repositories/trip-offer.repository.spec.ts
@@ -54,7 +54,7 @@ describe('TripOfferRepository', () => {
             lt: new Date('2026-05-02T00:00:00.000Z'),
           },
         },
-        orderBy: [{ departureDate: 'asc' }, { createdAt: 'desc' }],
+        orderBy: [{ departureDate: 'asc' }, { createdAt: 'desc' }, { id: 'asc' }],
         skip: 5,
         take: 5,
       }),
@@ -133,7 +133,7 @@ describe('TripOfferRepository', () => {
             lt: new Date('2026-05-02T00:00:00.000Z'),
           },
         },
-        orderBy: [{ departureDate: 'asc' }, { createdAt: 'desc' }],
+        orderBy: [{ departureDate: 'asc' }, { createdAt: 'desc' }, { id: 'asc' }],
         skip: 0,
         take: 10,
       }),
@@ -168,5 +168,80 @@ describe('TripOfferRepository', () => {
         },
       },
     });
+  });
+
+  it('orders public search results by price using the requested sort order', async () => {
+    prisma.tripOffer.findMany.mockReturnValue('findMany-operation');
+    prisma.tripOffer.count.mockReturnValue('count-operation');
+    prisma.$transaction.mockResolvedValue([[], 0]);
+
+    await tripOfferRepository.searchPublic({
+      origin: 'Buenos Aires',
+      destination: 'Rosario',
+      date: new Date('2026-05-01T15:24:00.000Z'),
+      requiredCapacity: 2,
+      sortBy: 'price',
+      sortOrder: 'desc',
+      page: 1,
+      limit: 10,
+    });
+
+    expect(prisma.tripOffer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [
+          { pricePerSlot: 'desc' },
+          { departureDate: 'asc' },
+          { id: 'asc' },
+        ],
+      }),
+    );
+  });
+
+  it('orders public search results by proximity using maxDetourKm as the current approximation', async () => {
+    prisma.tripOffer.findMany.mockReturnValue('findMany-operation');
+    prisma.tripOffer.count.mockReturnValue('count-operation');
+    prisma.$transaction.mockResolvedValue([[], 0]);
+
+    await tripOfferRepository.searchPublic({
+      origin: 'Buenos Aires',
+      destination: 'Rosario',
+      date: new Date('2026-05-01T15:24:00.000Z'),
+      requiredCapacity: 2,
+      sortBy: 'proximity',
+      page: 1,
+      limit: 10,
+    });
+
+    expect(prisma.tripOffer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [
+          { maxDetourKm: 'asc' },
+          { departureDate: 'asc' },
+          { id: 'asc' },
+        ],
+      }),
+    );
+  });
+
+  it('orders public search results by rating using the stable fallback while no aggregate rating exists', async () => {
+    prisma.tripOffer.findMany.mockReturnValue('findMany-operation');
+    prisma.tripOffer.count.mockReturnValue('count-operation');
+    prisma.$transaction.mockResolvedValue([[], 0]);
+
+    await tripOfferRepository.searchPublic({
+      origin: 'Buenos Aires',
+      destination: 'Rosario',
+      date: new Date('2026-05-01T15:24:00.000Z'),
+      requiredCapacity: 2,
+      sortBy: 'rating',
+      page: 1,
+      limit: 10,
+    });
+
+    expect(prisma.tripOffer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ departureDate: 'asc' }, { id: 'asc' }],
+      }),
+    );
   });
 });

--- a/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
+++ b/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
@@ -7,6 +7,7 @@ import {
 } from '@logistica/database';
 import type {
   CreateTripOfferInput,
+  TripOfferSearchOrderBy,
   SearchTripOffersQuery,
   TransporterProfileOwnerRecord,
   TripOfferRecord,
@@ -26,11 +27,12 @@ export class TripOfferRepository {
     query: SearchTripOffersQuery,
   ): Promise<{ items: TripOfferRecord[]; total: number }> {
     const where = this.buildSearchWhere(query);
+    const orderBy = this.buildSearchOrderBy(query);
 
     const [items, total] = await this.prisma.$transaction([
       this.prisma.tripOffer.findMany({
         where,
-        orderBy: [{ departureDate: 'asc' }, { createdAt: 'desc' }],
+        orderBy,
         skip: (query.page - 1) * query.limit,
         take: query.limit,
         select: tripOfferSelect,
@@ -187,5 +189,27 @@ export class TripOfferRepository {
         lt: nextDayStart,
       },
     };
+  }
+
+  private buildSearchOrderBy(
+    query: SearchTripOffersQuery,
+  ): TripOfferSearchOrderBy {
+    if (query.sortBy === 'price') {
+      return [
+        { pricePerSlot: query.sortOrder ?? 'asc' },
+        { departureDate: 'asc' },
+        { id: 'asc' },
+      ];
+    }
+
+    if (query.sortBy === 'proximity') {
+      return [{ maxDetourKm: 'asc' }, { departureDate: 'asc' }, { id: 'asc' }];
+    }
+
+    if (query.sortBy === 'rating') {
+      return [{ departureDate: 'asc' }, { id: 'asc' }];
+    }
+
+    return [{ departureDate: 'asc' }, { createdAt: 'desc' }, { id: 'asc' }];
   }
 }

--- a/apps/api/src/trip-offer/trip-offer.controller.spec.ts
+++ b/apps/api/src/trip-offer/trip-offer.controller.spec.ts
@@ -160,6 +160,8 @@ describe('TripOfferController', () => {
         maxPrice: '150000',
         verifiedOnly: 'true',
         maxDetourKm: '80',
+        sortBy: 'price',
+        sortOrder: 'desc',
         page: '2',
         limit: '5',
       })
@@ -192,6 +194,8 @@ describe('TripOfferController', () => {
       maxPrice: 150000,
       verifiedOnly: true,
       maxDetourKm: 80,
+      sortBy: 'price',
+      sortOrder: 'desc',
       page: 2,
       limit: 5,
     });
@@ -801,6 +805,68 @@ describe('TripOfferController', () => {
         date: '2026-05-01',
         requiredCapacity: '1',
         verifiedOnly: '1',
+      })
+      .expect(400);
+
+    expect(tripOfferService.searchPublicTripOffers).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when sortBy is invalid in search', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: '2026-05-01',
+        requiredCapacity: '1',
+        sortBy: 'createdAt',
+      })
+      .expect(400);
+
+    expect(tripOfferService.searchPublicTripOffers).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when sortOrder is invalid in search', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: '2026-05-01',
+        requiredCapacity: '1',
+        sortBy: 'price',
+        sortOrder: 'sideways',
+      })
+      .expect(400);
+
+    expect(tripOfferService.searchPublicTripOffers).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when sortOrder is sent for proximity in search', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/trip-offers/search')
+      .query({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: '2026-05-01',
+        requiredCapacity: '1',
+        sortBy: 'proximity',
+        sortOrder: 'asc',
       })
       .expect(400);
 

--- a/apps/api/src/trip-offer/types/trip-offer.types.ts
+++ b/apps/api/src/trip-offer/types/trip-offer.types.ts
@@ -49,3 +49,4 @@ export type TransporterProfileOwnerRecord =
 export type TripOfferCreateData = Prisma.TripOfferCreateInput;
 export type TripOfferUpdateData = Prisma.TripOfferUpdateInput;
 export type TripOfferSearchWhereInput = Prisma.TripOfferWhereInput;
+export type TripOfferSearchOrderBy = Prisma.TripOfferOrderByWithRelationInput[];

--- a/docs/api.md
+++ b/docs/api.md
@@ -370,10 +370,70 @@ Uso esperado:
 
 ---
 
+## Trip offers
+
+### `GET /trip-offers/search`
+
+Busqueda publica de ofertas publicadas.
+
+**Query params**
+
+- `origin`: `string` requerido
+- `destination`: `string` requerido
+- `date`: fecha requerida
+- `requiredCapacity`: entero positivo requerido
+- `minPrice`: entero no negativo opcional
+- `maxPrice`: entero no negativo opcional
+- `verifiedOnly`: `true | false` opcional
+- `maxDetourKm`: entero no negativo opcional
+- `sortBy`: `price | proximity | rating` opcional
+- `sortOrder`: `asc | desc` opcional, solo valido cuando `sortBy=price`
+- `page`: entero positivo opcional, default `1`
+- `limit`: entero positivo opcional, maximo `20`, default `10`
+
+**Respuesta 200**
+
+```json
+{
+  "items": [
+    {
+      "id": "string",
+      "originLabel": "string",
+      "destinationLabel": "string",
+      "departureDate": "2026-05-01T00:00:00.000Z",
+      "availableCapacity": 4,
+      "pricePerSlot": 120000,
+      "cargoType": "EQUINE | GENERAL_CARGO | FOOD | PEOPLE",
+      "status": "PUBLISHED | FULL"
+    }
+  ],
+  "page": 1,
+  "limit": 10,
+  "total": 1,
+  "totalPages": 1
+}
+```
+
+**Reglas actuales**
+
+- solo devuelve ofertas `PUBLISHED` con capacidad suficiente y filtros aplicados antes de paginar
+- si no se envia `sortBy`, el backend mantiene su orden default actual
+- `sortBy=price` ordena por `pricePerSlot`
+- `sortBy=proximity` usa una aproximacion temporal: menor `maxDetourKm` primero
+- `sortBy=rating` queda soportado desde ahora, pero mientras no exista rating agregado persistido el orden se resuelve con desempate estable
+- desempate estable para ordenamientos explicitos: `departureDate asc` y luego `id asc`
+- `sortOrder` solo se admite con `sortBy=price`
+
+**Errores**
+
+- `400` query invalida
+
+---
+
 ## Fuera de alcance por ahora
 
 Todavia no existen en la API:
 
 - endpoints de documentos de transportista
 - `verificationNote`
-- endpoints de `TripOffer`
+- detalle publico de `TripOffer`

--- a/packages/shared/src/schemas/trip-offer.schema.ts
+++ b/packages/shared/src/schemas/trip-offer.schema.ts
@@ -77,6 +77,9 @@ const optionalStrictBooleanQuerySchema = z.preprocess((value) => {
   return value;
 }, z.boolean().optional());
 
+const tripOfferSearchSortBySchema = z.enum(['price', 'proximity', 'rating']);
+const tripOfferSearchSortOrderSchema = z.enum(['asc', 'desc']);
+
 type TemporalFields = {
   departureDate?: Date | null;
   departureWindowStart?: Date | null;
@@ -228,6 +231,8 @@ export const TripOfferSearchQuerySchema = z
     maxPrice: nonNegativeIntegerQuerySchema.optional(),
     verifiedOnly: optionalStrictBooleanQuerySchema,
     maxDetourKm: nonNegativeIntegerQuerySchema.optional(),
+    sortBy: tripOfferSearchSortBySchema.optional(),
+    sortOrder: tripOfferSearchSortOrderSchema.optional(),
     page: positiveIntegerQuerySchema.default(1),
     limit: positiveIntegerQuerySchema.default(10),
   })
@@ -250,6 +255,14 @@ export const TripOfferSearchQuerySchema = z
         code: z.ZodIssueCode.custom,
         message: 'minPrice no puede ser mayor que maxPrice.',
         path: ['minPrice'],
+      });
+    }
+
+    if (value.sortOrder !== undefined && value.sortBy !== 'price') {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'sortOrder solo se permite cuando sortBy es price.',
+        path: ['sortOrder'],
       });
     }
   });


### PR DESCRIPTION
## Contexto
- agrega soporte de ordenamiento al endpoint GET /trip-offers/search
- mantiene elegibilidad base, filtros existentes y paginacion

## Alcance
- agrega sortBy y sortOrder con validacion server-side
- implementa ordenamiento por price, proximity y rating con desempate estable
- documenta la aproximacion temporal de proximity y el fallback actual de rating
- suma tests en controller, service y repository

## Validacion
- pnpm --filter @logistica/api test
- pnpm --filter @logistica/api typecheck
- pnpm typecheck sigue fallando por errores preexistentes en apps/web