### PR TITLE
feat(booking): validar capacidad real disponible

### DIFF
--- a/apps/api/src/booking/application/booking.service.spec.ts
+++ b/apps/api/src/booking/application/booking.service.spec.ts
@@ -23,6 +23,7 @@ describe('BookingService', () => {
 
     bookingRepository.findTripOfferById.mockResolvedValue({
       id: 'cmatripoffer0000wqz5oy7k8ph1',
+      availableCapacity: 4,
       pricePerSlot: 120000,
       status: TripOfferStatus.PUBLISHED,
     });
@@ -88,6 +89,7 @@ describe('BookingService', () => {
   it('throws when the trip offer is not published', async () => {
     bookingRepository.findTripOfferById.mockResolvedValue({
       id: 'cmatripoffer0000wqz5oy7k8ph1',
+      availableCapacity: 4,
       pricePerSlot: 120000,
       status: TripOfferStatus.DRAFT,
     });
@@ -110,6 +112,7 @@ describe('BookingService', () => {
 
     bookingRepository.findTripOfferById.mockResolvedValue({
       id: 'cmatripoffer0000wqz5oy7k8ph1',
+      availableCapacity: 5,
       pricePerSlot: 85000,
       status: TripOfferStatus.PUBLISHED,
     });
@@ -148,6 +151,7 @@ describe('BookingService', () => {
 
     bookingRepository.findTripOfferById.mockResolvedValue({
       id: 'cmatripoffer0000wqz5oy7k8ph1',
+      availableCapacity: 2,
       pricePerSlot: 120000,
       status: TripOfferStatus.PUBLISHED,
     });
@@ -176,5 +180,27 @@ describe('BookingService', () => {
     );
 
     jest.useRealTimers();
+  });
+
+  it('throws when requested units exceed available capacity', async () => {
+    bookingRepository.findTripOfferById.mockResolvedValue({
+      id: 'cmatripoffer0000wqz5oy7k8ph1',
+      availableCapacity: 1,
+      pricePerSlot: 120000,
+      status: TripOfferStatus.PUBLISHED,
+    });
+
+    await expect(
+      bookingService.createBooking('client-account-id', {
+        tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+        requestedUnits: 2,
+      }),
+    ).rejects.toThrow(
+      new ConflictException(
+        'Insufficient available capacity for the requested booking units.',
+      ),
+    );
+
+    expect(bookingRepository.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/booking/application/booking.service.ts
+++ b/apps/api/src/booking/application/booking.service.ts
@@ -32,6 +32,11 @@ export class BookingService {
       );
     }
 
+    this.ensureAvailableCapacity(
+      tripOffer.availableCapacity,
+      input.requestedUnits,
+    );
+
     const unitPriceSnapshot = tripOffer.pricePerSlot;
     const totalPriceSnapshot = unitPriceSnapshot * input.requestedUnits;
     const expiresAt = new Date(Date.now() + BOOKING_PENDING_PAYMENT_TTL_MS);
@@ -46,6 +51,17 @@ export class BookingService {
     });
 
     return this.toBookingResponse(booking);
+  }
+
+  private ensureAvailableCapacity(
+    availableCapacity: number,
+    requestedUnits: number,
+  ): void {
+    if (requestedUnits > availableCapacity) {
+      throw new ConflictException(
+        'Insufficient available capacity for the requested booking units.',
+      );
+    }
   }
 
   private toBookingResponse(booking: BookingRecord): BookingResponseDto {

--- a/apps/api/src/booking/booking.controller.spec.ts
+++ b/apps/api/src/booking/booking.controller.spec.ts
@@ -263,4 +263,26 @@ describe('BookingController', () => {
 
     await app.close();
   });
+
+  it('returns 409 when the requested units exceed available capacity', async () => {
+    bookingService.createBooking.mockRejectedValue(
+      new ConflictException(
+        'Insufficient available capacity for the requested booking units.',
+      ),
+    );
+
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/bookings')
+      .set('Authorization', 'Bearer CLIENT')
+      .send({
+        tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+        requestedUnits: 2,
+      })
+      .expect(409);
+
+    await app.close();
+  });
 });

--- a/apps/api/src/booking/types/booking.types.ts
+++ b/apps/api/src/booking/types/booking.types.ts
@@ -16,6 +16,7 @@ export const bookingSelect = {
 
 export const tripOfferBookingSelect = {
   id: true,
+  availableCapacity: true,
   pricePerSlot: true,
   status: true,
 } satisfies Prisma.TripOfferSelect;


### PR DESCRIPTION
## Objetivo
Implementar la validacion funcional de capacidad real disponible en booking antes de crear la reserva.

## Que cambia
- centraliza la validacion de capacidad en `BookingService`
- consulta `availableCapacity` junto con la oferta para validar antes del create
- rechaza reservas cuando `requestedUnits` supera la capacidad disponible
- mantiene el controller sin logica de negocio duplicada
- agrega cobertura unitaria y HTTP para el caso sin capacidad suficiente

## Criterios de aceptacion
- [x] El sistema valida capacidad real antes de reservar
- [x] No se puede reservar mas capacidad que la disponible
- [x] El error por falta de cupos esta controlado
- [x] `availableCapacity` no queda en negativo por validacion incorrecta
- [x] La validacion se ejecuta en el service antes de crear la reserva

## Validacion ejecutada
- [x] `pnpm --filter @logistica/api lint`
- [x] `pnpm --filter @logistica/api typecheck`
- [x] `pnpm --filter @logistica/api test`

## No entra en esta PR
- manejo de concurrencia entre requests simultaneos
- locking avanzado o `SELECT FOR UPDATE`
- tests de carrera
- expiracion automatica de bookings
- cancelacion con liberacion de cupos
- integracion de pagos
- consumo transaccional de capacidad

## Riesgo principal
Esta PR valida capacidad de forma funcional previa al create, pero no resuelve todavia concurrencia real. Eso queda explicitamente fuera de alcance y preparado para la siguiente issue transaccional.