### PR TITLE
feat(web): conectar auth frontend con backend

### DIFF
--- a/apps/web/app/(guest)/login/page.tsx
+++ b/apps/web/app/(guest)/login/page.tsx
@@ -1,5 +1,13 @@
 import { LoginPageView } from "@/features/auth/pages/login-page";
 
-export default function LoginPage() {
-  return <LoginPageView />;
+type LoginPageProps = {
+  searchParams?: Promise<{
+    registered?: string;
+  }>;
+};
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const resolvedSearchParams = await searchParams;
+
+  return <LoginPageView justRegistered={resolvedSearchParams?.registered === "1"} />;
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -684,6 +684,8 @@ footer { background: #1a1d22; padding: 56px 32px 28px; margin-top: 64px; }
 .social-btns { display: flex; flex-direction: column; gap: 10px; margin-bottom: 24px; }
 .social-btn { display: flex; align-items: center; justify-content: center; gap: 10px; padding: 12px; background: white; border: 1.5px solid var(--line); border-radius: 10px; font-family: var(--font-dm-sans),'DM Sans',sans-serif; font-size: 14px; font-weight: 600; color: var(--ink); cursor: pointer; transition: all .15s; }
 .social-btn:hover { border-color: var(--c4); background: var(--c4-soft); }
+.social-btn:disabled { cursor: not-allowed; opacity: .58; }
+.social-btn:disabled:hover { border-color: var(--line); background: white; }
 .social-btn svg { flex-shrink: 0; }
 
 .divider { display: flex; align-items: center; gap: 14px; margin-bottom: 24px; }
@@ -696,9 +698,14 @@ footer { background: #1a1d22; padding: 56px 32px 28px; margin-top: 64px; }
 .field-icon { position: absolute; left: 14px; top: 50%; transform: translateY(-50%); color: var(--c5); pointer-events: none; }
 .field-input { width: 100%; padding: 12px 14px 12px 42px; background: var(--c1); border: 1.5px solid var(--line); border-radius: 10px; font-family: var(--font-dm-sans),'DM Sans',sans-serif; font-size: 14px; color: var(--ink); outline: none; transition: all .15s; }
 .field-input:focus { border-color: var(--c4); background: white; box-shadow: 0 0 0 4px rgba(108,132,115,0.12); }
+.field-input:disabled { cursor: not-allowed; opacity: .68; }
+.field-input[aria-invalid="true"] { border-color: #b1583f; }
 .field-input::placeholder { color: var(--c5); }
 .field-toggle { position: absolute; right: 12px; top: 50%; transform: translateY(-50%); background: none; border: none; color: var(--c5); cursor: pointer; padding: 6px; border-radius: 6px; display: flex; align-items: center; justify-content: center; transition: all .15s; }
 .field-toggle:hover { color: var(--ink-soft); background: var(--c4-soft); }
+.field-toggle:disabled { cursor: not-allowed; opacity: .58; }
+.field-error { color: #b1583f; font-size: 12px; font-weight: 600; line-height: 1.45; margin-top: 6px; }
+.field-optional { color: var(--c5); font-size: 11px; font-weight: 500; margin-left: 6px; }
 
 .field-row { display: flex; align-items: center; justify-content: space-between; margin-bottom: 24px; }
 .checkbox-label { display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 13px; color: var(--ink-soft); font-weight: 500; }
@@ -708,6 +715,12 @@ footer { background: #1a1d22; padding: 56px 32px 28px; margin-top: 64px; }
 
 .submit-btn { width: 100%; padding: 14px; background: var(--c3); color: white; border: none; border-radius: 10px; font-family: var(--font-dm-sans),'DM Sans',sans-serif; font-size: 15px; font-weight: 700; cursor: pointer; transition: all .2s; box-shadow: 0 4px 14px rgba(172,132,62,0.30); display: flex; align-items: center; justify-content: center; gap: 8px; margin-bottom: 18px; }
 .submit-btn:hover { background: var(--c3-dark); transform: translateY(-1px); }
+.submit-btn:disabled { cursor: not-allowed; opacity: .62; transform: none; }
+.submit-btn:disabled:hover { background: var(--c3); transform: none; }
+
+.auth-feedback { border-radius: 10px; font-size: 13px; font-weight: 600; line-height: 1.55; margin-bottom: 16px; padding: 12px 14px; }
+.auth-feedback-error { background: rgba(177,88,63,0.08); border: 1px solid rgba(177,88,63,0.25); color: #b1583f; }
+.auth-feedback-success { background: rgba(108,132,115,0.12); border: 1px solid rgba(108,132,115,0.28); color: var(--c4-dark); }
 
 .auth-help { text-align: center; font-size: 13px; color: var(--c5); padding-top: 18px; border-top: 1px solid var(--line); }
 .auth-help a { color: var(--c4); font-weight: 600; text-decoration: none; cursor: pointer; }

--- a/apps/web/features/auth/hooks/use-login.test.ts
+++ b/apps/web/features/auth/hooks/use-login.test.ts
@@ -76,7 +76,7 @@ describe("loginRequest", () => {
         fetchMock,
       ),
     ).rejects.toMatchObject({
-      message: "Credenciales inválidas",
+      message: "Credenciales invalidas",
       name: "LoginRequestError",
     });
   });

--- a/apps/web/features/auth/hooks/use-login.ts
+++ b/apps/web/features/auth/hooks/use-login.ts
@@ -16,7 +16,7 @@ import type {
 import { LoginRequestError } from "../types/auth.types";
 
 const DEFAULT_ERROR_MESSAGE =
-  "No se pudo iniciar sesiÃ³n. IntentÃ¡ nuevamente en unos segundos.";
+  "No se pudo iniciar sesion. Intenta nuevamente en unos segundos.";
 
 function resolveErrorMessage(error: unknown): string {
   if (error instanceof LoginRequestError) {
@@ -24,7 +24,7 @@ function resolveErrorMessage(error: unknown): string {
   }
 
   if (error instanceof TypeError) {
-    return "No pudimos conectar con la API. VerificÃ¡ tu red e intentÃ¡ nuevamente.";
+    return "No pudimos conectar con la API. Verifica tu red e intenta nuevamente.";
   }
 
   return DEFAULT_ERROR_MESSAGE;

--- a/apps/web/features/auth/pages/login-page.tsx
+++ b/apps/web/features/auth/pages/login-page.tsx
@@ -1,25 +1,70 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import Link from 'next/link';
+import { useState } from "react";
+import Link from "next/link";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { useFormSubmit } from "@/src/lib/forms/hooks/useFormSubmit";
+import {
+  loginSchema,
+  type LoginSchemaValues,
+} from "@/src/lib/forms/schemas/auth.schema";
+import { useLogin } from "../hooks/use-login";
 
-export function LoginPageView() {
+type LoginPageViewProps = {
+  justRegistered?: boolean;
+};
+
+export function LoginPageView({ justRegistered = false }: LoginPageViewProps) {
   const [showPw, setShowPw] = useState(false);
+  const { error, isLoading, login } = useLogin();
+  const {
+    formState: { errors, isValid, isSubmitted },
+    handleSubmit,
+    register,
+  } = useForm<LoginSchemaValues>({
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+    mode: "onChange",
+    resolver: zodResolver(loginSchema),
+  });
+  const { isSubmitting, submit, submitError } = useFormSubmit(login);
+  const isBusy = isLoading || isSubmitting;
+  const feedbackError = error ?? submitError;
+  const emailError = (isSubmitted || errors.email) ? errors.email?.message : undefined;
+  const passwordError =
+    (isSubmitted || errors.password) ? errors.password?.message : undefined;
+
+  async function onSubmit(values: LoginSchemaValues) {
+    await submit(values);
+  }
 
   return (
     <div className="auth-wrap">
-
-      {/* LEFT — panel de marca */}
       <div className="auth-left">
         <Link className="auth-brand" href="/">
           <div className="auth-brand-mark">R</div>
-          <div className="auth-brand-word">Ruta<em> Directa</em></div>
+          <div className="auth-brand-word">
+            Ruta<em> Directa</em>
+          </div>
         </Link>
 
         <div className="auth-quote">
-          <div className="auth-quote-eyebrow"><span className="dot"></span>Bienvenido de vuelta</div>
-          <h2>Tu próximo viaje<br />está a un <em>click.</em></h2>
-          <p>Más de 1.200 traslados completados con transportistas verificados, pago protegido y comprobante digital.</p>
+          <div className="auth-quote-eyebrow">
+            <span className="dot" />
+            Bienvenido de vuelta
+          </div>
+          <h2>
+            Tu proximo viaje
+            <br />
+            esta a un <em>click.</em>
+          </h2>
+          <p>
+            Mas de 1.200 traslados completados con transportistas verificados,
+            pago protegido y comprobante digital.
+          </p>
           <div className="auth-stats">
             <div className="auth-stat">
               <div className="auth-stat-n">+1.200</div>
@@ -30,88 +75,183 @@ export function LoginPageView() {
               <div className="auth-stat-l">Camioneros</div>
             </div>
             <div className="auth-stat">
-              <div className="auth-stat-n">4.8★</div>
-              <div className="auth-stat-l">Calificación</div>
+              <div className="auth-stat-n">4.8</div>
+              <div className="auth-stat-l">Calificacion</div>
             </div>
           </div>
         </div>
 
         <Link className="auth-foot-link" href="/">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M19 12H5M12 5l-7 7 7 7"/></svg>
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path d="M19 12H5M12 5l-7 7 7 7" />
+          </svg>
           Volver al inicio
         </Link>
       </div>
 
-      {/* RIGHT — formulario */}
       <div className="auth-right">
         <div className="auth-form-wrap">
           <div className="auth-form-head">
-            <div className="auth-form-eyebrow">Iniciar sesión</div>
-            <h1 className="auth-form-title">Hola de nuevo 👋</h1>
-            <p className="auth-form-sub">¿Sos nuevo en Ruta Directa? <Link href="/register">Creá tu cuenta gratis</Link></p>
+            <div className="auth-form-eyebrow">Iniciar sesion</div>
+            <h1 className="auth-form-title">Hola de nuevo</h1>
+            <p className="auth-form-sub">
+              Sos nuevo en Ruta Directa?{" "}
+              <Link href="/register">Crea tu cuenta gratis</Link>
+            </p>
           </div>
 
-          <div className="social-btns">
-            <button type="button" className="social-btn">
-              <svg width="18" height="18" viewBox="0 0 24 24"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/></svg>
+          <div className="social-btns" aria-hidden="true">
+            <button type="button" className="social-btn" disabled>
               Continuar con Google
             </button>
-            <button type="button" className="social-btn">
-              <svg width="18" height="18" viewBox="0 0 24 24"><path fill="#1877F2" d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
+            <button type="button" className="social-btn" disabled>
               Continuar con Facebook
             </button>
           </div>
 
           <div className="divider">
-            <div className="divider-line"></div>
+            <div className="divider-line" />
             <span className="divider-text">o con email</span>
-            <div className="divider-line"></div>
+            <div className="divider-line" />
           </div>
 
-          <form onSubmit={(e) => e.preventDefault()}>
+          <form noValidate onSubmit={handleSubmit(onSubmit)}>
             <div className="field">
-              <label className="field-label">Email</label>
+              <label className="field-label" htmlFor="email">
+                Email
+              </label>
               <div className="field-wrap">
                 <span className="field-icon">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+                    <polyline points="22,6 12,13 2,6" />
+                  </svg>
                 </span>
-                <input type="email" className="field-input" placeholder="tu@email.com" required />
+                <input
+                  autoComplete="email"
+                  aria-invalid={Boolean(emailError)}
+                  className="field-input"
+                  disabled={isBusy}
+                  id="email"
+                  placeholder="tu@email.com"
+                  type="email"
+                  {...register("email")}
+                />
               </div>
+              {emailError ? <p className="field-error">{emailError}</p> : null}
             </div>
 
             <div className="field">
-              <label className="field-label">Contraseña</label>
+              <label className="field-label" htmlFor="password">
+                Contrasena
+              </label>
               <div className="field-wrap">
                 <span className="field-icon">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <rect x="3" y="11" width="18" height="11" rx="2" />
+                    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                  </svg>
                 </span>
-                <input type={showPw ? 'text' : 'password'} className="field-input" placeholder="Tu contraseña" required />
-                <button type="button" className="field-toggle" onClick={() => setShowPw(p => !p)}>
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                <input
+                  autoComplete="current-password"
+                  aria-invalid={Boolean(passwordError)}
+                  className="field-input"
+                  disabled={isBusy}
+                  id="password"
+                  placeholder="Tu contrasena"
+                  type={showPw ? "text" : "password"}
+                  {...register("password")}
+                />
+                <button
+                  type="button"
+                  className="field-toggle"
+                  disabled={isBusy}
+                  onClick={() => setShowPw((value) => !value)}
+                >
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                    <circle cx="12" cy="12" r="3" />
+                  </svg>
                 </button>
               </div>
+              {passwordError ? <p className="field-error">{passwordError}</p> : null}
             </div>
 
             <div className="field-row">
               <label className="checkbox-label">
-                <input type="checkbox" defaultChecked />
-                Mantener sesión iniciada
+                <input type="checkbox" defaultChecked disabled={isBusy} />
+                Mantener sesion iniciada
               </label>
-              <span className="field-link">¿Olvidaste tu contraseña?</span>
+              <Link className="field-link" href="/forgot-password">
+                Olvidaste tu contrasena?
+              </Link>
             </div>
 
-            <button type="submit" className="submit-btn">
-              Ingresar
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+            {justRegistered ? (
+              <div className="auth-feedback auth-feedback-success" aria-live="polite">
+                Tu cuenta fue creada correctamente. Ingresa con tus credenciales
+                para continuar.
+              </div>
+            ) : null}
+
+            {feedbackError ? (
+              <div className="auth-feedback auth-feedback-error" aria-live="polite">
+                {feedbackError}
+              </div>
+            ) : null}
+
+            <button
+              type="submit"
+              className="submit-btn"
+              disabled={!isValid || isBusy}
+            >
+              {isBusy ? "Ingresando" : "Ingresar"}
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2.5}
+              >
+                <path d="M5 12h14M12 5l7 7-7 7" />
+              </svg>
             </button>
           </form>
 
           <div className="auth-help">
-            ¿Necesitás ayuda? <a>Contactanos</a>
+            Necesitas ayuda? <Link href="/">Contactanos</Link>
           </div>
         </div>
       </div>
-
     </div>
   );
 }

--- a/apps/web/features/auth/pages/login-page.tsx
+++ b/apps/web/features/auth/pages/login-page.tsx
@@ -19,7 +19,7 @@ export function LoginPageView({ justRegistered = false }: LoginPageViewProps) {
   const [showPw, setShowPw] = useState(false);
   const { error, isLoading, login } = useLogin();
   const {
-    formState: { errors, isValid, isSubmitted },
+    formState: { errors, isSubmitted, isValid },
     handleSubmit,
     register,
   } = useForm<LoginSchemaValues>({
@@ -43,6 +43,7 @@ export function LoginPageView({ justRegistered = false }: LoginPageViewProps) {
 
   return (
     <div className="auth-wrap">
+      {/* LEFT — panel de marca */}
       <div className="auth-left">
         <Link className="auth-brand" href="/">
           <div className="auth-brand-mark">R</div>
@@ -53,16 +54,15 @@ export function LoginPageView({ justRegistered = false }: LoginPageViewProps) {
 
         <div className="auth-quote">
           <div className="auth-quote-eyebrow">
-            <span className="dot" />
-            Bienvenido de vuelta
+            <span className="dot"></span>Bienvenido de vuelta
           </div>
           <h2>
-            Tu proximo viaje
+            Tu próximo viaje
             <br />
-            esta a un <em>click.</em>
+            está a un <em>click.</em>
           </h2>
           <p>
-            Mas de 1.200 traslados completados con transportistas verificados,
+            Más de 1.200 traslados completados con transportistas verificados,
             pago protegido y comprobante digital.
           </p>
           <div className="auth-stats">
@@ -75,8 +75,8 @@ export function LoginPageView({ justRegistered = false }: LoginPageViewProps) {
               <div className="auth-stat-l">Camioneros</div>
             </div>
             <div className="auth-stat">
-              <div className="auth-stat-n">4.8</div>
-              <div className="auth-stat-l">Calificacion</div>
+              <div className="auth-stat-n">4.8★</div>
+              <div className="auth-stat-l">Calificación</div>
             </div>
           </div>
         </div>
@@ -96,30 +96,55 @@ export function LoginPageView({ justRegistered = false }: LoginPageViewProps) {
         </Link>
       </div>
 
+      {/* RIGHT — formulario */}
       <div className="auth-right">
         <div className="auth-form-wrap">
           <div className="auth-form-head">
-            <div className="auth-form-eyebrow">Iniciar sesion</div>
-            <h1 className="auth-form-title">Hola de nuevo</h1>
+            <div className="auth-form-eyebrow">Iniciar sesión</div>
+            <h1 className="auth-form-title">Hola de nuevo 👋</h1>
             <p className="auth-form-sub">
-              Sos nuevo en Ruta Directa?{" "}
-              <Link href="/register">Crea tu cuenta gratis</Link>
+              ¿Sos nuevo en Ruta Directa?{" "}
+              <Link href="/register">Creá tu cuenta gratis</Link>
             </p>
           </div>
 
-          <div className="social-btns" aria-hidden="true">
-            <button type="button" className="social-btn" disabled>
+          <div className="social-btns">
+            <button type="button" className="social-btn" disabled={isBusy}>
+              <svg width="18" height="18" viewBox="0 0 24 24">
+                <path
+                  fill="#4285F4"
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                />
+                <path
+                  fill="#34A853"
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                />
+                <path
+                  fill="#FBBC05"
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                />
+                <path
+                  fill="#EA4335"
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                />
+              </svg>
               Continuar con Google
             </button>
-            <button type="button" className="social-btn" disabled>
+            <button type="button" className="social-btn" disabled={isBusy}>
+              <svg width="18" height="18" viewBox="0 0 24 24">
+                <path
+                  fill="#1877F2"
+                  d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"
+                />
+              </svg>
               Continuar con Facebook
             </button>
           </div>
 
           <div className="divider">
-            <div className="divider-line" />
+            <div className="divider-line"></div>
             <span className="divider-text">o con email</span>
-            <div className="divider-line" />
+            <div className="divider-line"></div>
           </div>
 
           <form noValidate onSubmit={handleSubmit(onSubmit)}>
@@ -157,7 +182,7 @@ export function LoginPageView({ justRegistered = false }: LoginPageViewProps) {
 
             <div className="field">
               <label className="field-label" htmlFor="password">
-                Contrasena
+                Contraseña
               </label>
               <div className="field-wrap">
                 <span className="field-icon">
@@ -179,7 +204,7 @@ export function LoginPageView({ justRegistered = false }: LoginPageViewProps) {
                   className="field-input"
                   disabled={isBusy}
                   id="password"
-                  placeholder="Tu contrasena"
+                  placeholder="Tu contraseña"
                   type={showPw ? "text" : "password"}
                   {...register("password")}
                 />
@@ -208,16 +233,16 @@ export function LoginPageView({ justRegistered = false }: LoginPageViewProps) {
             <div className="field-row">
               <label className="checkbox-label">
                 <input type="checkbox" defaultChecked disabled={isBusy} />
-                Mantener sesion iniciada
+                Mantener sesión iniciada
               </label>
               <Link className="field-link" href="/forgot-password">
-                Olvidaste tu contrasena?
+                ¿Olvidaste tu contraseña?
               </Link>
             </div>
 
             {justRegistered ? (
               <div className="auth-feedback auth-feedback-success" aria-live="polite">
-                Tu cuenta fue creada correctamente. Ingresa con tus credenciales
+                Tu cuenta fue creada correctamente. Ingresá con tus credenciales
                 para continuar.
               </div>
             ) : null}
@@ -248,7 +273,7 @@ export function LoginPageView({ justRegistered = false }: LoginPageViewProps) {
           </form>
 
           <div className="auth-help">
-            Necesitas ayuda? <Link href="/">Contactanos</Link>
+            ¿Necesitás ayuda? <Link href="/">Contactanos</Link>
           </div>
         </div>
       </div>

--- a/apps/web/features/auth/pages/register-page.tsx
+++ b/apps/web/features/auth/pages/register-page.tsx
@@ -1,81 +1,203 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import Link from 'next/link';
+import { startTransition, useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { useFormSubmit } from "@/src/lib/forms/hooks/useFormSubmit";
+import { useRegister } from "../hooks/use-register";
+import {
+  registerFormDefaultValues,
+  registerFormSchema,
+} from "../schemas/register-form.schema";
+import {
+  toRegisterSubmissionValues,
+  type RegisterFormFields,
+} from "../utils/register-form-values";
 
-type Role = 'client' | 'driver';
+function getPwScore(value: string) {
+  if (!value) {
+    return 0;
+  }
 
-function getPwScore(v: string) {
-  if (!v) return 0;
   let score = 0;
-  if (v.length >= 8) score++;
-  if (/[A-Z]/.test(v)) score++;
-  if (/[0-9]/.test(v)) score++;
-  if (/[^A-Za-z0-9]/.test(v)) score++;
+  if (value.length >= 8) score += 1;
+  if (/[A-Z]/.test(value)) score += 1;
+  if (/[0-9]/.test(value)) score += 1;
+  if (/[^A-Za-z0-9]/.test(value)) score += 1;
+
   return score;
 }
 
 function getPwClass(score: number): string {
-  if (score <= 1) return 'weak';
-  if (score === 2) return 'med';
-  return 'good';
+  if (score <= 1) return "weak";
+  if (score === 2) return "med";
+  return "good";
 }
 
 function getPwHint(score: number, empty: boolean): string {
-  if (empty) return 'Usá al menos 8 caracteres con números y mayúsculas';
-  if (score <= 1) return 'Contraseña débil';
-  if (score === 2) return 'Contraseña regular';
-  if (score === 3) return 'Contraseña buena';
-  return 'Contraseña fuerte';
+  if (empty) return "Usa al menos 8 caracteres con numeros y mayusculas";
+  if (score <= 1) return "Contrasena debil";
+  if (score === 2) return "Contrasena regular";
+  if (score === 3) return "Contrasena buena";
+  return "Contrasena fuerte";
 }
 
 export function RegisterPageView() {
-  const [role, setRole] = useState<Role>('client');
+  const router = useRouter();
   const [showPw, setShowPw] = useState(false);
-  const [pwValue, setPwValue] = useState('');
-
-  const pwScore = getPwScore(pwValue);
+  const [acceptedTerms, setAcceptedTerms] = useState(false);
+  const { error, isLoading, isSuccess, register: registerAccount } = useRegister();
+  const {
+    formState: { errors, isSubmitted, isValid },
+    handleSubmit,
+    register,
+    setValue,
+    watch,
+  } = useForm<RegisterFormFields>({
+    defaultValues: registerFormDefaultValues,
+    mode: "onChange",
+    resolver: zodResolver(registerFormSchema),
+  });
+  const { isSubmitting, submit, submitError } = useFormSubmit(
+    (values: RegisterFormFields) =>
+      registerAccount(toRegisterSubmissionValues(values)),
+  );
+  const role = watch("role");
+  const password = watch("password");
+  const isTransporter = role === "TRANSPORTER";
+  const pwScore = getPwScore(password);
   const pwClass = getPwClass(pwScore);
-  const pwHint = getPwHint(pwScore, !pwValue);
-  const pwHintColor = !pwValue ? 'var(--c5)' : pwScore <= 1 ? '#ef4444' : pwScore === 2 ? '#eab308' : 'var(--c4-dark)';
+  const pwHint = getPwHint(pwScore, !password);
+  const pwHintColor = !password
+    ? "var(--c5)"
+    : pwScore <= 1
+      ? "#ef4444"
+      : pwScore === 2
+        ? "#eab308"
+        : "var(--c4-dark)";
+  const isBusy = isLoading || isSubmitting;
+  const isDisabled = isBusy || isSuccess;
+  const feedbackError = error ?? submitError;
+
+  useEffect(() => {
+    if (!isSuccess) {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      startTransition(() => {
+        router.push("/login?registered=1");
+      });
+    }, 900);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [isSuccess, router]);
+
+  async function onSubmit(values: RegisterFormFields) {
+    if (!acceptedTerms) {
+      return;
+    }
+
+    await submit(values);
+  }
+
+  function getFieldError(field: keyof RegisterFormFields) {
+    const fieldError = errors[field];
+
+    if (!isSubmitted && !fieldError) {
+      return undefined;
+    }
+
+    return fieldError?.message;
+  }
+
+  function selectRole(nextRole: RegisterFormFields["role"]) {
+    setValue("role", nextRole, {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: true,
+    });
+  }
 
   return (
     <div className="auth-wrap">
-
-      {/* LEFT — panel de marca */}
       <div className="auth-left">
         <Link className="auth-brand" href="/">
           <div className="auth-brand-mark">R</div>
-          <div className="auth-brand-word">Ruta<em> Directa</em></div>
+          <div className="auth-brand-word">
+            Ruta<em> Directa</em>
+          </div>
         </Link>
 
         <div className="auth-quote">
-          <div className="auth-quote-eyebrow"><span className="dot"></span>Crear cuenta</div>
-          <h2>Sumate a la red de transporte equino más <em>confiable.</em></h2>
-          <p>Empezá gratis. Sin tarjeta, sin permanencia.</p>
+          <div className="auth-quote-eyebrow">
+            <span className="dot" />
+            Crear cuenta
+          </div>
+          <h2>
+            Sumate a la red de transporte equino mas <em>confiable.</em>
+          </h2>
+          <p>Empeza gratis. Sin tarjeta, sin permanencia.</p>
 
           <div className="bens">
             <div className="ben">
               <div className="ben-icon">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}><path d="M20 6L9 17l-5-5"/></svg>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2.5}
+                >
+                  <path d="M20 6L9 17l-5-5" />
+                </svg>
               </div>
               <div className="ben-text">
                 <strong>Acceso completo gratis</strong>
-                <span>Buscá viajes, reservá cupos y coordiná directo con transportistas.</span>
+                <span>
+                  Busca viajes, reserva cupos y coordina directo con
+                  transportistas.
+                </span>
               </div>
             </div>
             <div className="ben">
               <div className="ben-icon">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                </svg>
               </div>
               <div className="ben-text">
                 <strong>Pago siempre protegido</strong>
-                <span>Seña retenida hasta que confirmás la entrega del traslado.</span>
+                <span>
+                  Sena retenida hasta que confirmas la entrega del traslado.
+                </span>
               </div>
             </div>
             <div className="ben">
               <div className="ben-icon">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                  <path d="M14 2v6h6" />
+                </svg>
               </div>
               <div className="ben-text">
                 <strong>Comprobante digital</strong>
@@ -86,148 +208,358 @@ export function RegisterPageView() {
         </div>
 
         <Link className="auth-foot-link" href="/">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M19 12H5M12 5l-7 7 7 7"/></svg>
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path d="M19 12H5M12 5l-7 7 7 7" />
+          </svg>
           Volver al inicio
         </Link>
       </div>
 
-      {/* RIGHT — formulario */}
-      <div className="auth-right" style={{ overflowY: 'auto' }}>
-        <div className="auth-form-wrap" style={{ maxWidth: '440px' }}>
+      <div className="auth-right" style={{ overflowY: "auto" }}>
+        <div className="auth-form-wrap" style={{ maxWidth: "440px" }}>
           <div className="auth-form-head">
             <div className="auth-form-eyebrow">Crear cuenta</div>
-            <h1 className="auth-form-title">Empezá ahora</h1>
-            <p className="auth-form-sub">¿Ya tenés cuenta? <Link href="/login">Iniciá sesión</Link></p>
+            <h1 className="auth-form-title">Empeza ahora</h1>
+            <p className="auth-form-sub">
+              Ya tenes cuenta? <Link href="/login">Inicia sesion</Link>
+            </p>
           </div>
 
-          {/* Role selector */}
           <div className="role-tabs">
             <button
               type="button"
-              className={`role-tab${role === 'client' ? ' active' : ''}`}
-              onClick={() => setRole('client')}
+              className={`role-tab${role === "CLIENT" ? " active" : ""}`}
+              disabled={isDisabled}
+              onClick={() => selectRole("CLIENT")}
             >
-              <span className="role-tab-icon">🐴</span>
+              <span className="role-tab-icon">EQ</span>
               <span className="role-tab-name">Tengo caballos</span>
               <span className="role-tab-desc">Cliente</span>
             </button>
             <button
               type="button"
-              className={`role-tab${role === 'driver' ? ' active' : ''}`}
-              onClick={() => setRole('driver')}
+              className={`role-tab${role === "TRANSPORTER" ? " active" : ""}`}
+              disabled={isDisabled}
+              onClick={() => selectRole("TRANSPORTER")}
             >
-              <span className="role-tab-icon">🚛</span>
+              <span className="role-tab-icon">TR</span>
               <span className="role-tab-name">Soy camionero</span>
               <span className="role-tab-desc">Transportista</span>
             </button>
           </div>
+          {getFieldError("role") ? (
+            <p className="field-error">{getFieldError("role")}</p>
+          ) : null}
 
-          {/* Social */}
-          <div className="social-btns">
-            <button type="button" className="social-btn">
-              <svg width="16" height="16" viewBox="0 0 24 24"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/></svg>
+          <div className="social-btns" aria-hidden="true">
+            <button type="button" className="social-btn" disabled>
               Continuar con Google
             </button>
           </div>
 
           <div className="divider">
-            <div className="divider-line"></div>
+            <div className="divider-line" />
             <span className="divider-text">o con email</span>
-            <div className="divider-line"></div>
+            <div className="divider-line" />
           </div>
 
-          <form onSubmit={(e) => e.preventDefault()}>
-            {/* Nombre + Apellido */}
-            <div className="field-row-2">
-              <div>
-                <label className="field-label">Nombre</label>
+          <form noValidate onSubmit={handleSubmit(onSubmit)}>
+            {isTransporter ? (
+              <div className="field">
+                <label className="field-label" htmlFor="displayName">
+                  Nombre comercial
+                </label>
                 <div className="field-wrap">
                   <span className="field-icon">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path d="M3 21h18" />
+                      <path d="M5 21V7l8-4v18" />
+                      <path d="M19 21V11l-6-4" />
+                    </svg>
                   </span>
-                  <input type="text" className="field-input" placeholder="María" required />
+                  <input
+                    autoComplete="organization"
+                    aria-invalid={Boolean(getFieldError("displayName"))}
+                    className="field-input"
+                    disabled={isDisabled}
+                    id="displayName"
+                    placeholder="Acme Transportes"
+                    type="text"
+                    {...register("displayName")}
+                  />
+                </div>
+                {getFieldError("displayName") ? (
+                  <p className="field-error">{getFieldError("displayName")}</p>
+                ) : null}
+              </div>
+            ) : (
+              <div className="field-row-2">
+                <div>
+                  <label className="field-label" htmlFor="firstName">
+                    Nombre
+                  </label>
+                  <div className="field-wrap">
+                    <span className="field-icon">
+                      <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                        <circle cx="12" cy="7" r="4" />
+                      </svg>
+                    </span>
+                    <input
+                      autoComplete="given-name"
+                      aria-invalid={Boolean(getFieldError("firstName"))}
+                      className="field-input"
+                      disabled={isDisabled}
+                      id="firstName"
+                      placeholder="Maria"
+                      type="text"
+                      {...register("firstName")}
+                    />
+                  </div>
+                  {getFieldError("firstName") ? (
+                    <p className="field-error">{getFieldError("firstName")}</p>
+                  ) : null}
+                </div>
+                <div>
+                  <label className="field-label" htmlFor="lastName">
+                    Apellido
+                  </label>
+                  <div className="field-wrap">
+                    <span className="field-icon">
+                      <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                        <circle cx="12" cy="7" r="4" />
+                      </svg>
+                    </span>
+                    <input
+                      autoComplete="family-name"
+                      aria-invalid={Boolean(getFieldError("lastName"))}
+                      className="field-input"
+                      disabled={isDisabled}
+                      id="lastName"
+                      placeholder="Alfonzo"
+                      type="text"
+                      {...register("lastName")}
+                    />
+                  </div>
+                  {getFieldError("lastName") ? (
+                    <p className="field-error">{getFieldError("lastName")}</p>
+                  ) : null}
                 </div>
               </div>
-              <div>
-                <label className="field-label">Apellido</label>
-                <div className="field-wrap">
-                  <span className="field-icon">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
-                  </span>
-                  <input type="text" className="field-input" placeholder="Alfonzo" required />
-                </div>
-              </div>
-            </div>
+            )}
 
-            {/* Email */}
             <div className="field">
-              <label className="field-label">Email</label>
+              <label className="field-label" htmlFor="email">
+                Email
+              </label>
               <div className="field-wrap">
                 <span className="field-icon">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-                </span>
-                <input type="email" className="field-input" placeholder="tu@email.com" required />
-              </div>
-            </div>
-
-            {/* Teléfono */}
-            <div className="field">
-              <label className="field-label">Teléfono</label>
-              <div className="field-wrap">
-                <span className="field-icon">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.13.96.37 1.9.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.91.33 1.85.57 2.81.7A2 2 0 0 1 22 16.92z"/></svg>
-                </span>
-                <input type="tel" className="field-input" placeholder="+54 9 351..." required />
-              </div>
-            </div>
-
-            {/* Contraseña */}
-            <div className="field">
-              <label className="field-label">Contraseña</label>
-              <div className="field-wrap">
-                <span className="field-icon">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+                    <polyline points="22,6 12,13 2,6" />
+                  </svg>
                 </span>
                 <input
-                  type={showPw ? 'text' : 'password'}
+                  autoComplete="email"
+                  aria-invalid={Boolean(getFieldError("email"))}
                   className="field-input"
-                  placeholder="Mínimo 8 caracteres"
-                  required
-                  value={pwValue}
-                  onChange={e => setPwValue(e.target.value)}
+                  disabled={isDisabled}
+                  id="email"
+                  placeholder="tu@email.com"
+                  type="email"
+                  {...register("email")}
                 />
-                <button type="button" className="field-toggle" onClick={() => setShowPw(p => !p)}>
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-                </button>
               </div>
-              <div className="pw-strength">
-                {[1, 2, 3, 4].map(i => (
-                  <div key={i} className={`pw-bar${pwValue && i <= pwScore ? ` ${pwClass}` : ''}`} />
-                ))}
-              </div>
-              <div className="pw-hint" style={{ color: pwHintColor }}>{pwHint}</div>
+              {getFieldError("email") ? (
+                <p className="field-error">{getFieldError("email")}</p>
+              ) : null}
             </div>
 
-            {/* Terms */}
+            {!isTransporter ? (
+              <div className="field">
+                <label className="field-label" htmlFor="phone">
+                  Telefono <span className="field-optional">Opcional</span>
+                </label>
+                <div className="field-wrap">
+                  <span className="field-icon">
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.13.96.37 1.9.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.91.33 1.85.57 2.81.7A2 2 0 0 1 22 16.92z" />
+                    </svg>
+                  </span>
+                  <input
+                    autoComplete="tel"
+                    aria-invalid={Boolean(getFieldError("phone"))}
+                    className="field-input"
+                    disabled={isDisabled}
+                    id="phone"
+                    placeholder="+54 9 351..."
+                    type="tel"
+                    {...register("phone")}
+                  />
+                </div>
+                {getFieldError("phone") ? (
+                  <p className="field-error">{getFieldError("phone")}</p>
+                ) : null}
+              </div>
+            ) : null}
+
+            <div className="field">
+              <label className="field-label" htmlFor="password">
+                Contrasena
+              </label>
+              <div className="field-wrap">
+                <span className="field-icon">
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <rect x="3" y="11" width="18" height="11" rx="2" />
+                    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                  </svg>
+                </span>
+                <input
+                  autoComplete="new-password"
+                  aria-invalid={Boolean(getFieldError("password"))}
+                  className="field-input"
+                  disabled={isDisabled}
+                  id="password"
+                  placeholder="Minimo 8 caracteres"
+                  type={showPw ? "text" : "password"}
+                  {...register("password")}
+                />
+                <button
+                  type="button"
+                  className="field-toggle"
+                  disabled={isDisabled}
+                  onClick={() => setShowPw((value) => !value)}
+                >
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                    <circle cx="12" cy="12" r="3" />
+                  </svg>
+                </button>
+              </div>
+              {getFieldError("password") ? (
+                <p className="field-error">{getFieldError("password")}</p>
+              ) : null}
+              <div className="pw-strength">
+                {[1, 2, 3, 4].map((item) => (
+                  <div
+                    key={item}
+                    className={`pw-bar${password && item <= pwScore ? ` ${pwClass}` : ""}`}
+                  />
+                ))}
+              </div>
+              <div className="pw-hint" style={{ color: pwHintColor }}>
+                {pwHint}
+              </div>
+            </div>
+
             <div className="terms-row">
-              <input type="checkbox" id="terms" required />
+              <input
+                type="checkbox"
+                id="terms"
+                checked={acceptedTerms}
+                disabled={isDisabled}
+                onChange={(event) => setAcceptedTerms(event.target.checked)}
+              />
               <label htmlFor="terms">
-                Acepto los <a>Términos</a> y la <a>Política de Privacidad</a>. Quiero recibir novedades por email.
+                Acepto los <Link href="/">Terminos</Link> y la{" "}
+                <Link href="/">Politica de Privacidad</Link>.
               </label>
             </div>
 
-            <button type="submit" className="submit-btn">
-              Crear cuenta
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+            {isSuccess ? (
+              <div className="auth-feedback auth-feedback-success" aria-live="polite">
+                Cuenta creada correctamente. Te estamos redirigiendo a iniciar
+                sesion.
+              </div>
+            ) : null}
+
+            {feedbackError ? (
+              <div className="auth-feedback auth-feedback-error" aria-live="polite">
+                {feedbackError}
+              </div>
+            ) : null}
+
+            <button
+              type="submit"
+              className="submit-btn"
+              disabled={!isValid || !acceptedTerms || isDisabled}
+            >
+              {isBusy ? "Creando cuenta" : "Crear cuenta"}
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2.5}
+              >
+                <path d="M5 12h14M12 5l7 7-7 7" />
+              </svg>
             </button>
           </form>
 
           <div className="auth-help">
-            ¿Ya tenés cuenta? <Link href="/login">Iniciá sesión</Link>
+            Ya tenes cuenta? <Link href="/login">Inicia sesion</Link>
           </div>
         </div>
       </div>
-
     </div>
   );
 }

--- a/apps/web/features/auth/pages/register-page.tsx
+++ b/apps/web/features/auth/pages/register-page.tsx
@@ -17,16 +17,12 @@ import {
 } from "../utils/register-form-values";
 
 function getPwScore(value: string) {
-  if (!value) {
-    return 0;
-  }
-
+  if (!value) return 0;
   let score = 0;
-  if (value.length >= 8) score += 1;
-  if (/[A-Z]/.test(value)) score += 1;
-  if (/[0-9]/.test(value)) score += 1;
-  if (/[^A-Za-z0-9]/.test(value)) score += 1;
-
+  if (value.length >= 8) score++;
+  if (/[A-Z]/.test(value)) score++;
+  if (/[0-9]/.test(value)) score++;
+  if (/[^A-Za-z0-9]/.test(value)) score++;
   return score;
 }
 
@@ -37,11 +33,11 @@ function getPwClass(score: number): string {
 }
 
 function getPwHint(score: number, empty: boolean): string {
-  if (empty) return "Usa al menos 8 caracteres con numeros y mayusculas";
-  if (score <= 1) return "Contrasena debil";
-  if (score === 2) return "Contrasena regular";
-  if (score === 3) return "Contrasena buena";
-  return "Contrasena fuerte";
+  if (empty) return "Usá al menos 8 caracteres con números y mayúsculas";
+  if (score <= 1) return "Contraseña débil";
+  if (score === 2) return "Contraseña regular";
+  if (score === 3) return "Contraseña buena";
+  return "Contraseña fuerte";
 }
 
 export function RegisterPageView() {
@@ -65,12 +61,12 @@ export function RegisterPageView() {
       registerAccount(toRegisterSubmissionValues(values)),
   );
   const role = watch("role");
-  const password = watch("password");
+  const pwValue = watch("password");
   const isTransporter = role === "TRANSPORTER";
-  const pwScore = getPwScore(password);
+  const pwScore = getPwScore(pwValue);
   const pwClass = getPwClass(pwScore);
-  const pwHint = getPwHint(pwScore, !password);
-  const pwHintColor = !password
+  const pwHint = getPwHint(pwScore, !pwValue);
+  const pwHintColor = !pwValue
     ? "var(--c5)"
     : pwScore <= 1
       ? "#ef4444"
@@ -90,7 +86,7 @@ export function RegisterPageView() {
       startTransition(() => {
         router.push("/login?registered=1");
       });
-    }, 900);
+    }, 1400);
 
     return () => {
       window.clearTimeout(timeoutId);
@@ -125,6 +121,7 @@ export function RegisterPageView() {
 
   return (
     <div className="auth-wrap">
+      {/* LEFT — panel de marca */}
       <div className="auth-left">
         <Link className="auth-brand" href="/">
           <div className="auth-brand-mark">R</div>
@@ -135,13 +132,12 @@ export function RegisterPageView() {
 
         <div className="auth-quote">
           <div className="auth-quote-eyebrow">
-            <span className="dot" />
-            Crear cuenta
+            <span className="dot"></span>Crear cuenta
           </div>
           <h2>
-            Sumate a la red de transporte equino mas <em>confiable.</em>
+            Sumate a la red de transporte equino más <em>confiable.</em>
           </h2>
-          <p>Empeza gratis. Sin tarjeta, sin permanencia.</p>
+          <p>Empezá gratis. Sin tarjeta, sin permanencia.</p>
 
           <div className="bens">
             <div className="ben">
@@ -160,7 +156,7 @@ export function RegisterPageView() {
               <div className="ben-text">
                 <strong>Acceso completo gratis</strong>
                 <span>
-                  Busca viajes, reserva cupos y coordina directo con
+                  Buscá viajes, reservá cupos y coordiná directo con
                   transportistas.
                 </span>
               </div>
@@ -180,9 +176,7 @@ export function RegisterPageView() {
               </div>
               <div className="ben-text">
                 <strong>Pago siempre protegido</strong>
-                <span>
-                  Sena retenida hasta que confirmas la entrega del traslado.
-                </span>
+                <span>Seña retenida hasta que confirmás la entrega del traslado.</span>
               </div>
             </div>
             <div className="ben">
@@ -222,16 +216,18 @@ export function RegisterPageView() {
         </Link>
       </div>
 
+      {/* RIGHT — formulario */}
       <div className="auth-right" style={{ overflowY: "auto" }}>
         <div className="auth-form-wrap" style={{ maxWidth: "440px" }}>
           <div className="auth-form-head">
             <div className="auth-form-eyebrow">Crear cuenta</div>
-            <h1 className="auth-form-title">Empeza ahora</h1>
+            <h1 className="auth-form-title">Empezá ahora</h1>
             <p className="auth-form-sub">
-              Ya tenes cuenta? <Link href="/login">Inicia sesion</Link>
+              ¿Ya tenés cuenta? <Link href="/login">Iniciá sesión</Link>
             </p>
           </div>
 
+          {/* Role selector */}
           <div className="role-tabs">
             <button
               type="button"
@@ -239,7 +235,7 @@ export function RegisterPageView() {
               disabled={isDisabled}
               onClick={() => selectRole("CLIENT")}
             >
-              <span className="role-tab-icon">EQ</span>
+              <span className="role-tab-icon">🐴</span>
               <span className="role-tab-name">Tengo caballos</span>
               <span className="role-tab-desc">Cliente</span>
             </button>
@@ -249,28 +245,45 @@ export function RegisterPageView() {
               disabled={isDisabled}
               onClick={() => selectRole("TRANSPORTER")}
             >
-              <span className="role-tab-icon">TR</span>
+              <span className="role-tab-icon">🚛</span>
               <span className="role-tab-name">Soy camionero</span>
               <span className="role-tab-desc">Transportista</span>
             </button>
           </div>
-          {getFieldError("role") ? (
-            <p className="field-error">{getFieldError("role")}</p>
-          ) : null}
 
-          <div className="social-btns" aria-hidden="true">
-            <button type="button" className="social-btn" disabled>
+          {/* Social */}
+          <div className="social-btns">
+            <button type="button" className="social-btn" disabled={isDisabled}>
+              <svg width="16" height="16" viewBox="0 0 24 24">
+                <path
+                  fill="#4285F4"
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                />
+                <path
+                  fill="#34A853"
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                />
+                <path
+                  fill="#FBBC05"
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                />
+                <path
+                  fill="#EA4335"
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                />
+              </svg>
               Continuar con Google
             </button>
           </div>
 
           <div className="divider">
-            <div className="divider-line" />
+            <div className="divider-line"></div>
             <span className="divider-text">o con email</span>
-            <div className="divider-line" />
+            <div className="divider-line"></div>
           </div>
 
           <form noValidate onSubmit={handleSubmit(onSubmit)}>
+            {/* Nombre + Apellido */}
             {isTransporter ? (
               <div className="field">
                 <label className="field-label" htmlFor="displayName">
@@ -332,7 +345,7 @@ export function RegisterPageView() {
                       className="field-input"
                       disabled={isDisabled}
                       id="firstName"
-                      placeholder="Maria"
+                      placeholder="María"
                       type="text"
                       {...register("firstName")}
                     />
@@ -377,6 +390,7 @@ export function RegisterPageView() {
               </div>
             )}
 
+            {/* Email */}
             <div className="field">
               <label className="field-label" htmlFor="email">
                 Email
@@ -411,10 +425,11 @@ export function RegisterPageView() {
               ) : null}
             </div>
 
+            {/* Teléfono */}
             {!isTransporter ? (
               <div className="field">
                 <label className="field-label" htmlFor="phone">
-                  Telefono <span className="field-optional">Opcional</span>
+                  Teléfono
                 </label>
                 <div className="field-wrap">
                   <span className="field-icon">
@@ -446,9 +461,10 @@ export function RegisterPageView() {
               </div>
             ) : null}
 
+            {/* Contraseña */}
             <div className="field">
               <label className="field-label" htmlFor="password">
-                Contrasena
+                Contraseña
               </label>
               <div className="field-wrap">
                 <span className="field-icon">
@@ -470,7 +486,7 @@ export function RegisterPageView() {
                   className="field-input"
                   disabled={isDisabled}
                   id="password"
-                  placeholder="Minimo 8 caracteres"
+                  placeholder="Mínimo 8 caracteres"
                   type={showPw ? "text" : "password"}
                   {...register("password")}
                 />
@@ -500,7 +516,7 @@ export function RegisterPageView() {
                 {[1, 2, 3, 4].map((item) => (
                   <div
                     key={item}
-                    className={`pw-bar${password && item <= pwScore ? ` ${pwClass}` : ""}`}
+                    className={`pw-bar${pwValue && item <= pwScore ? ` ${pwClass}` : ""}`}
                   />
                 ))}
               </div>
@@ -509,6 +525,7 @@ export function RegisterPageView() {
               </div>
             </div>
 
+            {/* Terms */}
             <div className="terms-row">
               <input
                 type="checkbox"
@@ -518,15 +535,16 @@ export function RegisterPageView() {
                 onChange={(event) => setAcceptedTerms(event.target.checked)}
               />
               <label htmlFor="terms">
-                Acepto los <Link href="/">Terminos</Link> y la{" "}
-                <Link href="/">Politica de Privacidad</Link>.
+                Acepto los <Link href="/">Términos</Link> y la{" "}
+                <Link href="/">Política de Privacidad</Link>. Quiero recibir
+                novedades por email.
               </label>
             </div>
 
             {isSuccess ? (
               <div className="auth-feedback auth-feedback-success" aria-live="polite">
                 Cuenta creada correctamente. Te estamos redirigiendo a iniciar
-                sesion.
+                sesión.
               </div>
             ) : null}
 
@@ -556,7 +574,7 @@ export function RegisterPageView() {
           </form>
 
           <div className="auth-help">
-            Ya tenes cuenta? <Link href="/login">Inicia sesion</Link>
+            ¿Ya tenés cuenta? <Link href="/login">Iniciá sesión</Link>
           </div>
         </div>
       </div>

--- a/apps/web/features/auth/services/api/auth-api.ts
+++ b/apps/web/features/auth/services/api/auth-api.ts
@@ -64,7 +64,7 @@ export async function loginRequest(
   if (response.status === 401) {
     throw new LoginRequestError(
       "INVALID_CREDENTIALS",
-      "Credenciales inválidas",
+      "Credenciales invalidas",
       response.status,
     );
   }

--- a/apps/web/features/auth/services/authorization/route-access.ts
+++ b/apps/web/features/auth/services/authorization/route-access.ts
@@ -31,7 +31,7 @@ type AuthRouteAccessResolution =
     };
 
 export const AUTHENTICATED_REDIRECT_PATH = DEFAULT_AUTHENTICATED_REDIRECT_PATH;
-export const UNAUTHENTICATED_REDIRECT_PATH = "/";
+export const UNAUTHENTICATED_REDIRECT_PATH = "/login";
 
 export function resolveAuthRouteAccess({
   allowedRoles,


### PR DESCRIPTION
## Contexto

Esta PR convierte las pantallas actuales de auth en flujo funcional contra el backend, manteniendo la visual previa de `/login` y `/register`.

Incluye las issues/objetivos del frente relacionados con:
- diseño y funcionalidad de login/register
- cliente HTTP con credenciales
- bootstrap de sesión con `/auth/me` y `/auth/refresh`
- logout desde web
- protección de rutas privadas
- base de autorización por rol en frontend

## Qué hice

- Conecté `/login` con `POST /auth/login` usando el hook `useLogin`.
- Conecté `/register` con `POST /auth/register` usando el hook `useRegister`.
- Mantuve `credentials: "include"` para que el backend pueda setear/leer la cookie HTTP-only de refresh token.
- Dejé el `accessToken` en memoria dentro del `AuthProvider`, como ya estaba planteado.
- Conservé el bootstrap existente: primero intenta `/auth/me`; si el access token no sirve, intenta `/auth/refresh` con cookie.
- Conservé logout contra `POST /auth/logout`.
- Ajusté la protección de rutas para que usuarios sin sesión vayan a `/login`.
- Restauré la visual anterior de `/login` y `/register` después de conectar la funcionalidad.
- Corregí mensajes rotos de encoding en errores de login.

## Rutas que deberían andar desde el frontend

### Públicas
- `/register`
  - Registra usuarios `CLIENT` y `TRANSPORTER` contra `POST /auth/register`.
  - Al registrar correctamente, redirige a `/login?registered=1`.
- `/login`
  - Inicia sesión contra `POST /auth/login`.
  - Recibe `accessToken`, actualiza sesión en frontend y permite que el backend setee cookie `refresh_token`.
  - Redirige a `/dashboard` si el login es exitoso.
- `/forgot-password`
  - La ruta existe visualmente, pero no forma parte de este flujo funcional de auth.

### Protegidas
- `/dashboard`
  - Debe exigir sesión.
  - Si no hay sesión, redirige a `/login`.
  - Si hay cookie válida y el access token se perdió/venció, debe restaurar sesión vía `/auth/refresh`.
- `/onboarding/transporter`
  - Protegida para `TRANSPORTER`.
- `/vehicles`, `/vehicles/new`, `/vehicles/[id]/edit`
  - Protegidas detrás del guard general y del flujo de perfil transportista cuando aplica.
- `/trailers/new`, `/trailers/[id]/edit`
  - Protegidas detrás del guard general y del flujo de perfil transportista cuando aplica.
- `/admin/users`, `/admin/transporters`, `/admin/transporters/[id]`
  - Protegidas para rol `ADMIN`.

## Endpoints de backend que usa este flujo

- `POST /auth/register`
- `POST /auth/login`
- `GET /auth/me`
- `POST /auth/refresh`
- `POST /auth/logout`

## Qué NO queda resuelto por esta PR

- No implementa OAuth real de Google/Facebook: los botones siguen siendo visuales/deshabilitados durante submit.
- No implementa recuperación real de contraseña en `/forgot-password`.
- No modifica backend, cookies, CORS ni DB: esta PR conecta el frontend con lo que ya existe.
- No prueba E2E real con navegador + DB + API corriendo; eso queda para validación manual/local.

## Checklist para validar que auth backend + frontend está 100%

1. Levantar API en `http://localhost:3001`.
2. Levantar web en `http://localhost:3000`.
3. Verificar `.env`:
   - `API_INTERNAL_URL=http://localhost:3001`
   - `NEXT_PUBLIC_API_URL` vacío o apuntando correctamente a la API
   - `CORS_ALLOWED_ORIGINS=http://localhost:3000`
   - `AUTH_ACCESS_TOKEN_SECRET`
   - `AUTH_REFRESH_TOKEN_SECRET`
   - `AUTH_ACCESS_TOKEN_TTL_SECONDS`
   - `AUTH_REFRESH_TOKEN_TTL_SECONDS`
   - `AUTH_REFRESH_COOKIE_NAME=refresh_token`
4. Crear usuario `CLIENT` desde `/register`.
5. Crear usuario `TRANSPORTER` desde `/register`.
6. Iniciar sesión desde `/login`.
7. Confirmar en DevTools que llega cookie HTTP-only `refresh_token`.
8. Entrar a `/dashboard` autenticado.
9. Recargar `/dashboard` y confirmar que la sesión se mantiene.
10. Borrar access token en memoria recargando o abriendo nueva pestaña y confirmar que `/auth/refresh` restaura sesión si la cookie sigue vigente.
11. Ejecutar logout y confirmar que:
    - se llama `POST /auth/logout`
    - se limpia sesión del frontend
    - la ruta protegida vuelve a redirigir a `/login`
12. Intentar entrar sin sesión a `/dashboard`, `/vehicles`, `/trailers/new`, `/admin/users` y confirmar redirects/denegación por rol.

## Tests ejecutados

- `pnpm --filter @logistica/web typecheck`
- `pnpm --filter @logistica/web test`
- `pnpm --filter @logistica/web build`

Resultado: pasan. El build mantiene warnings existentes en `app/como-funciona/page.tsx` por `react/no-unescaped-entities`, no relacionados con esta PR.

## Riesgos / notas

- Para cookies cross-origin, API y web tienen que coincidir con CORS y `credentials: true` en backend. El frontend ya manda `credentials: "include"`.
- En desarrollo local, si se usa el rewrite `/api -> API_INTERNAL_URL`, la experiencia de cookies es más estable porque el browser ve requests desde el mismo origen del frontend.
- La confirmación final de “auth 100%” requiere prueba manual contra backend y DB reales.