### PR TITLE
feat(booking): Desarrollo del modelo de Booking en BD

### DIFF
--- a/packages/database/prisma/migrations/20260424113000_add_booking_model/migration.sql
+++ b/packages/database/prisma/migrations/20260424113000_add_booking_model/migration.sql
@@ -1,0 +1,66 @@
+-- CreateEnum
+CREATE TYPE "BookingStatus" AS ENUM (
+    'PENDING_PAYMENT',
+    'CONFIRMED',
+    'IN_PROGRESS',
+    'DELIVERED_PENDING_CONFIRMATION',
+    'COMPLETED',
+    'CANCELLED',
+    'DISPUTED'
+);
+
+-- CreateTable
+CREATE TABLE "bookings" (
+    "id" TEXT NOT NULL,
+    "tripOfferId" TEXT NOT NULL,
+    "clientAccountId" TEXT NOT NULL,
+    "requestedUnits" INTEGER NOT NULL,
+    "unitPriceSnapshot" INTEGER NOT NULL,
+    "totalPriceSnapshot" INTEGER NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "status" "BookingStatus" NOT NULL DEFAULT 'PENDING_PAYMENT',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "bookings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "bookings_tripOfferId_idx"
+ON "bookings"("tripOfferId");
+
+-- CreateIndex
+CREATE INDEX "bookings_clientAccountId_idx"
+ON "bookings"("clientAccountId");
+
+-- CreateIndex
+CREATE INDEX "bookings_status_idx"
+ON "bookings"("status");
+
+-- CreateIndex
+CREATE INDEX "bookings_expiresAt_idx"
+ON "bookings"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX "bookings_tripOfferId_status_idx"
+ON "bookings"("tripOfferId", "status");
+
+-- CreateIndex
+CREATE INDEX "bookings_clientAccountId_createdAt_idx"
+ON "bookings"("clientAccountId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "bookings"
+ADD CONSTRAINT "bookings_tripOfferId_fkey"
+FOREIGN KEY ("tripOfferId")
+REFERENCES "trip_offers"("id")
+ON DELETE RESTRICT
+ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "bookings"
+ADD CONSTRAINT "bookings_clientAccountId_fkey"
+FOREIGN KEY ("clientAccountId")
+REFERENCES "accounts"("id")
+ON DELETE RESTRICT
+ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -49,6 +49,16 @@ enum TripOfferStatus {
   CANCELLED
 }
 
+enum BookingStatus {
+  PENDING_PAYMENT
+  CONFIRMED
+  IN_PROGRESS
+  DELIVERED_PENDING_CONFIRMATION
+  COMPLETED
+  CANCELLED
+  DISPUTED
+}
+
 model Account {
   id                 String              @id @default(cuid())
   email              String              @unique
@@ -63,6 +73,7 @@ model Account {
   userProfile        UserProfile?
   transporterProfile TransporterProfile?
   sessions           Session[]
+  clientBookings     Booking[]           @relation("ClientBookings")
 
   @@index([role])
   @@index([status])
@@ -169,12 +180,37 @@ model TripOffer {
   updatedAt            DateTime         @updatedAt
 
   transporterProfile   TransporterProfile @relation(fields: [transporterProfileId], references: [id], onDelete: Cascade)
+  bookings             Booking[]
 
   @@index([transporterProfileId])
   @@index([transporterProfileId, status])
   @@index([status])
   @@index([cargoType, status])
   @@map("trip_offers")
+}
+
+model Booking {
+  id                 String        @id @default(cuid())
+  tripOfferId        String
+  clientAccountId    String
+  requestedUnits     Int
+  unitPriceSnapshot  Int
+  totalPriceSnapshot Int
+  expiresAt          DateTime
+  status             BookingStatus @default(PENDING_PAYMENT)
+  createdAt          DateTime      @default(now())
+  updatedAt          DateTime      @updatedAt
+
+  tripOffer          TripOffer     @relation(fields: [tripOfferId], references: [id], onDelete: Restrict)
+  clientAccount      Account       @relation("ClientBookings", fields: [clientAccountId], references: [id], onDelete: Restrict)
+
+  @@index([tripOfferId])
+  @@index([clientAccountId])
+  @@index([status])
+  @@index([expiresAt])
+  @@index([tripOfferId, status])
+  @@index([clientAccountId, createdAt])
+  @@map("bookings")
 }
 
 model Session {

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -3,8 +3,10 @@ export { PrismaService } from './prisma.service';
 export {
   AccountRole,
   AccountStatus,
+  BookingStatus,
   CargoType,
   Prisma,
+  type Booking,
   TripOfferStatus,
   TransporterVerificationStatus,
   type Account,

--- a/packages/shared/src/interfaces/interfaces.ts
+++ b/packages/shared/src/interfaces/interfaces.ts
@@ -112,6 +112,17 @@ export const TripOfferStatusSchema = z.enum([
 ]);
 export type ITripOfferStatus = z.infer<typeof TripOfferStatusSchema>;
 
+export const BookingStatusSchema = z.enum([
+  'PENDING_PAYMENT',
+  'CONFIRMED',
+  'IN_PROGRESS',
+  'DELIVERED_PENDING_CONFIRMATION',
+  'COMPLETED',
+  'CANCELLED',
+  'DISPUTED',
+]);
+export type IBookingStatus = z.infer<typeof BookingStatusSchema>;
+
 export type IUpdateTransporterProfileDto = {
   displayName?: string;
   businessName?: string | null;


### PR DESCRIPTION
## Contexto
Esta PR implementa la primera issue de la epica E6-BE: modelar la entidad Booking y los snapshots de reserva para dejar la base lista para futuras issues de creacion de booking y anti-overbooking.

## Objetivo
Definir la estructura base de Booking para soportar:
- reserva de capacidad
- precio congelado al momento de reservar
- expiracion de la reserva
- ciclo de estados de negocio

## Cambios incluidos
- agregado de enum BookingStatus en Prisma con los estados:
  - PENDING_PAYMENT
  - CONFIRMED
  - IN_PROGRESS
  - DELIVERED_PENDING_CONFIRMATION
  - COMPLETED
  - CANCELLED
  - DISPUTED
- creacion del modelo Booking en Prisma
- relacion de Booking con TripOffer
- relacion de Booking con el cliente via Account
- agregado de campos:
  - equestedUnits
  - unitPriceSnapshot
  - 	otalPriceSnapshot
  - expiresAt
- agregado de indices para consultas futuras por oferta, cliente, estado y expiracion
- migracion SQL no destructiva para crear enum, tabla, FKs e indices
- export de Booking y BookingStatus en @logistica/database
- agregado de BookingStatusSchema e IBookingStatus en @logistica/shared

## Decision de modelado
Se eligio relacionar Booking con Account y no con UserProfile porque la identidad operativa del backend ya esta centrada en la cuenta autenticada. Eso deja el modelo alineado con auth actual y evita acoplar la reserva a un perfil derivado.

## Fuera de alcance
Esta PR no incluye:
- endpoint POST /bookings
- logica transaccional
- decremento de vailableCapacity
- expiracion automatica por job
- cancelacion de booking
- integracion de pagos

## Criterios de aceptacion cubiertos
- existe la entidad Booking con sus relaciones principales
- el booking guarda equestedUnits
- el booking guarda snapshot de precio al momento de reservar
- el booking contempla expiresAt y estados de negocio validos

## Riesgos / consideraciones
- no se agrega todavia logica de transicion de estados; solo se modela el enum y el default inicial
- no se agrega todavia anti-overbooking; eso queda para la siguiente issue de la epica
- la PR deja lista la base para futuras integraciones con pagos y expiracion sin adelantar comportamiento fuera de alcance

## Validacion
- prisma validate
- pnpm typecheck
- pnpm lint
- pnpm test

## Como revisar
1. Revisar packages/database/prisma/schema.prisma para confirmar el modelo, relaciones e indices.
2. Revisar la migracion 20260424113000_add_booking_model.
3. Confirmar que no hay endpoints ni logica de negocio agregada fuera del modelado.
4. Verificar que la PR queda lista como base para las proximas issues de creacion de booking y anti-overbooking.