### PR TITLE
feat(booking): implementar detalle de booking para cliente

### DIFF
--- a/apps/api/src/booking/application/booking.service.spec.ts
+++ b/apps/api/src/booking/application/booking.service.spec.ts
@@ -5,6 +5,7 @@ import { BookingService } from './booking.service';
 
 describe('BookingService', () => {
   const bookingRepository = {
+    findOwnedDetailById: jest.fn(),
     lockTripOfferById: jest.fn(),
     expirePendingBookingsForTripOffer: jest.fn(),
     updateTripOfferAvailability: jest.fn(),
@@ -118,6 +119,94 @@ describe('BookingService', () => {
         expiresAt,
       },
       tx,
+    );
+  });
+
+  it('returns the detail for a booking owned by the authenticated client', async () => {
+    const createdAt = new Date('2026-04-24T13:00:00.000Z');
+    const expiresAt = new Date('2026-04-24T13:30:00.000Z');
+
+    bookingRepository.findOwnedDetailById.mockResolvedValue({
+      id: 'cmabooking0000wqz5oy7k8ph1',
+      tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+      requestedUnits: 2,
+      unitPriceSnapshot: 120000,
+      totalPriceSnapshot: 240000,
+      expiresAt,
+      status: BookingStatus.PENDING_PAYMENT,
+      createdAt,
+      updatedAt: createdAt,
+      tripOffer: {
+        id: 'cmatripoffer0000wqz5oy7k8ph1',
+        originLabel: 'Buenos Aires',
+        destinationLabel: 'Rosario',
+        departureDate: new Date('2026-04-25T10:00:00.000Z'),
+        departureWindowStart: null,
+        departureWindowEnd: null,
+        status: TripOfferStatus.PUBLISHED,
+      },
+    });
+
+    await expect(
+      bookingService.getOwnBookingById(
+        'client-account-id',
+        'cmabooking0000wqz5oy7k8ph1',
+      ),
+    ).resolves.toEqual({
+      id: 'cmabooking0000wqz5oy7k8ph1',
+      tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+      requestedUnits: 2,
+      unitPriceSnapshot: 120000,
+      totalPriceSnapshot: 240000,
+      expiresAt,
+      status: BookingStatus.PENDING_PAYMENT,
+      createdAt,
+      updatedAt: createdAt,
+      tripOffer: {
+        id: 'cmatripoffer0000wqz5oy7k8ph1',
+        originLabel: 'Buenos Aires',
+        destinationLabel: 'Rosario',
+        departureDate: new Date('2026-04-25T10:00:00.000Z'),
+        departureWindowStart: null,
+        departureWindowEnd: null,
+        status: TripOfferStatus.PUBLISHED,
+      },
+    });
+
+    expect(bookingRepository.findOwnedDetailById).toHaveBeenCalledWith(
+      'client-account-id',
+      'cmabooking0000wqz5oy7k8ph1',
+    );
+  });
+
+  it('throws when the booking does not exist for the authenticated client', async () => {
+    bookingRepository.findOwnedDetailById.mockResolvedValue(null);
+
+    await expect(
+      bookingService.getOwnBookingById(
+        'client-account-id',
+        'cmabooking0000wqz5oy7k8ph1',
+      ),
+    ).rejects.toThrow(
+      new NotFoundException('Booking not found for the authenticated account.'),
+    );
+  });
+
+  it('throws the same not found response when the booking belongs to another client', async () => {
+    bookingRepository.findOwnedDetailById.mockResolvedValue(null);
+
+    await expect(
+      bookingService.getOwnBookingById(
+        'another-client-account-id',
+        'cmabooking0000wqz5oy7k8ph1',
+      ),
+    ).rejects.toThrow(
+      new NotFoundException('Booking not found for the authenticated account.'),
+    );
+
+    expect(bookingRepository.findOwnedDetailById).toHaveBeenCalledWith(
+      'another-client-account-id',
+      'cmabooking0000wqz5oy7k8ph1',
     );
   });
 
@@ -420,7 +509,9 @@ describe('BookingService', () => {
       requestedUnits: 1,
     });
 
-    expect(bookingRepository.updateTripOfferAvailability).not.toHaveBeenCalled();
+    expect(
+      bookingRepository.updateTripOfferAvailability,
+    ).not.toHaveBeenCalled();
     expect(
       bookingRepository.expirePendingBookingsForTripOffer,
     ).toHaveBeenCalledTimes(1);

--- a/apps/api/src/booking/application/booking.service.ts
+++ b/apps/api/src/booking/application/booking.service.ts
@@ -9,9 +9,11 @@ import {
   PrismaService,
   TripOfferStatus,
 } from '@logistica/database';
+import type { BookingDetailResponseDto } from '../dto/booking-detail.response.dto';
 import type { BookingResponseDto } from '../dto/booking.response.dto';
 import { BookingRepository } from '../repositories/booking.repository';
 import type {
+  BookingDetailRecord,
   BookingRecord,
   CreateBookingInput,
   TripOfferBookingRecord,
@@ -107,6 +109,24 @@ export class BookingService {
     return this.toBookingResponse(booking);
   }
 
+  async getOwnBookingById(
+    clientAccountId: string,
+    bookingId: string,
+  ): Promise<BookingDetailResponseDto> {
+    const booking = await this.bookingRepository.findOwnedDetailById(
+      clientAccountId,
+      bookingId,
+    );
+
+    if (!booking) {
+      throw new NotFoundException(
+        'Booking not found for the authenticated account.',
+      );
+    }
+
+    return this.toBookingDetailResponse(booking);
+  }
+
   private getPendingPaymentTtlMilliseconds(
     configService: ConfigService,
   ): number {
@@ -193,6 +213,31 @@ export class BookingService {
       status: booking.status ?? BookingStatus.PENDING_PAYMENT,
       createdAt: booking.createdAt,
       updatedAt: booking.updatedAt,
+    };
+  }
+
+  private toBookingDetailResponse(
+    booking: BookingDetailRecord,
+  ): BookingDetailResponseDto {
+    return {
+      id: booking.id,
+      tripOfferId: booking.tripOfferId,
+      requestedUnits: booking.requestedUnits,
+      unitPriceSnapshot: booking.unitPriceSnapshot,
+      totalPriceSnapshot: booking.totalPriceSnapshot,
+      expiresAt: booking.expiresAt,
+      status: booking.status ?? BookingStatus.PENDING_PAYMENT,
+      createdAt: booking.createdAt,
+      updatedAt: booking.updatedAt,
+      tripOffer: {
+        id: booking.tripOffer.id,
+        originLabel: booking.tripOffer.originLabel,
+        destinationLabel: booking.tripOffer.destinationLabel,
+        departureDate: booking.tripOffer.departureDate,
+        departureWindowStart: booking.tripOffer.departureWindowStart,
+        departureWindowEnd: booking.tripOffer.departureWindowEnd,
+        status: booking.tripOffer.status,
+      },
     };
   }
 }

--- a/apps/api/src/booking/booking.controller.spec.ts
+++ b/apps/api/src/booking/booking.controller.spec.ts
@@ -44,6 +44,7 @@ class TestJwtAuthGuard {
 describe('BookingController', () => {
   const bookingService = {
     createBooking: jest.fn(),
+    getOwnBookingById: jest.fn(),
   };
 
   beforeEach(() => {
@@ -120,6 +121,64 @@ describe('BookingController', () => {
     await app.close();
   });
 
+  it('returns the requested booking detail for the authenticated client', async () => {
+    bookingService.getOwnBookingById.mockResolvedValue({
+      id: 'cmabooking0000wqz5oy7k8ph1',
+      tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+      requestedUnits: 2,
+      unitPriceSnapshot: 120000,
+      totalPriceSnapshot: 240000,
+      expiresAt: new Date('2026-04-24T13:30:00.000Z'),
+      status: 'PENDING_PAYMENT',
+      createdAt: new Date('2026-04-24T13:00:00.000Z'),
+      updatedAt: new Date('2026-04-24T13:00:00.000Z'),
+      tripOffer: {
+        id: 'cmatripoffer0000wqz5oy7k8ph1',
+        originLabel: 'Buenos Aires',
+        destinationLabel: 'Rosario',
+        departureDate: new Date('2026-04-25T10:00:00.000Z'),
+        departureWindowStart: null,
+        departureWindowEnd: null,
+        status: 'PUBLISHED',
+      },
+    });
+
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/bookings/cmabooking0000wqz5oy7k8ph1')
+      .set('Authorization', 'Bearer CLIENT')
+      .expect(200)
+      .expect({
+        id: 'cmabooking0000wqz5oy7k8ph1',
+        tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+        requestedUnits: 2,
+        unitPriceSnapshot: 120000,
+        totalPriceSnapshot: 240000,
+        expiresAt: '2026-04-24T13:30:00.000Z',
+        status: 'PENDING_PAYMENT',
+        createdAt: '2026-04-24T13:00:00.000Z',
+        updatedAt: '2026-04-24T13:00:00.000Z',
+        tripOffer: {
+          id: 'cmatripoffer0000wqz5oy7k8ph1',
+          originLabel: 'Buenos Aires',
+          destinationLabel: 'Rosario',
+          departureDate: '2026-04-25T10:00:00.000Z',
+          departureWindowStart: null,
+          departureWindowEnd: null,
+          status: 'PUBLISHED',
+        },
+      });
+
+    expect(bookingService.getOwnBookingById).toHaveBeenCalledWith(
+      'client-account-id',
+      'cmabooking0000wqz5oy7k8ph1',
+    );
+
+    await app.close();
+  });
+
   it('returns 400 when tripOfferId is invalid', async () => {
     const app = await createApp();
     const server = app.getHttpServer() as Parameters<typeof request>[0];
@@ -134,6 +193,20 @@ describe('BookingController', () => {
       .expect(400);
 
     expect(bookingService.createBooking).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when booking id is invalid', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/bookings/not-a-cuid')
+      .set('Authorization', 'Bearer CLIENT')
+      .expect(400);
+
+    expect(bookingService.getOwnBookingById).not.toHaveBeenCalled();
 
     await app.close();
   });
@@ -207,6 +280,17 @@ describe('BookingController', () => {
     await app.close();
   });
 
+  it('returns 401 when reading a booking without an access token', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/bookings/cmabooking0000wqz5oy7k8ph1')
+      .expect(401);
+
+    await app.close();
+  });
+
   it('returns 403 when the authenticated role is not CLIENT', async () => {
     const app = await createApp();
     const server = app.getHttpServer() as Parameters<typeof request>[0];
@@ -218,6 +302,18 @@ describe('BookingController', () => {
         tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
         requestedUnits: 2,
       })
+      .expect(403);
+
+    await app.close();
+  });
+
+  it('returns 403 when reading a booking with a non-client role', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/bookings/cmabooking0000wqz5oy7k8ph1')
+      .set('Authorization', 'Bearer TRANSPORTER')
       .expect(403);
 
     await app.close();
@@ -239,6 +335,27 @@ describe('BookingController', () => {
         requestedUnits: 2,
       })
       .expect(404);
+
+    await app.close();
+  });
+
+  it('returns 404 when the booking does not exist or is not accessible', async () => {
+    bookingService.getOwnBookingById.mockRejectedValue(
+      new NotFoundException('Booking not found for the authenticated account.'),
+    );
+
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .get('/bookings/cmabooking0000wqz5oy7k8ph1')
+      .set('Authorization', 'Bearer CLIENT')
+      .expect(404)
+      .expect({
+        error: 'Not Found',
+        message: 'Booking not found for the authenticated account.',
+        statusCode: 404,
+      });
 
     await app.close();
   });

--- a/apps/api/src/booking/booking.controller.ts
+++ b/apps/api/src/booking/booking.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { CreateBookingSchema } from '@logistica/shared';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { Roles } from '../identity/authentication/decorators/roles.decorator';
@@ -6,7 +14,10 @@ import { JwtAuthGuard } from '../identity/authentication/guards/jwt-auth.guard';
 import { RolesGuard } from '../identity/authentication/guards/roles.guard';
 import type { AuthenticatedAccount } from '../identity/authentication/types/authentication.types';
 import { BookingService } from './application/booking.service';
+import type { BookingDetailResponseDto } from './dto/booking-detail.response.dto';
 import type { CreateBookingDto } from './dto/create-booking.dto';
+import type { BookingParamsDto } from './dto/get-booking.dto';
+import { BookingParamsSchema } from './dto/get-booking.dto';
 import type { BookingResponseDto } from './dto/booking.response.dto';
 
 interface AuthenticatedHttpRequest {
@@ -16,6 +27,20 @@ interface AuthenticatedHttpRequest {
 @Controller('bookings')
 export class BookingController {
   constructor(private readonly bookingService: BookingService) {}
+
+  @Get(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('CLIENT')
+  async getOwnBookingById(
+    @Req() request: AuthenticatedHttpRequest,
+    @Param(new ZodValidationPipe(BookingParamsSchema))
+    params: BookingParamsDto,
+  ): Promise<BookingDetailResponseDto> {
+    return this.bookingService.getOwnBookingById(
+      request.user.accountId,
+      params.id,
+    );
+  }
 
   @Post()
   @UseGuards(JwtAuthGuard, RolesGuard)

--- a/apps/api/src/booking/dto/booking-detail.response.dto.ts
+++ b/apps/api/src/booking/dto/booking-detail.response.dto.ts
@@ -1,0 +1,3 @@
+import type { IBookingDetail } from '@logistica/shared';
+
+export type BookingDetailResponseDto = IBookingDetail;

--- a/apps/api/src/booking/dto/get-booking.dto.ts
+++ b/apps/api/src/booking/dto/get-booking.dto.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+import type { IBookingParamsDto } from '@logistica/shared';
+
+export const BookingParamsSchema = z.object({
+  id: z.string().cuid(),
+});
+
+export type BookingParamsDto = IBookingParamsDto;

--- a/apps/api/src/booking/repositories/booking.repository.spec.ts
+++ b/apps/api/src/booking/repositories/booking.repository.spec.ts
@@ -11,13 +11,74 @@ describe('BookingRepository', () => {
       create: jest.fn(),
     },
   };
-  const prisma = {};
+  const prisma = {
+    booking: {
+      findFirst: jest.fn(),
+    },
+  };
 
   let bookingRepository: BookingRepository;
 
   beforeEach(() => {
     jest.clearAllMocks();
     bookingRepository = new BookingRepository(prisma as never);
+  });
+
+  it('finds the booking detail only when it belongs to the authenticated client', async () => {
+    prisma.booking.findFirst.mockResolvedValue({
+      id: 'cmabooking0000wqz5oy7k8ph1',
+      tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+      requestedUnits: 2,
+      unitPriceSnapshot: 120000,
+      totalPriceSnapshot: 240000,
+      expiresAt: new Date('2026-04-24T13:30:00.000Z'),
+      status: BookingStatus.PENDING_PAYMENT,
+      createdAt: new Date('2026-04-24T13:00:00.000Z'),
+      updatedAt: new Date('2026-04-24T13:00:00.000Z'),
+      tripOffer: {
+        id: 'cmatripoffer0000wqz5oy7k8ph1',
+        originLabel: 'Buenos Aires',
+        destinationLabel: 'Rosario',
+        departureDate: new Date('2026-04-25T10:00:00.000Z'),
+        departureWindowStart: null,
+        departureWindowEnd: null,
+        status: TripOfferStatus.PUBLISHED,
+      },
+    });
+
+    await bookingRepository.findOwnedDetailById(
+      'client-account-id',
+      'cmabooking0000wqz5oy7k8ph1',
+    );
+
+    expect(prisma.booking.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'cmabooking0000wqz5oy7k8ph1',
+        clientAccountId: 'client-account-id',
+      },
+      select: {
+        id: true,
+        tripOfferId: true,
+        requestedUnits: true,
+        unitPriceSnapshot: true,
+        totalPriceSnapshot: true,
+        expiresAt: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+        tripOffer: {
+          select: {
+            id: true,
+            originLabel: true,
+            destinationLabel: true,
+            departureDate: true,
+            departureWindowStart: true,
+            departureWindowEnd: true,
+            status: true,
+          },
+        },
+      },
+    });
   });
 
   it('locks the trip offer row before consuming capacity', async () => {

--- a/apps/api/src/booking/repositories/booking.repository.ts
+++ b/apps/api/src/booking/repositories/booking.repository.ts
@@ -7,7 +7,9 @@ import {
   type Prisma as PrismaNamespace,
 } from '@logistica/database';
 import {
+  bookingDetailSelect,
   bookingSelect,
+  type BookingDetailRecord,
   type BookingRecord,
   tripOfferBookingSelect,
   type TripOfferBookingRecord,
@@ -25,6 +27,19 @@ interface CreateBookingRecordInput {
 @Injectable()
 export class BookingRepository {
   constructor(private readonly prisma: PrismaService) {}
+
+  async findOwnedDetailById(
+    clientAccountId: string,
+    bookingId: string,
+  ): Promise<BookingDetailRecord | null> {
+    return this.prisma.booking.findFirst({
+      where: {
+        id: bookingId,
+        clientAccountId,
+      },
+      select: bookingDetailSelect,
+    });
+  }
 
   async lockTripOfferById(
     tripOfferId: string,

--- a/apps/api/src/booking/types/booking.types.ts
+++ b/apps/api/src/booking/types/booking.types.ts
@@ -1,5 +1,5 @@
 import type { Prisma } from '@logistica/database';
-import type { ICreateBookingDto } from '@logistica/shared';
+import type { IBookingDetail, ICreateBookingDto } from '@logistica/shared';
 
 export const bookingSelect = {
   id: true,
@@ -22,9 +22,36 @@ export const tripOfferBookingSelect = {
   status: true,
 } satisfies Prisma.TripOfferSelect;
 
+export const bookingDetailSelect = {
+  id: true,
+  tripOfferId: true,
+  requestedUnits: true,
+  unitPriceSnapshot: true,
+  totalPriceSnapshot: true,
+  expiresAt: true,
+  status: true,
+  createdAt: true,
+  updatedAt: true,
+  tripOffer: {
+    select: {
+      id: true,
+      originLabel: true,
+      destinationLabel: true,
+      departureDate: true,
+      departureWindowStart: true,
+      departureWindowEnd: true,
+      status: true,
+    },
+  },
+} satisfies Prisma.BookingSelect;
+
 export type CreateBookingInput = ICreateBookingDto;
+export type BookingDetail = IBookingDetail;
 export type BookingRecord = Prisma.BookingGetPayload<{
   select: typeof bookingSelect;
+}>;
+export type BookingDetailRecord = Prisma.BookingGetPayload<{
+  select: typeof bookingDetailSelect;
 }>;
 export type TripOfferBookingRecord = Prisma.TripOfferGetPayload<{
   select: typeof tripOfferBookingSelect;

--- a/packages/shared/src/interfaces/interfaces.ts
+++ b/packages/shared/src/interfaces/interfaces.ts
@@ -27,6 +27,9 @@ import {
   UpdateTripOfferSchema,
 } from '../schemas/trip-offer.schema';
 import {
+  BookingDetailSchema,
+  BookingParamsSchema,
+  BookingTripOfferSummarySchema,
   BookingViewSchema,
   CreateBookingSchema,
 } from '../schemas/booking.schema';
@@ -154,6 +157,9 @@ export type ICreateTripOfferDto = z.infer<typeof CreateTripOfferDtoSchema>;
 export const CreateBookingDtoSchema = CreateBookingSchema;
 export type ICreateBookingDto = z.infer<typeof CreateBookingDtoSchema>;
 
+export const BookingParamsDtoSchema = BookingParamsSchema;
+export type IBookingParamsDto = z.infer<typeof BookingParamsDtoSchema>;
+
 export const UpdateTripOfferDtoSchema = UpdateTripOfferSchema;
 export type IUpdateTripOfferDto = z.infer<typeof UpdateTripOfferDtoSchema>;
 
@@ -170,6 +176,14 @@ export type ITripOfferView = z.infer<typeof TripOfferViewDtoSchema>;
 
 export const BookingViewDtoSchema = BookingViewSchema;
 export type IBookingView = z.infer<typeof BookingViewDtoSchema>;
+
+export const BookingTripOfferSummaryDtoSchema = BookingTripOfferSummarySchema;
+export type IBookingTripOfferSummary = z.infer<
+  typeof BookingTripOfferSummaryDtoSchema
+>;
+
+export const BookingDetailDtoSchema = BookingDetailSchema;
+export type IBookingDetail = z.infer<typeof BookingDetailDtoSchema>;
 
 export const PublicTripOfferSearchItemDtoSchema =
   PublicTripOfferSearchItemSchema;

--- a/packages/shared/src/schemas/booking.schema.ts
+++ b/packages/shared/src/schemas/booking.schema.ts
@@ -2,6 +2,10 @@ import { z } from 'zod';
 
 const cuidSchema = z.string().cuid();
 
+export const BookingParamsSchema = z.object({
+  id: cuidSchema,
+});
+
 export const CreateBookingSchema = z
   .object({
     tripOfferId: cuidSchema,
@@ -11,6 +15,16 @@ export const CreateBookingSchema = z
       .positive('El valor debe ser mayor a cero.'),
   })
   .strict();
+
+export const BookingTripOfferSummarySchema = z.object({
+  id: cuidSchema,
+  originLabel: z.string().trim().min(1),
+  destinationLabel: z.string().trim().min(1),
+  departureDate: z.date().nullable(),
+  departureWindowStart: z.date().nullable(),
+  departureWindowEnd: z.date().nullable(),
+  status: z.enum(['DRAFT', 'PUBLISHED', 'FULL', 'CLOSED', 'CANCELLED']),
+});
 
 export const BookingViewSchema = z.object({
   id: cuidSchema,
@@ -34,5 +48,32 @@ export const BookingViewSchema = z.object({
   updatedAt: z.date(),
 });
 
+export const BookingDetailSchema = z.object({
+  id: cuidSchema,
+  tripOfferId: cuidSchema,
+  requestedUnits: z.number().int().positive(),
+  unitPriceSnapshot: z.number().int().min(0),
+  totalPriceSnapshot: z.number().int().min(0),
+  expiresAt: z.date(),
+  status: z.enum([
+    'PENDING_PAYMENT',
+    'EXPIRED',
+    'CONFIRMED',
+    'IN_PROGRESS',
+    'DELIVERED_PENDING_CONFIRMATION',
+    'COMPLETED',
+    'CANCELLED',
+    'DISPUTED',
+  ]),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+  tripOffer: BookingTripOfferSummarySchema,
+});
+
+export type BookingParamsDto = z.infer<typeof BookingParamsSchema>;
 export type CreateBookingDto = z.infer<typeof CreateBookingSchema>;
+export type BookingTripOfferSummary = z.infer<
+  typeof BookingTripOfferSummarySchema
+>;
 export type BookingView = z.infer<typeof BookingViewSchema>;
+export type BookingDetail = z.infer<typeof BookingDetailSchema>;


### PR DESCRIPTION
## Contexto

Esta PR implementa la issue **"Implementar detalle de booking para cliente"** dentro de la �pica **E6-BE � Booking con anti-overbooking backend**.

El objetivo es permitir que un cliente autenticado consulte el detalle de una reserva puntual propia mediante el endpoint `GET /bookings/:id`, manteniendo la arquitectura actual del proyecto y sin extender el alcance hacia listados, pagos o cancelaciones.

## Alcance

Incluye:
- endpoint `GET /bookings/:id`
- validaci�n del `id` por par�metro
- validaci�n de ownership del booking en el service
- respuesta de detalle con datos clave del booking
- resumen m�nimo de la oferta asociada
- manejo controlado para booking inexistente o no accesible

No incluye:
- listado de bookings
- filtros o paginaci�n
- cancelaci�n desde este endpoint
- cambios en pagos
- l�gica nueva de expiraci�n
- cambios fuera del detalle puntual de una reserva

## Cambios realizados

### Backend API
- Se agreg� el endpoint autenticado `GET /bookings/:id` en el m�dulo `booking`.
- El controller valida el par�metro con Zod y delega al service.
- El service implementa `getOwnBookingById(accountId, bookingId)`.
- El ownership se resuelve del lado del service a partir de una consulta acotada al `clientAccountId` autenticado.
- Un booking inexistente o ajeno responde `404`, evitando exponer existencia de reservas de otros clientes.

### Repository y tipos
- Se agreg� una consulta espec�fica para detalle: `findOwnedDetailById(clientAccountId, bookingId)`.
- Se incorpor� un `select` tipado para el detalle del booking con resumen m�nimo de `tripOffer`.
- Se mantuvo la separaci�n entre records de Prisma y DTOs de respuesta.

### Contratos compartidos
- Se agregaron schemas y tipos compartidos para:
  - params del booking
  - resumen de oferta dentro del detalle
  - response shape del detalle de booking

## Response esperada

El endpoint devuelve:
- `id`
- `tripOfferId`
- `requestedUnits`
- `unitPriceSnapshot`
- `totalPriceSnapshot`
- `expiresAt`
- `status`
- `createdAt`
- `updatedAt`
- `tripOffer`:
  - `id`
  - `originLabel`
  - `destinationLabel`
  - `departureDate`
  - `departureWindowStart`
  - `departureWindowEnd`
  - `status`

## Criterios de aceptaci�n

- [x] Existe el endpoint de detalle de booking
- [x] El cliente puede consultar su booking
- [x] El detalle muestra estado, `requestedUnits`, precio y expiraci�n
- [x] No se puede consultar un booking ajeno
- [x] Un booking inexistente responde con error controlado
- [x] La respuesta es consistente con el contrato general de la API

## Tests agregados o ajustados

### Controller
- �xito `200` para booking propio
- `400` por `id` inv�lido
- `401` sin token
- `403` para rol distinto de `CLIENT`
- `404` para booking inexistente o no accesible

### Service
- retorna detalle para booking propio
- lanza `NotFoundException` si el booking no existe
- lanza la misma respuesta controlada si el booking pertenece a otro cliente

### Repository
- verifica el filtro por `id` y `clientAccountId`
- verifica el `select` del resumen de la oferta

## Checks ejecutados

- [x] `pnpm --filter @logistica/api lint`
- [x] `pnpm --filter @logistica/api typecheck`
- [x] `pnpm --filter @logistica/api test`
- [x] `pnpm --filter @logistica/api build`
- [ ] `pnpm typecheck`

## Nota sobre `pnpm typecheck`

El `typecheck` global del monorepo no est� en verde por errores **preexistentes** en `apps/web` relacionados con dependencias y tipos faltantes del frontend. No forman parte de esta issue ni fueron introducidos por esta PR.

## Riesgos y consideraciones

- El endpoint devuelve �nicamente la informaci�n necesaria para el cliente.
- No se modifica la l�gica actual de creaci�n de bookings ni la de anti-overbooking.
- No se introducen cambios en pagos ni en estados fuera del alcance pedido.
