### PR TITLE
feat(trip-offer): agregar endpoint publico de detalle de oferta

### DIFF
--- a/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
+++ b/apps/api/src/trip-offer/application/trip-offer.service.spec.ts
@@ -38,6 +38,7 @@ const createTripOfferRecord = (
 describe('TripOfferService', () => {
   const tripOfferRepository = {
     searchPublic: jest.fn(),
+    findPublicById: jest.fn(),
     findTransporterProfileByAccountId: jest.fn(),
     findById: jest.fn(),
     findOwnedByAccountId: jest.fn(),
@@ -311,6 +312,60 @@ describe('TripOfferService', () => {
       page: 3,
       limit: 2,
     });
+  });
+
+  it('returns the public trip offer detail with a transporter summary', async () => {
+    tripOfferRepository.findPublicById.mockResolvedValue({
+      id: 'trip-offer-public-id',
+      originLabel: 'Buenos Aires',
+      destinationLabel: 'Rosario',
+      departureDate: new Date('2026-05-01T00:00:00.000Z'),
+      departureWindowStart: null,
+      departureWindowEnd: null,
+      availableCapacity: 6,
+      pricePerSlot: 120000,
+      maxDetourKm: 50,
+      notes: 'Salida temprana',
+      cancellationPolicy: 'Flexible',
+      transporterProfile: {
+        id: 'transporter-profile-id',
+        displayName: 'Acme Transportes',
+        verificationStatus: 'VERIFIED',
+      },
+    });
+
+    await expect(
+      tripOfferService.getPublicTripOfferById('trip-offer-public-id'),
+    ).resolves.toEqual({
+      id: 'trip-offer-public-id',
+      price: 120000,
+      availableCapacity: 6,
+      origin: 'Buenos Aires',
+      destination: 'Rosario',
+      departureDate: new Date('2026-05-01T00:00:00.000Z'),
+      departureWindowStart: null,
+      departureWindowEnd: null,
+      maxDetourKm: 50,
+      notes: 'Salida temprana',
+      cancellationPolicy: 'Flexible',
+      transporter: {
+        id: 'transporter-profile-id',
+        displayName: 'Acme Transportes',
+        verificationStatus: 'VERIFIED',
+      },
+    });
+
+    expect(tripOfferRepository.findPublicById).toHaveBeenCalledWith(
+      'trip-offer-public-id',
+    );
+  });
+
+  it('throws when the public trip offer does not exist or is not published', async () => {
+    tripOfferRepository.findPublicById.mockResolvedValue(null);
+
+    await expect(
+      tripOfferService.getPublicTripOfferById('missing-trip-offer-id'),
+    ).rejects.toThrow(NotFoundException);
   });
 
   it('creates a draft trip offer for the authenticated transporter', async () => {

--- a/apps/api/src/trip-offer/application/trip-offer.service.ts
+++ b/apps/api/src/trip-offer/application/trip-offer.service.ts
@@ -6,11 +6,13 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { TripOfferStatus } from '@logistica/database';
+import type { PublicTripOfferDetailResponseDto } from '../dto/public-trip-offer-detail.response.dto';
 import type { SearchTripOffersResponseDto } from '../dto/search-trip-offers.response.dto';
 import type { TripOfferResponseDto } from '../dto/trip-offer.response.dto';
 import { TripOfferRepository } from '../repositories/trip-offer.repository';
 import type {
   CreateTripOfferInput,
+  PublicTripOfferDetailRecord,
   SearchTripOffersQuery,
   TripOfferRecord,
   UpdateTripOfferInput,
@@ -67,6 +69,19 @@ export class TripOfferService {
       total,
       totalPages: total === 0 ? 0 : Math.ceil(total / normalizedQuery.limit),
     };
+  }
+
+  async getPublicTripOfferById(
+    tripOfferId: string,
+  ): Promise<PublicTripOfferDetailResponseDto> {
+    const tripOffer =
+      await this.tripOfferRepository.findPublicById(tripOfferId);
+
+    if (!tripOffer) {
+      throw new NotFoundException('Trip offer not found.');
+    }
+
+    return this.toPublicTripOfferDetail(tripOffer);
   }
 
   private validateSearchSort(query: SearchTripOffersQuery): void {
@@ -608,6 +623,29 @@ export class TripOfferService {
       pricePerSlot: tripOffer.pricePerSlot,
       cargoType: tripOffer.cargoType,
       status: this.getEffectiveStatus(tripOffer),
+    };
+  }
+
+  private toPublicTripOfferDetail(
+    tripOffer: PublicTripOfferDetailRecord,
+  ): PublicTripOfferDetailResponseDto {
+    return {
+      id: tripOffer.id,
+      price: tripOffer.pricePerSlot,
+      availableCapacity: tripOffer.availableCapacity,
+      origin: tripOffer.originLabel,
+      destination: tripOffer.destinationLabel,
+      departureDate: tripOffer.departureDate,
+      departureWindowStart: tripOffer.departureWindowStart,
+      departureWindowEnd: tripOffer.departureWindowEnd,
+      maxDetourKm: tripOffer.maxDetourKm,
+      notes: tripOffer.notes,
+      cancellationPolicy: tripOffer.cancellationPolicy,
+      transporter: {
+        id: tripOffer.transporterProfile.id,
+        displayName: tripOffer.transporterProfile.displayName,
+        verificationStatus: tripOffer.transporterProfile.verificationStatus,
+      },
     };
   }
 }

--- a/apps/api/src/trip-offer/dto/public-trip-offer-detail.response.dto.ts
+++ b/apps/api/src/trip-offer/dto/public-trip-offer-detail.response.dto.ts
@@ -1,0 +1,3 @@
+import type { IPublicTripOfferDetail } from '@logistica/shared';
+
+export type PublicTripOfferDetailResponseDto = IPublicTripOfferDetail;

--- a/apps/api/src/trip-offer/repositories/trip-offer.repository.spec.ts
+++ b/apps/api/src/trip-offer/repositories/trip-offer.repository.spec.ts
@@ -1,4 +1,5 @@
 import {
+  type Prisma,
   TripOfferStatus,
   TransporterVerificationStatus,
 } from '@logistica/database';
@@ -8,6 +9,7 @@ describe('TripOfferRepository', () => {
   const prisma = {
     $transaction: jest.fn(),
     tripOffer: {
+      findFirst: jest.fn(),
       findMany: jest.fn(),
       count: jest.fn(),
     },
@@ -54,7 +56,11 @@ describe('TripOfferRepository', () => {
             lt: new Date('2026-05-02T00:00:00.000Z'),
           },
         },
-        orderBy: [{ departureDate: 'asc' }, { createdAt: 'desc' }, { id: 'asc' }],
+        orderBy: [
+          { departureDate: 'asc' },
+          { createdAt: 'desc' },
+          { id: 'asc' },
+        ],
         skip: 5,
         take: 5,
       }),
@@ -133,7 +139,11 @@ describe('TripOfferRepository', () => {
             lt: new Date('2026-05-02T00:00:00.000Z'),
           },
         },
-        orderBy: [{ departureDate: 'asc' }, { createdAt: 'desc' }, { id: 'asc' }],
+        orderBy: [
+          { departureDate: 'asc' },
+          { createdAt: 'desc' },
+          { id: 'asc' },
+        ],
         skip: 0,
         take: 10,
       }),
@@ -261,8 +271,14 @@ describe('TripOfferRepository', () => {
       limit: 2,
     });
 
-    const findManyArgs = prisma.tripOffer.findMany.mock.calls[0][0];
-    const countArgs = prisma.tripOffer.count.mock.calls[0][0];
+    const findManyCalls = prisma.tripOffer.findMany.mock.calls as [
+      [Prisma.TripOfferFindManyArgs],
+    ];
+    const countCalls = prisma.tripOffer.count.mock.calls as [
+      [Prisma.TripOfferCountArgs],
+    ];
+    const [findManyArgs] = findManyCalls[0];
+    const [countArgs] = countCalls[0];
 
     expect(findManyArgs.where).toBe(countArgs.where);
     expect(findManyArgs.orderBy).toEqual([
@@ -272,5 +288,38 @@ describe('TripOfferRepository', () => {
     ]);
     expect(findManyArgs.skip).toBe(4);
     expect(findManyArgs.take).toBe(2);
+  });
+
+  it('loads the public trip offer detail using a published-only public select', async () => {
+    prisma.tripOffer.findFirst.mockResolvedValue(null);
+
+    await tripOfferRepository.findPublicById('cm9tripoffer0000wqz5oy7k8ph1');
+
+    expect(prisma.tripOffer.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'cm9tripoffer0000wqz5oy7k8ph1',
+        status: TripOfferStatus.PUBLISHED,
+      },
+      select: {
+        id: true,
+        originLabel: true,
+        destinationLabel: true,
+        departureDate: true,
+        departureWindowStart: true,
+        departureWindowEnd: true,
+        availableCapacity: true,
+        pricePerSlot: true,
+        maxDetourKm: true,
+        notes: true,
+        cancellationPolicy: true,
+        transporterProfile: {
+          select: {
+            id: true,
+            displayName: true,
+            verificationStatus: true,
+          },
+        },
+      },
+    });
   });
 });

--- a/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
+++ b/apps/api/src/trip-offer/repositories/trip-offer.repository.ts
@@ -7,6 +7,7 @@ import {
 } from '@logistica/database';
 import type {
   CreateTripOfferInput,
+  PublicTripOfferDetailRecord,
   TripOfferSearchOrderBy,
   SearchTripOffersQuery,
   TransporterProfileOwnerRecord,
@@ -15,6 +16,7 @@ import type {
   TripOfferUpdateData,
 } from '../types/trip-offer.types';
 import {
+  publicTripOfferDetailSelect,
   transporterProfileOwnerSelect,
   tripOfferSelect,
 } from '../types/trip-offer.types';
@@ -56,6 +58,18 @@ export class TripOfferRepository {
     return this.prisma.tripOffer.findUnique({
       where: { id: tripOfferId },
       select: tripOfferSelect,
+    });
+  }
+
+  async findPublicById(
+    tripOfferId: string,
+  ): Promise<PublicTripOfferDetailRecord | null> {
+    return this.prisma.tripOffer.findFirst({
+      where: {
+        id: tripOfferId,
+        status: TripOfferStatus.PUBLISHED,
+      },
+      select: publicTripOfferDetailSelect,
     });
   }
 

--- a/apps/api/src/trip-offer/trip-offer.controller.spec.ts
+++ b/apps/api/src/trip-offer/trip-offer.controller.spec.ts
@@ -44,6 +44,7 @@ class TestJwtAuthGuard {
 describe('TripOfferController', () => {
   const tripOfferService = {
     searchPublicTripOffers: jest.fn(),
+    getPublicTripOfferById: jest.fn(),
     listOwnTripOffers: jest.fn(),
     createOwnTripOffer: jest.fn(),
     publishOwnTripOffer: jest.fn(),
@@ -241,6 +242,60 @@ describe('TripOfferController', () => {
       page: 1,
       limit: 10,
     });
+
+    await app.close();
+  });
+
+  it('returns a public trip offer detail when the id is valid', async () => {
+    const tripOfferId = 'cm9tripoffer0000wqz5oy7k8ph1';
+
+    tripOfferService.getPublicTripOfferById.mockResolvedValue({
+      id: tripOfferId,
+      price: 120000,
+      availableCapacity: 6,
+      origin: 'Buenos Aires',
+      destination: 'Rosario',
+      departureDate: new Date('2026-05-01T00:00:00.000Z'),
+      departureWindowStart: null,
+      departureWindowEnd: null,
+      maxDetourKm: 50,
+      notes: 'Salida temprana',
+      cancellationPolicy: 'Flexible',
+      transporter: {
+        id: 'cm9transporter0000wqz5oy7k8ph1',
+        displayName: 'Acme Transportes',
+        verificationStatus: 'VERIFIED',
+      },
+    });
+
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get(`/trip-offers/${tripOfferId}/public`)
+      .expect(200)
+      .expect({
+        id: tripOfferId,
+        price: 120000,
+        availableCapacity: 6,
+        origin: 'Buenos Aires',
+        destination: 'Rosario',
+        departureDate: '2026-05-01T00:00:00.000Z',
+        departureWindowStart: null,
+        departureWindowEnd: null,
+        maxDetourKm: 50,
+        notes: 'Salida temprana',
+        cancellationPolicy: 'Flexible',
+        transporter: {
+          id: 'cm9transporter0000wqz5oy7k8ph1',
+          displayName: 'Acme Transportes',
+          verificationStatus: 'VERIFIED',
+        },
+      });
+
+    expect(tripOfferService.getPublicTripOfferById).toHaveBeenCalledWith(
+      tripOfferId,
+    );
 
     await app.close();
   });
@@ -917,6 +972,17 @@ describe('TripOfferController', () => {
     await app.close();
   });
 
+  it('returns 400 when the path id is invalid for the public detail endpoint', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server).get('/trip-offers/not-a-cuid/public').expect(400);
+
+    expect(tripOfferService.getPublicTripOfferById).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
   it('returns 401 when the access token is missing', async () => {
     const app = await createApp();
     const server = app.getHttpServer() as Parameters<typeof request>[0];
@@ -969,6 +1035,20 @@ describe('TripOfferController', () => {
         pricePerSlot: 140000,
       })
       .expect(404);
+
+    await app.close();
+  });
+
+  it('returns 404 when the public trip offer detail is not visible', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+    const tripOfferId = 'cm9tripoffer0000wqz5oy7k8ph1';
+
+    tripOfferService.getPublicTripOfferById.mockRejectedValue(
+      new NotFoundException('Trip offer not found.'),
+    );
+
+    await request(server).get(`/trip-offers/${tripOfferId}/public`).expect(404);
 
     await app.close();
   });

--- a/apps/api/src/trip-offer/trip-offer.controller.ts
+++ b/apps/api/src/trip-offer/trip-offer.controller.ts
@@ -24,6 +24,7 @@ import type { CreateTripOfferDto } from './dto/create-trip-offer.dto';
 import type { SearchTripOffersQueryDto } from './dto/search-trip-offers.dto';
 import { SearchTripOffersQuerySchema } from './dto/search-trip-offers.dto';
 import type { SearchTripOffersResponseDto } from './dto/search-trip-offers.response.dto';
+import type { PublicTripOfferDetailResponseDto } from './dto/public-trip-offer-detail.response.dto';
 import type {
   TripOfferParamsDto,
   UpdateTripOfferDto,
@@ -45,6 +46,14 @@ export class TripOfferController {
     query: SearchTripOffersQueryDto,
   ): Promise<SearchTripOffersResponseDto> {
     return this.tripOfferService.searchPublicTripOffers(query);
+  }
+
+  @Get(':id/public')
+  async getPublicTripOfferById(
+    @Param(new ZodValidationPipe(TripOfferParamsSchema))
+    params: TripOfferParamsDto,
+  ): Promise<PublicTripOfferDetailResponseDto> {
+    return this.tripOfferService.getPublicTripOfferById(params.id);
   }
 
   @Get('my')

--- a/apps/api/src/trip-offer/types/trip-offer.types.ts
+++ b/apps/api/src/trip-offer/types/trip-offer.types.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from '@logistica/database';
 import type {
   ICreateTripOfferDto,
+  IPublicTripOfferDetail,
   ITripOfferSearchQueryDto,
   IPublicTripOfferSearchItem,
   IUpdateTripOfferDto,
@@ -35,12 +36,37 @@ export const transporterProfileOwnerSelect = {
   id: true,
 } satisfies Prisma.TransporterProfileSelect;
 
+export const publicTripOfferDetailSelect = {
+  id: true,
+  originLabel: true,
+  destinationLabel: true,
+  departureDate: true,
+  departureWindowStart: true,
+  departureWindowEnd: true,
+  availableCapacity: true,
+  pricePerSlot: true,
+  maxDetourKm: true,
+  notes: true,
+  cancellationPolicy: true,
+  transporterProfile: {
+    select: {
+      id: true,
+      displayName: true,
+      verificationStatus: true,
+    },
+  },
+} satisfies Prisma.TripOfferSelect;
+
 export type CreateTripOfferInput = ICreateTripOfferDto;
 export type UpdateTripOfferInput = IUpdateTripOfferDto;
 export type SearchTripOffersQuery = ITripOfferSearchQueryDto;
 export type PublicTripOfferSearchItem = IPublicTripOfferSearchItem;
+export type PublicTripOfferDetail = IPublicTripOfferDetail;
 export type TripOfferRecord = Prisma.TripOfferGetPayload<{
   select: typeof tripOfferSelect;
+}>;
+export type PublicTripOfferDetailRecord = Prisma.TripOfferGetPayload<{
+  select: typeof publicTripOfferDetailSelect;
 }>;
 export type TransporterProfileOwnerRecord =
   Prisma.TransporterProfileGetPayload<{

--- a/packages/shared/src/interfaces/interfaces.ts
+++ b/packages/shared/src/interfaces/interfaces.ts
@@ -17,8 +17,10 @@ import {
 } from '../schemas/trailer.schema';
 import {
   CreateTripOfferSchema,
+  PublicTripOfferDetailSchema,
   PublicTripOfferSearchItemSchema,
   PublicTripOfferSearchResponseSchema,
+  PublicTripOfferTransporterSummarySchema,
   TripOfferSearchQuerySchema,
   TripOfferParamsSchema,
   TripOfferViewSchema,
@@ -147,7 +149,8 @@ export type ITripOfferSearchQueryDto = z.infer<
 export const TripOfferViewDtoSchema = TripOfferViewSchema;
 export type ITripOfferView = z.infer<typeof TripOfferViewDtoSchema>;
 
-export const PublicTripOfferSearchItemDtoSchema = PublicTripOfferSearchItemSchema;
+export const PublicTripOfferSearchItemDtoSchema =
+  PublicTripOfferSearchItemSchema;
 export type IPublicTripOfferSearchItem = z.infer<
   typeof PublicTripOfferSearchItemDtoSchema
 >;
@@ -156,6 +159,17 @@ export const PublicTripOfferSearchResponseDtoSchema =
   PublicTripOfferSearchResponseSchema;
 export type IPublicTripOfferSearchResponse = z.infer<
   typeof PublicTripOfferSearchResponseDtoSchema
+>;
+
+export const PublicTripOfferTransporterSummaryDtoSchema =
+  PublicTripOfferTransporterSummarySchema;
+export type IPublicTripOfferTransporterSummary = z.infer<
+  typeof PublicTripOfferTransporterSummaryDtoSchema
+>;
+
+export const PublicTripOfferDetailDtoSchema = PublicTripOfferDetailSchema;
+export type IPublicTripOfferDetail = z.infer<
+  typeof PublicTripOfferDetailDtoSchema
 >;
 
 export const AuthProfileViewSchema = z

--- a/packages/shared/src/schemas/trip-offer.schema.ts
+++ b/packages/shared/src/schemas/trip-offer.schema.ts
@@ -310,6 +310,27 @@ export const PublicTripOfferSearchResponseSchema = z.object({
   totalPages: z.number().int().min(0),
 });
 
+export const PublicTripOfferTransporterSummarySchema = z.object({
+  id: cuidSchema,
+  displayName: z.string().trim().min(1).max(160),
+  verificationStatus: z.enum(['INCOMPLETE', 'PENDING', 'VERIFIED', 'REJECTED']),
+});
+
+export const PublicTripOfferDetailSchema = z.object({
+  id: cuidSchema,
+  price: z.number().int().min(0),
+  availableCapacity: z.number().int().min(0),
+  origin: z.string().trim().min(1).max(160),
+  destination: z.string().trim().min(1).max(160),
+  departureDate: z.date().nullable(),
+  departureWindowStart: z.date().nullable(),
+  departureWindowEnd: z.date().nullable(),
+  maxDetourKm: z.number().int().min(0).nullable(),
+  notes: z.string().max(2000).nullable(),
+  cancellationPolicy: z.string().max(1000).nullable(),
+  transporter: PublicTripOfferTransporterSummarySchema,
+});
+
 export type CreateTripOfferDto = z.infer<typeof CreateTripOfferSchema>;
 export type UpdateTripOfferDto = z.infer<typeof UpdateTripOfferSchema>;
 export type TripOfferParamsDto = z.infer<typeof TripOfferParamsSchema>;
@@ -323,3 +344,7 @@ export type PublicTripOfferSearchItem = z.infer<
 export type PublicTripOfferSearchResponse = z.infer<
   typeof PublicTripOfferSearchResponseSchema
 >;
+export type PublicTripOfferTransporterSummary = z.infer<
+  typeof PublicTripOfferTransporterSummarySchema
+>;
+export type PublicTripOfferDetail = z.infer<typeof PublicTripOfferDetailSchema>;


### PR DESCRIPTION
## Contexto
Cierra el flujo backend de exploracion de ofertas para E5-BE agregando el detalle publico de una oferta antes de reservar.

## Que cambia
- agrega `GET /trip-offers/:id/public` en el modulo `trip-offer`
- valida server-side el `id` con el schema existente de params
- expone solo ofertas en estado `PUBLISHED`
- incorpora un contrato compartido para detalle publico y resumen publico del transportista
- carga el detalle desde controller -> service -> repository con un `select` publico dedicado
- evita exponer datos sensibles del transportista como telefono, email, business name o bio
- responde `404` tanto para oferta inexistente como para oferta no visible publicamente

## Respuesta publica
Incluye:
- `id`
- `price`
- `availableCapacity`
- `origin`
- `destination`
- `departureDate`
- `departureWindowStart`
- `departureWindowEnd`
- `maxDetourKm`
- `notes`
- `cancellationPolicy`
- `transporter.{id, displayName, verificationStatus}`

## Tests y verificacion
- `pnpm --filter @logistica/api lint`
- `pnpm --filter @logistica/api typecheck`
- `pnpm --filter @logistica/api build`
- `pnpm --filter @logistica/api test -- trip-offer`

## Notas
Los checks globales del monorepo (`pnpm lint`, `pnpm typecheck`, `pnpm build`) siguen fallando por problemas preexistentes en `apps/web` ajenos a este cambio.