### PR TITLE
feature: Implementar cancelación de reserva

### DIFF
--- a/apps/api/src/booking/application/booking.errors.ts
+++ b/apps/api/src/booking/application/booking.errors.ts
@@ -1,2 +1,8 @@
 export const BOOKING_INSUFFICIENT_CAPACITY_MESSAGE =
   'The requested booking units exceed the trip offer available capacity.';
+
+export const BOOKING_NOT_FOUND_FOR_ACCOUNT_MESSAGE =
+  'Booking not found for the authenticated account.';
+
+export const BOOKING_CANCELLATION_NOT_ALLOWED_MESSAGE =
+  'Only bookings in PENDING_PAYMENT status can be cancelled.';

--- a/apps/api/src/booking/application/booking.service.spec.ts
+++ b/apps/api/src/booking/application/booking.service.spec.ts
@@ -1,15 +1,22 @@
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import { BookingStatus, TripOfferStatus } from '@logistica/database';
-import { BOOKING_INSUFFICIENT_CAPACITY_MESSAGE } from './booking.errors';
+import {
+  BOOKING_CANCELLATION_NOT_ALLOWED_MESSAGE,
+  BOOKING_INSUFFICIENT_CAPACITY_MESSAGE,
+  BOOKING_NOT_FOUND_FOR_ACCOUNT_MESSAGE,
+} from './booking.errors';
 import { BookingService } from './booking.service';
 
 describe('BookingService', () => {
   const bookingRepository = {
     findOwnedDetailById: jest.fn(),
+    findOwnedBookingForCancellation: jest.fn(),
     lockTripOfferById: jest.fn(),
     expirePendingBookingsForTripOffer: jest.fn(),
     updateTripOfferAvailability: jest.fn(),
     updateTripOfferCapacity: jest.fn(),
+    releaseTripOfferCapacity: jest.fn(),
+    cancelPendingBooking: jest.fn(),
     create: jest.fn(),
   };
   const prisma = {
@@ -188,7 +195,7 @@ describe('BookingService', () => {
         'cmabooking0000wqz5oy7k8ph1',
       ),
     ).rejects.toThrow(
-      new NotFoundException('Booking not found for the authenticated account.'),
+      new NotFoundException(BOOKING_NOT_FOUND_FOR_ACCOUNT_MESSAGE),
     );
   });
 
@@ -201,7 +208,7 @@ describe('BookingService', () => {
         'cmabooking0000wqz5oy7k8ph1',
       ),
     ).rejects.toThrow(
-      new NotFoundException('Booking not found for the authenticated account.'),
+      new NotFoundException(BOOKING_NOT_FOUND_FOR_ACCOUNT_MESSAGE),
     );
 
     expect(bookingRepository.findOwnedDetailById).toHaveBeenCalledWith(
@@ -222,6 +229,150 @@ describe('BookingService', () => {
 
     expect(bookingRepository.updateTripOfferCapacity).not.toHaveBeenCalled();
     expect(bookingRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('cancels a pending booking and releases its capacity atomically', async () => {
+    const now = new Date('2026-04-24T13:00:00.000Z');
+
+    jest.useFakeTimers().setSystemTime(now);
+
+    bookingRepository.findOwnedBookingForCancellation.mockResolvedValue({
+      id: 'cmabooking0000wqz5oy7k8ph1',
+      tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+      clientAccountId: 'client-account-id',
+      requestedUnits: 2,
+      expiresAt: new Date('2026-04-24T13:30:00.000Z'),
+      status: BookingStatus.PENDING_PAYMENT,
+    });
+    bookingRepository.lockTripOfferById.mockResolvedValue({
+      id: 'cmatripoffer0000wqz5oy7k8ph1',
+      capacityTotal: 4,
+      availableCapacity: 0,
+      pricePerSlot: 120000,
+      status: TripOfferStatus.FULL,
+    });
+    bookingRepository.cancelPendingBooking.mockResolvedValue({
+      id: 'cmabooking0000wqz5oy7k8ph1',
+      tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+      clientAccountId: 'client-account-id',
+      requestedUnits: 2,
+      unitPriceSnapshot: 120000,
+      totalPriceSnapshot: 240000,
+      expiresAt: new Date('2026-04-24T13:30:00.000Z'),
+      status: BookingStatus.CANCELLED,
+      createdAt: new Date('2026-04-24T12:50:00.000Z'),
+      updatedAt: now,
+    });
+    bookingRepository.releaseTripOfferCapacity.mockResolvedValue({
+      id: 'cmatripoffer0000wqz5oy7k8ph1',
+      capacityTotal: 4,
+      availableCapacity: 2,
+      pricePerSlot: 120000,
+      status: TripOfferStatus.PUBLISHED,
+    });
+
+    await expect(
+      bookingService.cancelOwnBooking(
+        'client-account-id',
+        'cmabooking0000wqz5oy7k8ph1',
+      ),
+    ).resolves.toMatchObject({
+      id: 'cmabooking0000wqz5oy7k8ph1',
+      status: BookingStatus.CANCELLED,
+      requestedUnits: 2,
+    });
+
+    expect(
+      bookingRepository.findOwnedBookingForCancellation,
+    ).toHaveBeenCalledWith(
+      'client-account-id',
+      'cmabooking0000wqz5oy7k8ph1',
+      tx,
+    );
+    expect(bookingRepository.cancelPendingBooking).toHaveBeenCalledWith(
+      'cmabooking0000wqz5oy7k8ph1',
+      now,
+      tx,
+    );
+    expect(bookingRepository.releaseTripOfferCapacity).toHaveBeenCalledWith(
+      'cmatripoffer0000wqz5oy7k8ph1',
+      2,
+      TripOfferStatus.PUBLISHED,
+      tx,
+    );
+  });
+
+  it('throws when the booking is not found for cancellation', async () => {
+    bookingRepository.findOwnedBookingForCancellation.mockResolvedValue(null);
+
+    await expect(
+      bookingService.cancelOwnBooking(
+        'client-account-id',
+        'cmabooking0000wqz5oy7k8ph1',
+      ),
+    ).rejects.toThrow(
+      new NotFoundException(BOOKING_NOT_FOUND_FOR_ACCOUNT_MESSAGE),
+    );
+
+    expect(bookingRepository.lockTripOfferById).not.toHaveBeenCalled();
+    expect(bookingRepository.cancelPendingBooking).not.toHaveBeenCalled();
+  });
+
+  it('throws when the booking status is not cancellable', async () => {
+    bookingRepository.findOwnedBookingForCancellation.mockResolvedValue({
+      id: 'cmabooking0000wqz5oy7k8ph1',
+      tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+      clientAccountId: 'client-account-id',
+      requestedUnits: 2,
+      expiresAt: new Date('2026-04-24T13:30:00.000Z'),
+      status: BookingStatus.CANCELLED,
+    });
+
+    await expect(
+      bookingService.cancelOwnBooking(
+        'client-account-id',
+        'cmabooking0000wqz5oy7k8ph1',
+      ),
+    ).rejects.toThrow(
+      new ConflictException(BOOKING_CANCELLATION_NOT_ALLOWED_MESSAGE),
+    );
+
+    expect(bookingRepository.lockTripOfferById).not.toHaveBeenCalled();
+    expect(bookingRepository.releaseTripOfferCapacity).not.toHaveBeenCalled();
+  });
+
+  it('throws when cancellation loses the race and the booking was already updated', async () => {
+    const now = new Date('2026-04-24T13:00:00.000Z');
+
+    jest.useFakeTimers().setSystemTime(now);
+
+    bookingRepository.findOwnedBookingForCancellation.mockResolvedValue({
+      id: 'cmabooking0000wqz5oy7k8ph1',
+      tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+      clientAccountId: 'client-account-id',
+      requestedUnits: 2,
+      expiresAt: new Date('2026-04-24T13:30:00.000Z'),
+      status: BookingStatus.PENDING_PAYMENT,
+    });
+    bookingRepository.lockTripOfferById.mockResolvedValue({
+      id: 'cmatripoffer0000wqz5oy7k8ph1',
+      capacityTotal: 4,
+      availableCapacity: 1,
+      pricePerSlot: 120000,
+      status: TripOfferStatus.PUBLISHED,
+    });
+    bookingRepository.cancelPendingBooking.mockResolvedValue(null);
+
+    await expect(
+      bookingService.cancelOwnBooking(
+        'client-account-id',
+        'cmabooking0000wqz5oy7k8ph1',
+      ),
+    ).rejects.toThrow(
+      new ConflictException(BOOKING_CANCELLATION_NOT_ALLOWED_MESSAGE),
+    );
+
+    expect(bookingRepository.releaseTripOfferCapacity).not.toHaveBeenCalled();
   });
 
   it('throws when the trip offer is not published after cleanup', async () => {

--- a/apps/api/src/booking/application/booking.service.ts
+++ b/apps/api/src/booking/application/booking.service.ts
@@ -13,12 +13,17 @@ import type { BookingDetailResponseDto } from '../dto/booking-detail.response.dt
 import type { BookingResponseDto } from '../dto/booking.response.dto';
 import { BookingRepository } from '../repositories/booking.repository';
 import type {
+  BookingCancellationRecord,
   BookingDetailRecord,
   BookingRecord,
   CreateBookingInput,
   TripOfferBookingRecord,
 } from '../types/booking.types';
 import { BOOKING_INSUFFICIENT_CAPACITY_MESSAGE } from './booking.errors';
+import {
+  BOOKING_CANCELLATION_NOT_ALLOWED_MESSAGE,
+  BOOKING_NOT_FOUND_FOR_ACCOUNT_MESSAGE,
+} from './booking.errors';
 
 @Injectable()
 export class BookingService {
@@ -119,12 +124,71 @@ export class BookingService {
     );
 
     if (!booking) {
-      throw new NotFoundException(
-        'Booking not found for the authenticated account.',
-      );
+      throw new NotFoundException(BOOKING_NOT_FOUND_FOR_ACCOUNT_MESSAGE);
     }
 
     return this.toBookingDetailResponse(booking);
+  }
+
+  async cancelOwnBooking(
+    clientAccountId: string,
+    bookingId: string,
+  ): Promise<BookingResponseDto> {
+    const now = new Date();
+
+    const booking = await this.prisma.$transaction(async (tx) => {
+      const existingBooking =
+        await this.bookingRepository.findOwnedBookingForCancellation(
+          clientAccountId,
+          bookingId,
+          tx,
+        );
+
+      if (!existingBooking) {
+        throw new NotFoundException(BOOKING_NOT_FOUND_FOR_ACCOUNT_MESSAGE);
+      }
+
+      this.ensureBookingCanBeCancelled(existingBooking);
+
+      const lockedTripOffer = await this.bookingRepository.lockTripOfferById(
+        existingBooking.tripOfferId,
+        tx,
+      );
+
+      if (!lockedTripOffer) {
+        throw new NotFoundException('Trip offer not found.');
+      }
+
+      const cancelledBooking =
+        await this.bookingRepository.cancelPendingBooking(
+          existingBooking.id,
+          now,
+          tx,
+        );
+
+      if (!cancelledBooking) {
+        throw new ConflictException(BOOKING_CANCELLATION_NOT_ALLOWED_MESSAGE);
+      }
+
+      const nextAvailableCapacity = Math.min(
+        lockedTripOffer.capacityTotal,
+        lockedTripOffer.availableCapacity + existingBooking.requestedUnits,
+      );
+
+      await this.bookingRepository.releaseTripOfferCapacity(
+        lockedTripOffer.id,
+        existingBooking.requestedUnits,
+        this.resolveStatusForAvailableCapacity(
+          lockedTripOffer.status,
+          nextAvailableCapacity,
+        ),
+        tx,
+      );
+
+      return cancelledBooking;
+    });
+
+    return this.toBookingResponse(booking);
   }
 
   private getPendingPaymentTtlMilliseconds(
@@ -183,6 +247,16 @@ export class BookingService {
     if (requestedUnits > availableCapacity) {
       throw new ConflictException(BOOKING_INSUFFICIENT_CAPACITY_MESSAGE);
     }
+  }
+
+  private ensureBookingCanBeCancelled(
+    booking: BookingCancellationRecord,
+  ): void {
+    if (booking.status === BookingStatus.PENDING_PAYMENT) {
+      return;
+    }
+
+    throw new ConflictException(BOOKING_CANCELLATION_NOT_ALLOWED_MESSAGE);
   }
 
   private resolveStatusForAvailableCapacity(

--- a/apps/api/src/booking/booking.controller.spec.ts
+++ b/apps/api/src/booking/booking.controller.spec.ts
@@ -45,6 +45,7 @@ describe('BookingController', () => {
   const bookingService = {
     createBooking: jest.fn(),
     getOwnBookingById: jest.fn(),
+    cancelOwnBooking: jest.fn(),
   };
 
   beforeEach(() => {
@@ -211,6 +212,48 @@ describe('BookingController', () => {
     await app.close();
   });
 
+  it('cancels a booking for the authenticated client', async () => {
+    bookingService.cancelOwnBooking.mockResolvedValue({
+      id: 'cmabooking0000wqz5oy7k8ph1',
+      tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+      clientAccountId: 'client-account-id',
+      requestedUnits: 2,
+      unitPriceSnapshot: 120000,
+      totalPriceSnapshot: 240000,
+      expiresAt: new Date('2026-04-24T13:30:00.000Z'),
+      status: 'CANCELLED',
+      createdAt: new Date('2026-04-24T13:00:00.000Z'),
+      updatedAt: new Date('2026-04-24T13:05:00.000Z'),
+    });
+
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/bookings/cmabooking0000wqz5oy7k8ph1/cancel')
+      .set('Authorization', 'Bearer CLIENT')
+      .expect(201)
+      .expect({
+        id: 'cmabooking0000wqz5oy7k8ph1',
+        tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+        clientAccountId: 'client-account-id',
+        requestedUnits: 2,
+        unitPriceSnapshot: 120000,
+        totalPriceSnapshot: 240000,
+        expiresAt: '2026-04-24T13:30:00.000Z',
+        status: 'CANCELLED',
+        createdAt: '2026-04-24T13:00:00.000Z',
+        updatedAt: '2026-04-24T13:05:00.000Z',
+      });
+
+    expect(bookingService.cancelOwnBooking).toHaveBeenCalledWith(
+      'client-account-id',
+      'cmabooking0000wqz5oy7k8ph1',
+    );
+
+    await app.close();
+  });
+
   it('returns 400 when requestedUnits is zero', async () => {
     const app = await createApp();
     const server = app.getHttpServer() as Parameters<typeof request>[0];
@@ -291,6 +334,17 @@ describe('BookingController', () => {
     await app.close();
   });
 
+  it('returns 401 when cancelling a booking without an access token', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/bookings/cmabooking0000wqz5oy7k8ph1/cancel')
+      .expect(401);
+
+    await app.close();
+  });
+
   it('returns 403 when the authenticated role is not CLIENT', async () => {
     const app = await createApp();
     const server = app.getHttpServer() as Parameters<typeof request>[0];
@@ -313,6 +367,18 @@ describe('BookingController', () => {
 
     await request(server)
       .get('/bookings/cmabooking0000wqz5oy7k8ph1')
+      .set('Authorization', 'Bearer TRANSPORTER')
+      .expect(403);
+
+    await app.close();
+  });
+
+  it('returns 403 when cancelling a booking with a non-client role', async () => {
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/bookings/cmabooking0000wqz5oy7k8ph1/cancel')
       .set('Authorization', 'Bearer TRANSPORTER')
       .expect(403);
 
@@ -349,6 +415,27 @@ describe('BookingController', () => {
 
     await request(server)
       .get('/bookings/cmabooking0000wqz5oy7k8ph1')
+      .set('Authorization', 'Bearer CLIENT')
+      .expect(404)
+      .expect({
+        error: 'Not Found',
+        message: 'Booking not found for the authenticated account.',
+        statusCode: 404,
+      });
+
+    await app.close();
+  });
+
+  it('returns 404 when the booking to cancel does not exist or is not accessible', async () => {
+    bookingService.cancelOwnBooking.mockRejectedValue(
+      new NotFoundException('Booking not found for the authenticated account.'),
+    );
+
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/bookings/cmabooking0000wqz5oy7k8ph1/cancel')
       .set('Authorization', 'Bearer CLIENT')
       .expect(404)
       .expect({
@@ -401,6 +488,29 @@ describe('BookingController', () => {
       .expect({
         error: 'Conflict',
         message: BOOKING_INSUFFICIENT_CAPACITY_MESSAGE,
+        statusCode: 409,
+      });
+
+    await app.close();
+  });
+
+  it('returns 409 when the booking cannot be cancelled', async () => {
+    bookingService.cancelOwnBooking.mockRejectedValue(
+      new ConflictException(
+        'Only bookings in PENDING_PAYMENT status can be cancelled.',
+      ),
+    );
+
+    const app = await createApp();
+    const server = app.getHttpServer() as Parameters<typeof request>[0];
+
+    await request(server)
+      .post('/bookings/cmabooking0000wqz5oy7k8ph1/cancel')
+      .set('Authorization', 'Bearer CLIENT')
+      .expect(409)
+      .expect({
+        error: 'Conflict',
+        message: 'Only bookings in PENDING_PAYMENT status can be cancelled.',
         statusCode: 409,
       });
 

--- a/apps/api/src/booking/booking.controller.ts
+++ b/apps/api/src/booking/booking.controller.ts
@@ -42,6 +42,20 @@ export class BookingController {
     );
   }
 
+  @Post(':id/cancel')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('CLIENT')
+  async cancelOwnBooking(
+    @Req() request: AuthenticatedHttpRequest,
+    @Param(new ZodValidationPipe(BookingParamsSchema))
+    params: BookingParamsDto,
+  ): Promise<BookingResponseDto> {
+    return this.bookingService.cancelOwnBooking(
+      request.user.accountId,
+      params.id,
+    );
+  }
+
   @Post()
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('CLIENT')

--- a/apps/api/src/booking/repositories/booking.repository.spec.ts
+++ b/apps/api/src/booking/repositories/booking.repository.spec.ts
@@ -8,7 +8,9 @@ describe('BookingRepository', () => {
       update: jest.fn(),
     },
     booking: {
+      findFirst: jest.fn(),
       create: jest.fn(),
+      updateManyAndReturn: jest.fn(),
     },
   };
   const prisma = {
@@ -106,6 +108,38 @@ describe('BookingRepository', () => {
     expect(tx.$queryRaw).toHaveBeenCalledTimes(1);
   });
 
+  it('finds the owned booking data needed to cancel inside the transaction', async () => {
+    tx.booking.findFirst.mockResolvedValue({
+      id: 'cmabooking0000wqz5oy7k8ph1',
+      tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+      clientAccountId: 'client-account-id',
+      requestedUnits: 2,
+      expiresAt: new Date('2026-04-24T13:30:00.000Z'),
+      status: BookingStatus.PENDING_PAYMENT,
+    });
+
+    await bookingRepository.findOwnedBookingForCancellation(
+      'client-account-id',
+      'cmabooking0000wqz5oy7k8ph1',
+      tx as never,
+    );
+
+    expect(tx.booking.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'cmabooking0000wqz5oy7k8ph1',
+        clientAccountId: 'client-account-id',
+      },
+      select: {
+        id: true,
+        tripOfferId: true,
+        clientAccountId: true,
+        requestedUnits: true,
+        expiresAt: true,
+        status: true,
+      },
+    });
+  });
+
   it('decrements availableCapacity and persists the resolved status in the same trip offer update', async () => {
     tx.tripOffer.update.mockResolvedValue({
       id: 'cmatripoffer0000wqz5oy7k8ph1',
@@ -142,6 +176,96 @@ describe('BookingRepository', () => {
         availableCapacity: true,
         pricePerSlot: true,
         status: true,
+      },
+    });
+  });
+
+  it('increments availableCapacity and persists the resolved status when a booking is cancelled', async () => {
+    tx.tripOffer.update.mockResolvedValue({
+      id: 'cmatripoffer0000wqz5oy7k8ph1',
+      capacityTotal: 4,
+      availableCapacity: 2,
+      pricePerSlot: 120000,
+      status: TripOfferStatus.PUBLISHED,
+    });
+
+    await expect(
+      bookingRepository.releaseTripOfferCapacity(
+        'cmatripoffer0000wqz5oy7k8ph1',
+        2,
+        TripOfferStatus.PUBLISHED,
+        tx as never,
+      ),
+    ).resolves.toEqual({
+      id: 'cmatripoffer0000wqz5oy7k8ph1',
+      capacityTotal: 4,
+      availableCapacity: 2,
+      pricePerSlot: 120000,
+      status: TripOfferStatus.PUBLISHED,
+    });
+
+    expect(tx.tripOffer.update).toHaveBeenCalledWith({
+      where: { id: 'cmatripoffer0000wqz5oy7k8ph1' },
+      data: {
+        availableCapacity: {
+          increment: 2,
+        },
+        status: TripOfferStatus.PUBLISHED,
+      },
+      select: {
+        id: true,
+        capacityTotal: true,
+        availableCapacity: true,
+        pricePerSlot: true,
+        status: true,
+      },
+    });
+  });
+
+  it('cancels the booking only when it is still pending payment', async () => {
+    const updatedAt = new Date('2026-04-24T13:05:00.000Z');
+
+    tx.booking.updateManyAndReturn.mockResolvedValue([
+      {
+        id: 'cmabooking0000wqz5oy7k8ph1',
+        tripOfferId: 'cmatripoffer0000wqz5oy7k8ph1',
+        clientAccountId: 'client-account-id',
+        requestedUnits: 2,
+        unitPriceSnapshot: 120000,
+        totalPriceSnapshot: 240000,
+        expiresAt: new Date('2026-04-24T13:30:00.000Z'),
+        status: BookingStatus.CANCELLED,
+        createdAt: new Date('2026-04-24T13:00:00.000Z'),
+        updatedAt,
+      },
+    ]);
+
+    await bookingRepository.cancelPendingBooking(
+      'cmabooking0000wqz5oy7k8ph1',
+      updatedAt,
+      tx as never,
+    );
+
+    expect(tx.booking.updateManyAndReturn).toHaveBeenCalledWith({
+      where: {
+        id: 'cmabooking0000wqz5oy7k8ph1',
+        status: BookingStatus.PENDING_PAYMENT,
+      },
+      data: {
+        status: BookingStatus.CANCELLED,
+        updatedAt,
+      },
+      select: {
+        id: true,
+        tripOfferId: true,
+        clientAccountId: true,
+        requestedUnits: true,
+        unitPriceSnapshot: true,
+        totalPriceSnapshot: true,
+        expiresAt: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
       },
     });
   });

--- a/apps/api/src/booking/repositories/booking.repository.ts
+++ b/apps/api/src/booking/repositories/booking.repository.ts
@@ -8,7 +8,9 @@ import {
 } from '@logistica/database';
 import {
   bookingDetailSelect,
+  bookingCancellationSelect,
   bookingSelect,
+  type BookingCancellationRecord,
   type BookingDetailRecord,
   type BookingRecord,
   tripOfferBookingSelect,
@@ -38,6 +40,20 @@ export class BookingRepository {
         clientAccountId,
       },
       select: bookingDetailSelect,
+    });
+  }
+
+  async findOwnedBookingForCancellation(
+    clientAccountId: string,
+    bookingId: string,
+    tx: PrismaNamespace.TransactionClient,
+  ): Promise<BookingCancellationRecord | null> {
+    return tx.booking.findFirst({
+      where: {
+        id: bookingId,
+        clientAccountId,
+      },
+      select: bookingCancellationSelect,
     });
   }
 
@@ -119,6 +135,44 @@ export class BookingRepository {
       },
       select: tripOfferBookingSelect,
     });
+  }
+
+  async releaseTripOfferCapacity(
+    tripOfferId: string,
+    releasedUnits: number,
+    status: TripOfferStatus,
+    tx: PrismaNamespace.TransactionClient,
+  ): Promise<TripOfferBookingRecord> {
+    return tx.tripOffer.update({
+      where: { id: tripOfferId },
+      data: {
+        availableCapacity: {
+          increment: releasedUnits,
+        },
+        status,
+      },
+      select: tripOfferBookingSelect,
+    });
+  }
+
+  async cancelPendingBooking(
+    bookingId: string,
+    now: Date,
+    tx: PrismaNamespace.TransactionClient,
+  ): Promise<BookingRecord | null> {
+    const result = await tx.booking.updateManyAndReturn({
+      where: {
+        id: bookingId,
+        status: BookingStatus.PENDING_PAYMENT,
+      },
+      data: {
+        status: BookingStatus.CANCELLED,
+        updatedAt: now,
+      },
+      select: bookingSelect,
+    });
+
+    return result[0] ?? null;
   }
 
   async create(

--- a/apps/api/src/booking/types/booking.types.ts
+++ b/apps/api/src/booking/types/booking.types.ts
@@ -14,6 +14,15 @@ export const bookingSelect = {
   updatedAt: true,
 } satisfies Prisma.BookingSelect;
 
+export const bookingCancellationSelect = {
+  id: true,
+  tripOfferId: true,
+  clientAccountId: true,
+  requestedUnits: true,
+  expiresAt: true,
+  status: true,
+} satisfies Prisma.BookingSelect;
+
 export const tripOfferBookingSelect = {
   id: true,
   capacityTotal: true,
@@ -49,6 +58,9 @@ export type CreateBookingInput = ICreateBookingDto;
 export type BookingDetail = IBookingDetail;
 export type BookingRecord = Prisma.BookingGetPayload<{
   select: typeof bookingSelect;
+}>;
+export type BookingCancellationRecord = Prisma.BookingGetPayload<{
+  select: typeof bookingCancellationSelect;
 }>;
 export type BookingDetailRecord = Prisma.BookingGetPayload<{
   select: typeof bookingDetailSelect;


### PR DESCRIPTION
## Contexto
Implementa la cancelacion manual de bookings pendientes dentro de la epica E6-BE, liberando capacidad de la oferta de forma consistente y atomica.

## Alcance
- agrega endpoint POST /bookings/:id/cancel
- centraliza la logica de cancelacion en BookingService
- valida ownership y estado PENDING_PAYMENT
- cancela el booking y libera equestedUnits en una transaccion
- recalcula el estado de la oferta cuando recupera capacidad (FULL -> PUBLISHED)
- evita liberar capacidad mas de una vez con update condicionado por estado

## Riesgos
- toca logica critica de booking y anti-overbooking
- depende de bloqueo de oferta con FOR UPDATE y orden correcto dentro de la transaccion

## Como testear
- pnpm --filter @logistica/api typecheck
- pnpm --filter @logistica/api lint
- pnpm --filter @logistica/api build
- ejecutar los tests del modulo booking con Jest:
  
ode_modules\\.bin\\jest.CMD --config jest.config.cjs --runInBand src/booking/application/booking.service.spec.ts src/booking/booking.controller.spec.ts src/booking/repositories/booking.repository.spec.ts

## Nota
No pude dejar verdes los comandos raiz del monorepo porque pps/web ya tiene fallas preexistentes de dependencias/tipado y pnpm --filter @logistica/api test depende de prisma generate, que en este entorno falla de forma intermitente por descarga de binarios de Prisma.