### PR TITLE
feat(api): formalizar paginacion en busqueda publica de ofertas

### DIFF
--- a/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
+++ b/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
@@ -206,6 +206,30 @@ describe('TripOfferService', () => {
     });
   });
 
+  it('calculates totalPages from the total and requested limit', async () => {
+    tripOfferRepository.searchPublic.mockResolvedValue({
+      items: [],
+      total: 12,
+    });
+
+    await expect(
+      tripOfferService.searchPublicTripOffers({
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        date: new Date('2026-05-01T00:00:00.000Z'),
+        requiredCapacity: 1,
+        page: 2,
+        limit: 4,
+      }),
+    ).resolves.toEqual({
+      items: [],
+      page: 2,
+      limit: 4,
+      total: 12,
+      totalPages: 3,
+    });
+  });
+
   it('keeps public search results limited to published offers with enough capacity', async () => {
     tripOfferRepository.searchPublic.mockResolvedValue({
       items: [

--- a/apps/api/src/trip-offer/repositories/trip-offer.repository.spec.ts
+++ b/apps/api/src/trip-offer/repositories/trip-offer.repository.spec.ts
@@ -244,4 +244,33 @@ describe('TripOfferRepository', () => {
       }),
     );
   });
+
+  it('reuses the final filtered query for items and total while paginating the requested page', async () => {
+    prisma.tripOffer.findMany.mockReturnValue('findMany-operation');
+    prisma.tripOffer.count.mockReturnValue('count-operation');
+    prisma.$transaction.mockResolvedValue([[], 0]);
+
+    await tripOfferRepository.searchPublic({
+      origin: 'Buenos Aires',
+      destination: 'Rosario',
+      date: new Date('2026-05-01T15:24:00.000Z'),
+      requiredCapacity: 2,
+      sortBy: 'price',
+      sortOrder: 'asc',
+      page: 3,
+      limit: 2,
+    });
+
+    const findManyArgs = prisma.tripOffer.findMany.mock.calls[0][0];
+    const countArgs = prisma.tripOffer.count.mock.calls[0][0];
+
+    expect(findManyArgs.where).toBe(countArgs.where);
+    expect(findManyArgs.orderBy).toEqual([
+      { pricePerSlot: 'asc' },
+      { departureDate: 'asc' },
+      { id: 'asc' },
+    ]);
+    expect(findManyArgs.skip).toBe(4);
+    expect(findManyArgs.take).toBe(2);
+  });
 });

--- a/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
+++ b/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
@@ -28,13 +28,13 @@ export class TripOfferRepository {
   ): Promise<{ items: TripOfferRecord[]; total: number }> {
     const where = this.buildSearchWhere(query);
     const orderBy = this.buildSearchOrderBy(query);
+    const pagination = this.buildSearchPagination(query);
 
     const [items, total] = await this.prisma.$transaction([
       this.prisma.tripOffer.findMany({
         where,
         orderBy,
-        skip: (query.page - 1) * query.limit,
-        take: query.limit,
+        ...pagination,
         select: tripOfferSelect,
       }),
       this.prisma.tripOffer.count({ where }),
@@ -211,5 +211,12 @@ export class TripOfferRepository {
     }
 
     return [{ departureDate: 'asc' }, { createdAt: 'desc' }, { id: 'asc' }];
+  }
+
+  private buildSearchPagination(query: SearchTripOffersQuery) {
+    return {
+      skip: (query.page - 1) * query.limit,
+      take: query.limit,
+    } as const;
   }
 }


### PR DESCRIPTION
## Summary

- formaliza la paginacion server-side en GET /trip-offers/search
- deja explicita la construccion de la paginacion sobre la query final filtrada y ordenada
- refuerza la cobertura sobre 	otal, 	otalPages y consistencia entre items y count

## What Changed

- extraje la construccion de skip/	ake a un helper del repository para dejar explicito el paso de paginacion sobre la consulta final
- agregue tests de repository para fijar que indMany y count reutilizan el mismo criterio filtrado y que el offset de pagina es correcto
- agregue tests de service para fijar el calculo estable de 	otalPages

## Validation

- 
ode node_modules/typescript/bin/tsc --noEmit -p apps/api/tsconfig.json
- pps\\api\\node_modules\\.bin\\jest.CMD --config apps/api/jest.config.cjs --runInBand --cacheDirectory C:\\Users\\cavin\\Proyectos\\Logistica\\.jest-cache apps/api/src/trip-offer/repositories/trip-offer.repository.spec.ts apps/api/src/trip-offer/application/trip-offer.service.spec.ts apps/api/src/trip-offer/trip-offer.controller.spec.ts

## Risks

- no hay cambio de contrato publico, pero la implementacion ya depende de que count y indMany se mantengan alineados si se agregan filtros nuevos en el futuro