### PR TITLE
fix(booking): standardize insufficient capacity conflict error

### DIFF
--- a/apps/api/src/booking/application/booking.errors.ts
+++ b/apps/api/src/booking/application/booking.errors.ts
@@ -1,0 +1,2 @@
+export const BOOKING_INSUFFICIENT_CAPACITY_MESSAGE =
+  'The requested booking units exceed the trip offer available capacity.';

--- a/apps/api/src/booking/application/booking.service.spec.ts
+++ b/apps/api/src/booking/application/booking.service.spec.ts
@@ -1,5 +1,6 @@
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import { BookingStatus, TripOfferStatus } from '@logistica/database';
+import { BOOKING_INSUFFICIENT_CAPACITY_MESSAGE } from './booking.errors';
 import { BookingService } from './booking.service';
 
 describe('BookingService', () => {
@@ -195,11 +196,14 @@ describe('BookingService', () => {
         tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
         requestedUnits: 2,
       }),
-    ).rejects.toThrow(
-      new ConflictException(
-        'Insufficient available capacity for the requested booking units.',
-      ),
-    );
+    ).rejects.toMatchObject({
+      response: {
+        error: 'Conflict',
+        message: BOOKING_INSUFFICIENT_CAPACITY_MESSAGE,
+        statusCode: 409,
+      },
+      status: 409,
+    });
 
     expect(bookingRepository.create).not.toHaveBeenCalled();
   });

--- a/apps/api/src/booking/application/booking.service.ts
+++ b/apps/api/src/booking/application/booking.service.ts
@@ -7,6 +7,7 @@ import { BookingStatus, TripOfferStatus } from '@logistica/database';
 import type { BookingResponseDto } from '../dto/booking.response.dto';
 import { BookingRepository } from '../repositories/booking.repository';
 import type { BookingRecord, CreateBookingInput } from '../types/booking.types';
+import { BOOKING_INSUFFICIENT_CAPACITY_MESSAGE } from './booking.errors';
 
 const BOOKING_PENDING_PAYMENT_TTL_MS = 30 * 60 * 1000;
 
@@ -58,9 +59,7 @@ export class BookingService {
     requestedUnits: number,
   ): void {
     if (requestedUnits > availableCapacity) {
-      throw new ConflictException(
-        'Insufficient available capacity for the requested booking units.',
-      );
+      throw new ConflictException(BOOKING_INSUFFICIENT_CAPACITY_MESSAGE);
     }
   }
 

--- a/apps/api/src/booking/booking.controller.spec.ts
+++ b/apps/api/src/booking/booking.controller.spec.ts
@@ -10,6 +10,7 @@ import request from 'supertest';
 import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
 import { RolesGuard } from '../identity/authentication/guards/roles.guard';
 import { BookingService } from './application/booking.service';
+import { BOOKING_INSUFFICIENT_CAPACITY_MESSAGE } from './application/booking.errors';
 import { BookingController } from './booking.controller';
 
 @Injectable()
@@ -266,9 +267,7 @@ describe('BookingController', () => {
 
   it('returns 409 when the requested units exceed available capacity', async () => {
     bookingService.createBooking.mockRejectedValue(
-      new ConflictException(
-        'Insufficient available capacity for the requested booking units.',
-      ),
+      new ConflictException(BOOKING_INSUFFICIENT_CAPACITY_MESSAGE),
     );
 
     const app = await createApp();
@@ -281,7 +280,12 @@ describe('BookingController', () => {
         tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
         requestedUnits: 2,
       })
-      .expect(409);
+      .expect(409)
+      .expect({
+        error: 'Conflict',
+        message: BOOKING_INSUFFICIENT_CAPACITY_MESSAGE,
+        statusCode: 409,
+      });
 
     await app.close();
   });


### PR DESCRIPTION
## Contexto
Implementa el manejo semantico de error 409 cuando una reserva no puede concretarse por falta de cupos disponibles.

## Alcance
- centraliza el mensaje de capacidad insuficiente en booking
- mantiene ConflictException con payload HTTP consistente
- ajusta tests de service y controller para validar statusCode, message y error

## Validacion
- pnpm --filter @logistica/api lint
- pnpm --filter @logistica/api typecheck
- pnpm --filter @logistica/api exec jest --config jest.config.cjs --runInBand src/booking/application/booking.service.spec.ts src/booking/booking.controller.spec.ts

## Notas
- no modifica concurrencia, pagos, expiracion ni otras reglas de negocio
- el monorepo raiz sigue teniendo fallas preexistentes en apps/web fuera del alcance de esta PR